### PR TITLE
Add build and test CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: build
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+      - run: dotnet build Borea.slnx --configuration Release
+      - run: dotnet test Borea.slnx --configuration Release --no-build


### PR DESCRIPTION
Runs `dotnet build` and `dotnet test` against `Borea.slnx` on every pull request and on pushes to `main`.