### PR TITLE
Order GameVersion by revision

### DIFF
--- a/src/Borea.Core/Game/GameVersion.cs
+++ b/src/Borea.Core/Game/GameVersion.cs
@@ -1,17 +1,23 @@
-﻿namespace Borea.Core.Game;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Borea.Core.Game;
 
 /// <summary>
-/// KSA's own versioning scheme: Year.Month.BuildNumber.LastCommitNumber.
-/// Currently Opaque and only compatability checks are equality checks.
+/// KSA's version scheme: Year.Month.BuildNumber.Revision, plus an optional -suffix and +hash.
+/// Only the revision orders releases; the build number is machine-local and year and month are display only.
+/// Equality compares every component, so versions with equal revisions can still be distinct.
+/// See https://github.com/KSAModding/mod-manager-design/blob/main/rfcs/0017-game-version-ordering-and-compatibility.md
 /// </summary>
-public readonly record struct GameVersion
+public readonly partial record struct GameVersion : IComparable<GameVersion>
 {
     public int Year { get; }
     public int Month { get; }
     public int BuildNumber { get; }
-    public int LastCommitNumber { get; }
+    public int Revision { get; }
+    public string Suffix { get; }
 
-    public GameVersion(int year, int month, int buildNumber, int lastCommitNumber)
+    public GameVersion(int year, int month, int buildNumber, int revision, string suffix = "")
     {
         if (year < 0)
             throw new ArgumentOutOfRangeException(nameof(year), "Year cannot be negative.");
@@ -22,13 +28,16 @@ public readonly record struct GameVersion
         if (buildNumber < 0)
             throw new ArgumentOutOfRangeException(nameof(buildNumber), "Build number cannot be negative.");
 
-        if (lastCommitNumber < 0)
-            throw new ArgumentOutOfRangeException(nameof(lastCommitNumber), "Last commit number cannot be negative.");
+        if (revision < 0)
+            throw new ArgumentOutOfRangeException(nameof(revision), "Revision cannot be negative.");
 
         Year = year;
         Month = month;
         BuildNumber = buildNumber;
-        LastCommitNumber = lastCommitNumber;
+        Revision = revision;
+        Suffix = string.IsNullOrEmpty(suffix) ? string.Empty
+            : suffix.StartsWith('-') ? suffix
+            : "-" + suffix;
     }
 
     public static GameVersion Parse(string value)
@@ -46,22 +55,42 @@ public readonly record struct GameVersion
         if (string.IsNullOrWhiteSpace(value))
             return false;
 
-        var parts = value.Split('.');
-        if (parts.Length != 4)
+        var match = Pattern().Match(value);
+        if (!match.Success)
             return false;
 
-        if (!int.TryParse(parts[0], out var year) ||
-            !int.TryParse(parts[1], out var month) ||
-            !int.TryParse(parts[2], out var build) ||
-            !int.TryParse(parts[3], out var commit))
+        if (!int.TryParse(match.Groups["Year"].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var year) ||
+            !int.TryParse(match.Groups["Month"].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var month) ||
+            !int.TryParse(match.Groups["Build"].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var build) ||
+            !int.TryParse(match.Groups["Revision"].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var revision))
             return false;
 
-        if (year < 0 || month is < 1 or > 12 || build < 0 || commit < 0)
+        if (month is < 1 or > 12)
             return false;
 
-        result = new GameVersion(year, month, build, commit);
+        // The constructor normalizes the leading dash, like VersionInfo.ParseVersion.
+        var suffix = match.Groups["Suffix"].Success ? match.Groups["Suffix"].Value : string.Empty;
+
+        result = new GameVersion(year, month, build, revision, suffix);
         return true;
     }
 
-    public override string ToString() => $"{Year}.{Month}.{BuildNumber}.{LastCommitNumber}";
+    /// <summary>
+    /// Newer means a higher revision, nothing else is compared.
+    /// </summary>
+    public int CompareTo(GameVersion other) => Revision.CompareTo(other.Revision);
+
+    public static bool operator <(GameVersion left, GameVersion right) => left.CompareTo(right) < 0;
+
+    public static bool operator <=(GameVersion left, GameVersion right) => left.CompareTo(right) <= 0;
+
+    public static bool operator >(GameVersion left, GameVersion right) => left.CompareTo(right) > 0;
+
+    public static bool operator >=(GameVersion left, GameVersion right) => left.CompareTo(right) >= 0;
+
+    public override string ToString() => $"{Year}.{Month}.{BuildNumber}.{Revision}{Suffix}";
+
+    // The game's own version pattern (VersionInfo.MyRegex).
+    [GeneratedRegex(@"^v?(?<Year>\d+)\.(?<Month>\d+)\.(?<Build>\d+)\.(?<Revision>\d+)(?:-(?<Suffix>[^+]+))?(?:\+.*)?$")]
+    private static partial Regex Pattern();
 }

--- a/tests/Borea.Core.Tests/Game/GameVersionTests.cs
+++ b/tests/Borea.Core.Tests/Game/GameVersionTests.cs
@@ -1,4 +1,4 @@
-﻿using Borea.Core.Game;
+using Borea.Core.Game;
 
 namespace Borea.Core.Tests.Game;
 
@@ -13,7 +13,33 @@ public sealed class GameVersionTests
         Assert.Equal(2026, result.Year);
         Assert.Equal(7, result.Month);
         Assert.Equal(4, result.BuildNumber);
-        Assert.Equal(2131, result.LastCommitNumber);
+        Assert.Equal(2131, result.Revision);
+        Assert.Equal(string.Empty, result.Suffix);
+    }
+
+    [Theory]
+    [InlineData("v2026.7.4.2131")]                 // Leading v, as the game renders it.
+    [InlineData("2026.7.4.2131+6b87889f")]         // Hash is accepted and discarded.
+    [InlineData("v2026.7.4.2131+6b87889f")]        // Both at once.
+    public void TryParse_AcceptsGameShapedDecorations(string input)
+    {
+        var success = GameVersion.TryParse(input, out var result);
+
+        Assert.True(success);
+        Assert.Equal(GameVersion.Parse("2026.7.4.2131"), result);
+    }
+
+    [Theory]
+    [InlineData("2026.7.4.2131-LOCAL")]
+    [InlineData("v2026.7.4.2131-LOCAL+6b87889f")]
+    [InlineData("2026.7.4.2131--LOCAL")] // Collapses to one dash, like VersionInfo.ParseVersion.
+    public void TryParse_KeepsSuffixAndDiscardsHash(string input)
+    {
+        var success = GameVersion.TryParse(input, out var result);
+
+        Assert.True(success);
+        Assert.Equal("-LOCAL", result.Suffix);
+        Assert.Equal(2131, result.Revision);
     }
 
     [Theory]
@@ -25,7 +51,7 @@ public sealed class GameVersionTests
     [InlineData("2026.13.4.2131")]  // Invalid month.
     [InlineData("2026.0.4.2131")]   // Invalid month (zero).
     [InlineData("2026.7.-1.2131")]  // Invalid build number.
-    [InlineData("2026.7.4.-138")]   // Invalid last commit number.
+    [InlineData("2026.7.4.-138")]   // Invalid revision.
     [InlineData("a.b.c.d")]         // Non-numeric.
     public void TryParse_InvalidInput_ReturnsFalse(string? input)
     {
@@ -40,24 +66,58 @@ public sealed class GameVersionTests
         Assert.Throws<FormatException>(() => GameVersion.Parse("not-a-version"));
     }
 
-    [Fact]
-    public void ToString_RoundTripsThroughParse()
+    [Theory]
+    [InlineData("2026.7.4.2131")]
+    [InlineData("2026.8.3.5117-LOCAL")]
+    public void ToString_RoundTripsThroughParse(string input)
     {
-        var version = GameVersion.Parse("2026.7.4.2131");
+        var version = GameVersion.Parse(input);
 
-        Assert.Equal("2026.7.4.2131", version.ToString());
+        Assert.Equal(input, version.ToString());
     }
 
     [Fact]
-    public void Equality_IsExactMatchOnly_SameLastCommitDifferentBuild()
+    public void CompareTo_OrdersByRevisionAlone()
     {
-        // Confirms the "no ordering" design holds even for the field
-        // RocketWerkz called "most core" — same LastCommitNumber, different
-        // BuildNumber still means "different," not "equal or comparable."
+        // Real shipped pair where the older release has the higher build number.
+        var newer = GameVersion.Parse("2025.8.24.2263");
+        var older = GameVersion.Parse("2025.8.33.2091");
+
+        Assert.True(newer > older);
+        Assert.True(older < newer);
+        Assert.True(newer >= older);
+        Assert.True(older <= newer);
+    }
+
+    [Fact]
+    public void Sorting_ReproducesReleaseOrder()
+    {
+        // True release order; a four-part sort would invert both same-month pairs.
+        var expected = new[]
+        {
+            GameVersion.Parse("2025.8.33.2091"),
+            GameVersion.Parse("2025.8.24.2263"),
+            GameVersion.Parse("2025.9.3.2279"),
+            GameVersion.Parse("2025.9.2.2383"),
+        };
+
+        var shuffled = new[] { expected[2], expected[0], expected[3], expected[1] };
+        var sorted = shuffled.OrderBy(v => v).ToArray();
+
+        Assert.Equal(expected, sorted);
+    }
+
+    [Fact]
+    public void SameRevisionDifferentBuild_ComparesAsNeitherNewerNorOlder()
+    {
+        // Same revision, different build: distinct versions, neither is newer.
         var a = GameVersion.Parse("2026.7.4.2131");
         var b = GameVersion.Parse("2026.7.9.2131");
 
         Assert.NotEqual(a, b);
+        Assert.Equal(0, a.CompareTo(b));
+        Assert.False(a < b);
+        Assert.False(a > b);
     }
 
     [Fact]
@@ -68,5 +128,15 @@ public sealed class GameVersionTests
 
         Assert.Equal(a, b);
         Assert.True(a == b);
+    }
+
+    [Fact]
+    public void Equality_DistinguishesSuffix()
+    {
+        var plain = GameVersion.Parse("2026.7.4.2131");
+        var local = GameVersion.Parse("2026.7.4.2131-LOCAL");
+
+        Assert.NotEqual(plain, local);
+        Assert.Equal(0, plain.CompareTo(local));
     }
 }


### PR DESCRIPTION
`GameVersion` now orders by the revision alone, while equality keeps checking every component.

Parsing accepts the shape the game itself accepts: an optional leading `v`, an optional `-suffix` (kept), and an optional `+hash` (discarded). `LastCommitNumber` is renamed to `Revision`.

Ordering rule and rationale: [RFC 0017](https://github.com/KSAModding/mod-manager-design/blob/main/rfcs/0017-game-version-ordering-and-compatibility.md), grounded in [research/ksa-versioning.md](https://github.com/KSAModding/mod-manager-design/blob/main/research/ksa-versioning.md).

Closes #9.