### PR TITLE
Add LatestVersionPing for the master server

### DIFF
--- a/src/Borea.Core/Game/ILatestVersionPing.cs
+++ b/src/Borea.Core/Game/ILatestVersionPing.cs
@@ -1,0 +1,9 @@
+namespace Borea.Core.Game;
+
+/// <summary>
+/// Asks the KSA master server for the current public game version.
+/// </summary>
+public interface ILatestVersionPing
+{
+    Task<LatestVersionInfo> PingAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Borea.Core/Game/LatestVersionInfo.cs
+++ b/src/Borea.Core/Game/LatestVersionInfo.cs
@@ -1,0 +1,7 @@
+namespace Borea.Core.Game;
+
+/// <summary>
+/// The master server's answer: the current public build and its download page.
+/// Version is null when the answer did not parse; RawVersion keeps the original string.
+/// </summary>
+public sealed record LatestVersionInfo(GameVersion? Version, string RawVersion, string DownloadUrl);

--- a/src/Borea.Network/MasterServer/LatestVersionPing.cs
+++ b/src/Borea.Network/MasterServer/LatestVersionPing.cs
@@ -1,0 +1,82 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Borea.Core.Game;
+
+namespace Borea.Network.MasterServer;
+
+/// <summary>
+/// ILatestVersionPing implementation against the master server endpoint the game
+/// itself polls. Successful answers are cached for a minute, matching
+/// VersionInfo.AllowUpdateCheck, and overlapping calls share one request.
+/// The cache is per instance, so callers should share one.
+/// </summary>
+public sealed class LatestVersionPing : ILatestVersionPing
+{
+    private const string VersionUrl = "http://ksa-master1.rocketwerkz.com:8082/version";
+    private static readonly TimeSpan MinimumInterval = TimeSpan.FromMinutes(1);
+
+    private readonly HttpClient _httpClient;
+    private readonly TimeProvider _timeProvider;
+    private readonly object _gate = new();
+
+    private LatestVersionInfo? _lastAnswer;
+    private DateTimeOffset _lastAnswerAt;
+    private Task<LatestVersionInfo>? _inFlight;
+
+    public LatestVersionPing(HttpClient httpClient, TimeProvider? timeProvider = null)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public Task<LatestVersionInfo> PingAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (_lastAnswer is not null && _timeProvider.GetUtcNow() - _lastAnswerAt < MinimumInterval)
+                return Task.FromResult(_lastAnswer);
+
+            // Never join a completed task; finished fetches are only served via the cache.
+            if (_inFlight is null || _inFlight.IsCompleted)
+                _inFlight = FetchAsync();
+
+            // A caller's token cancels only their wait, not the shared request.
+            return _inFlight.WaitAsync(cancellationToken);
+        }
+    }
+
+    private async Task<LatestVersionInfo> FetchAsync()
+    {
+        // The reply shape is KSA.VersionMetaInfo: {"Version": "...", "Url": "..."}.
+        VersionMetaInfoDto? dto;
+        try
+        {
+            dto = await _httpClient.GetFromJsonAsync<VersionMetaInfoDto>(VersionUrl).ConfigureAwait(false);
+        }
+        catch (JsonException)
+        {
+            // A non-JSON body is an unusable answer, not a transport error, same as
+            // in VersionInfo.GetServerVersionAsync.
+            dto = null;
+        }
+
+        var raw = dto?.Version ?? string.Empty;
+        var answer = new LatestVersionInfo(
+            GameVersion.TryParse(raw, out var version) ? version : null,
+            raw,
+            dto?.Url ?? string.Empty);
+
+        lock (_gate)
+        {
+            _lastAnswer = answer;
+            _lastAnswerAt = _timeProvider.GetUtcNow();
+        }
+        return answer;
+    }
+}
+
+internal sealed class VersionMetaInfoDto
+{
+    public string Version { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
+}

--- a/tests/Borea.Network.Tests/MasterServer/LatestVersionPingTests.cs
+++ b/tests/Borea.Network.Tests/MasterServer/LatestVersionPingTests.cs
@@ -1,0 +1,162 @@
+using System.Net;
+using Borea.Core.Game;
+using Borea.Network.MasterServer;
+
+namespace Borea.Network.Tests;
+
+public sealed class LatestVersionPingTests
+{
+    private const string RealResponseJson = """{"Version":"2026.8.3.5117","Url":"https://ksa.ahwoo.com"}""";
+
+    [Fact]
+    public async Task PingAsync_RealShapedResponse_HandsBackVersionAndUrl()
+    {
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(RealResponseJson), out var handler);
+        var ping = new LatestVersionPing(client, new FakeTimeProvider());
+
+        var answer = await ping.PingAsync();
+
+        Assert.Equal(GameVersion.Parse("2026.8.3.5117"), answer.Version);
+        Assert.Equal("2026.8.3.5117", answer.RawVersion);
+        Assert.Equal("https://ksa.ahwoo.com", answer.DownloadUrl);
+        Assert.Equal("http://ksa-master1.rocketwerkz.com:8082/version", handler.LastRequest!.RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task PingAsync_DecoratedVersionString_StillParses()
+    {
+        var json = """{"Version":"v2026.8.3.5117+6b87889f","Url":"https://ksa.ahwoo.com"}""";
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
+        var ping = new LatestVersionPing(client, new FakeTimeProvider());
+
+        var answer = await ping.PingAsync();
+
+        Assert.NotNull(answer.Version);
+        Assert.Equal(5117, answer.Version!.Value.Revision);
+    }
+
+    [Fact]
+    public async Task PingAsync_UnparseableVersion_BecomesUnknownInsteadOfThrowing()
+    {
+        var json = """{"Version":"soon","Url":"https://ksa.ahwoo.com"}""";
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
+        var ping = new LatestVersionPing(client, new FakeTimeProvider());
+
+        var answer = await ping.PingAsync();
+
+        Assert.Null(answer.Version);
+        Assert.Equal("soon", answer.RawVersion);
+        Assert.Equal("https://ksa.ahwoo.com", answer.DownloadUrl);
+    }
+
+    [Fact]
+    public async Task PingAsync_NullBody_BecomesUnknownInsteadOfThrowing()
+    {
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse("null"), out _);
+        var ping = new LatestVersionPing(client, new FakeTimeProvider());
+
+        var answer = await ping.PingAsync();
+
+        Assert.Null(answer.Version);
+        Assert.Equal(string.Empty, answer.RawVersion);
+        Assert.Equal(string.Empty, answer.DownloadUrl);
+    }
+
+    [Fact]
+    public async Task PingAsync_WithinAMinute_ReturnsCachedAnswerWithoutASecondRequest()
+    {
+        var requests = 0;
+        var client = FakeHttpMessageHandler.BuildClient(_ =>
+        {
+            requests++;
+            return FakeHttpMessageHandler.JsonResponse(RealResponseJson);
+        }, out _);
+        var time = new FakeTimeProvider();
+        var ping = new LatestVersionPing(client, time);
+
+        var first = await ping.PingAsync();
+        time.UtcNow += TimeSpan.FromSeconds(30);
+        var second = await ping.PingAsync();
+
+        Assert.Equal(1, requests);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public async Task PingAsync_AfterAMinute_PingsAgainAndHandsBackTheFreshAnswer()
+    {
+        var requests = 0;
+        var client = FakeHttpMessageHandler.BuildClient(_ =>
+        {
+            requests++;
+            return FakeHttpMessageHandler.JsonResponse(requests == 1
+                ? RealResponseJson
+                : """{"Version":"2026.9.1.5200","Url":"https://ksa.ahwoo.com"}""");
+        }, out _);
+        var time = new FakeTimeProvider();
+        var ping = new LatestVersionPing(client, time);
+
+        await ping.PingAsync();
+        time.UtcNow += TimeSpan.FromSeconds(61);
+        var second = await ping.PingAsync();
+
+        Assert.Equal(2, requests);
+        Assert.Equal(GameVersion.Parse("2026.9.1.5200"), second.Version);
+    }
+
+    [Fact]
+    public async Task PingAsync_NonJsonBody_BecomesUnknownInsteadOfThrowing()
+    {
+        var client = FakeHttpMessageHandler.BuildClient(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("<html>sign in to continue</html>", System.Text.Encoding.UTF8, "text/html"),
+        }, out _);
+        var ping = new LatestVersionPing(client, new FakeTimeProvider());
+
+        var answer = await ping.PingAsync();
+
+        Assert.Null(answer.Version);
+        Assert.Equal(string.Empty, answer.RawVersion);
+    }
+
+    [Fact]
+    public async Task PingAsync_OverlappingCalls_ShareOneRequest()
+    {
+        var requests = 0;
+        var pending = new TaskCompletionSource<HttpResponseMessage>();
+        var client = FakeHttpMessageHandler.BuildClient(_ =>
+        {
+            requests++;
+            return pending.Task;
+        }, out _);
+        var ping = new LatestVersionPing(client, new FakeTimeProvider());
+
+        var first = ping.PingAsync();
+        var second = ping.PingAsync();
+        Assert.False(first.IsCompleted);
+        pending.SetResult(FakeHttpMessageHandler.JsonResponse(RealResponseJson));
+
+        Assert.Same(await first, await second);
+        Assert.Equal(1, requests);
+    }
+
+    [Fact]
+    public async Task PingAsync_TransportFailure_ThrowsAndDoesNotStartTheCacheWindow()
+    {
+        var requests = 0;
+        var client = FakeHttpMessageHandler.BuildClient(_ =>
+        {
+            requests++;
+            return requests == 1
+                ? new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                : FakeHttpMessageHandler.JsonResponse(RealResponseJson);
+        }, out _);
+        var ping = new LatestVersionPing(client, new FakeTimeProvider());
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => ping.PingAsync());
+        var answer = await ping.PingAsync();
+
+        Assert.Equal(2, requests);
+        Assert.NotNull(answer.Version);
+    }
+}

--- a/tests/Borea.Network.Tests/Temp/FakeHttpMessageHandler.cs
+++ b/tests/Borea.Network.Tests/Temp/FakeHttpMessageHandler.cs
@@ -6,19 +6,22 @@
 /// </summary>
 internal sealed class FakeHttpMessageHandler : HttpMessageHandler
 {
-    private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+    private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> _responder;
 
     public HttpRequestMessage? LastRequest { get; private set; }
 
-    public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) => _responder = responder;
+    public FakeHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder) => _responder = responder;
 
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         LastRequest = request;
-        return Task.FromResult(_responder(request));
+        return _responder(request);
     }
 
-    public static HttpClient BuildClient(Func<HttpRequestMessage, HttpResponseMessage> responder, out FakeHttpMessageHandler handler)
+    public static HttpClient BuildClient(Func<HttpRequestMessage, HttpResponseMessage> responder, out FakeHttpMessageHandler handler) =>
+        BuildClient(request => Task.FromResult(responder(request)), out handler);
+
+    public static HttpClient BuildClient(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder, out FakeHttpMessageHandler handler)
     {
         handler = new FakeHttpMessageHandler(responder);
         return new HttpClient(handler) { BaseAddress = new Uri("https://spacedock.info/") };

--- a/tests/Borea.Network.Tests/Temp/FakeTimeProvider.cs
+++ b/tests/Borea.Network.Tests/Temp/FakeTimeProvider.cs
@@ -1,0 +1,11 @@
+namespace Borea.Network.Tests;
+
+/// <summary>
+/// A TimeProvider whose clock only moves when a test moves it.
+/// </summary>
+internal sealed class FakeTimeProvider : TimeProvider
+{
+    public DateTimeOffset UtcNow { get; set; } = new(2026, 8, 4, 0, 0, 0, TimeSpan.Zero);
+
+    public override DateTimeOffset GetUtcNow() => UtcNow;
+}


### PR DESCRIPTION
`LatestVersionPing` asks the master server for the current public build and hands back the reported version and download url, without any comparison logic. Successful answers are cached for a minute, matching the game's own check interval, overlapping calls share one request, and an unusable answer surfaces as an unknown version instead of an exception.

Closes #12.