### PR TITLE
Report test coverage to Coveralls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,28 @@ jobs:
         with:
           dotnet-version: 10.0.x
       - run: dotnet build Borea.slnx --configuration Release
-      - run: dotnet test Borea.slnx --configuration Release --no-build
+      # Collected on every leg, reported from Linux only so one build is one Coveralls job.
+      - run: dotnet test Borea.slnx --configuration Release --no-build --collect:"XPlat Code Coverage" --results-directory coverage
+
+      # Merge the per-project Cobertura files into one lcov report; lcov keeps the absolute
+      # source paths Coveralls needs, and the filter drops generated code under obj/.
+      - name: Merge coverage reports
+        if: matrix.os == 'ubuntu-latest'
+        uses: danielpalme/ReportGenerator-GitHub-Action@5.5.11
+        with:
+          reports: coverage/**/coverage.cobertura.xml
+          targetdir: coverage/merged
+          reporttypes: lcov
+          filefilters: '-*/obj/*'
+          toolpath: ${{ runner.temp }}/reportgenerator
+
+      - name: Report coverage to Coveralls
+        if: matrix.os == 'ubuntu-latest'
+        uses: coverallsapp/github-action@v2
+        with:
+          file: coverage/merged/lcov.info
+          format: lcov
+          fail-on-error: false
 
   format:
     name: format

--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,8 @@ coverage*.json
 coverage*.xml
 coverage*.info
 
+coverage/
+
 # Visual Studio code coverage results
 *.coverage
 *.coveragexml


### PR DESCRIPTION
Coverage is collected on all three matrix legs and reported from the Linux leg only.
ReportGenerator merges the per-project Cobertura files into one lcov report first: the Coveralls Cobertura parser ignores `<sources>`, and coverlet writes a different source root per test project, so the raw files would report wrong paths and upload `Borea.Core` three times.
No repo secret is needed, the action identifies the repo with the built-in `GITHUB_TOKEN`.
No threshold, and `fail-on-error: false`, so coverage never gates a build.

@averageksp one step needs org owner rights before this reports anything.
Coveralls is a GitHub OAuth app, not a GitHub App, and KSAModding has third party access restrictions on, so its repos do not appear on coveralls.io at all.
I already requested access, please approve it under org Settings -> Third-party Access -> OAuth app policy.

The rest is on me: @coveralls is already invited to this repo with the write role, and I enable the repo on coveralls.io once the org access is through.

Closes #15.
