### PR TITLE
Storage: persist the new metadata model

### DIFF
--- a/src/Borea.Storage/Instances/FileInstanceRepository.cs
+++ b/src/Borea.Storage/Instances/FileInstanceRepository.cs
@@ -22,7 +22,9 @@ public sealed class FileInstanceRepository : IInstanceRepository
 
 
     /// <summary>
-    /// Returns all instances that exist on disk.
+    /// Returns all instances that exist on disk. An instance whose file cannot
+    /// be read or mapped is skipped, so one broken file does not take the whole
+    /// list down; loading it directly by id still surfaces the error.
     /// </summary>
     public async Task<IReadOnlyList<Instance>> GetAllAsync()
     {
@@ -37,7 +39,16 @@ public sealed class FileInstanceRepository : IInstanceRepository
             if (!Guid.TryParse(Path.GetFileName(dir), out var instanceId))
                 continue;
 
-            var instance = await GetByIdAsync(instanceId).ConfigureAwait(false);
+            Instance? instance;
+            try
+            {
+                instance = await GetByIdAsync(instanceId).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                continue;
+            }
+
             if (instance is not null)
                 instances.Add(instance);
         }

--- a/src/Borea.Storage/ModPacks/FileModPackFavoritesRepository.cs
+++ b/src/Borea.Storage/ModPacks/FileModPackFavoritesRepository.cs
@@ -22,14 +22,14 @@ public sealed class FileModPackFavoritesRepository : IModPackFavoritesRepository
     public async Task<bool> IsFavoriteAsync(string modPackId, CancellationToken cancellationToken = default)
     {
         var dto = await ReadAsync(cancellationToken).ConfigureAwait(false);
-        return dto.ModPackIds.Contains(modPackId, StringComparer.Ordinal);
+        return dto.ModPackIds.Contains(modPackId, Borea.Core.Mods.ModIds.Comparer);
     }
 
     public async Task AddFavoriteAsync(string modPackId, CancellationToken cancellationToken = default)
     {
         var dto = await ReadAsync(cancellationToken).ConfigureAwait(false);
 
-        if (dto.ModPackIds.Contains(modPackId, StringComparer.Ordinal))
+        if (dto.ModPackIds.Contains(modPackId, Borea.Core.Mods.ModIds.Comparer))
             return;
 
         dto.ModPackIds.Add(modPackId);
@@ -40,7 +40,7 @@ public sealed class FileModPackFavoritesRepository : IModPackFavoritesRepository
     {
         var dto = await ReadAsync(cancellationToken).ConfigureAwait(false);
 
-        if (dto.ModPackIds.RemoveAll(id => string.Equals(id, modPackId, StringComparison.Ordinal)) > 0)
+        if (dto.ModPackIds.RemoveAll(id => Borea.Core.Mods.ModIds.Equals(id, modPackId)) > 0)
             await WriteAsync(dto, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Borea.Storage/Mods/DownloadInfoDto.cs
+++ b/src/Borea.Storage/Mods/DownloadInfoDto.cs
@@ -1,0 +1,13 @@
+﻿namespace Borea.Storage.Mods;
+
+/// <summary>
+/// Flat, TOML-serializable representation of a DownloadInfo.
+/// </summary>
+public sealed class DownloadInfoDto
+{
+    public string Url { get; set; } = string.Empty;
+    public string Sha256 { get; set; } = string.Empty;
+    public long SizeBytes { get; set; }
+    public string ContentType { get; set; } = string.Empty;
+    public List<string> Mirrors { get; set; } = new();
+}

--- a/src/Borea.Storage/Mods/DownloadInfoMapper.cs
+++ b/src/Borea.Storage/Mods/DownloadInfoMapper.cs
@@ -1,0 +1,22 @@
+﻿using Borea.Core.Mods;
+
+namespace Borea.Storage.Mods;
+
+public static class DownloadInfoMapper
+{
+    public static DownloadInfoDto ToDto(DownloadInfo download) => new()
+    {
+        Url = download.Url,
+        Sha256 = download.Sha256,
+        SizeBytes = download.SizeBytes,
+        ContentType = download.ContentType,
+        Mirrors = download.Mirrors.ToList(),
+    };
+
+    public static DownloadInfo FromDto(DownloadInfoDto dto) => new(
+        dto.Url,
+        dto.Sha256,
+        dto.SizeBytes,
+        dto.ContentType,
+        dto.Mirrors);
+}

--- a/src/Borea.Storage/Mods/FileModFavoritesRepository.cs
+++ b/src/Borea.Storage/Mods/FileModFavoritesRepository.cs
@@ -26,14 +26,14 @@ public sealed class FileModFavoritesRepository : IModFavoritesRepository
     public async Task<bool> IsFavoriteAsync(string modId, CancellationToken cancellationToken = default)
     {
         var dto = await ReadAsync(cancellationToken).ConfigureAwait(false);
-        return dto.ModIds.Contains(modId, StringComparer.Ordinal);
+        return dto.ModIds.Contains(modId, ModIds.Comparer);
     }
 
     public async Task AddFavoriteAsync(string modId, CancellationToken cancellationToken = default)
     {
         var dto = await ReadAsync(cancellationToken).ConfigureAwait(false);
 
-        if (dto.ModIds.Contains(modId, StringComparer.Ordinal))
+        if (dto.ModIds.Contains(modId, ModIds.Comparer))
             return;
 
         dto.ModIds.Add(modId);
@@ -44,7 +44,7 @@ public sealed class FileModFavoritesRepository : IModFavoritesRepository
     {
         var dto = await ReadAsync(cancellationToken).ConfigureAwait(false);
 
-        if (dto.ModIds.RemoveAll(id => string.Equals(id, modId, StringComparison.Ordinal)) > 0)
+        if (dto.ModIds.RemoveAll(id => ModIds.Equals(id, modId)) > 0)
             await WriteAsync(dto, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Borea.Storage/Mods/FileModUninstaller.cs
+++ b/src/Borea.Storage/Mods/FileModUninstaller.cs
@@ -20,9 +20,16 @@ public sealed class FileModUninstaller : IModUninstaller
         if (string.IsNullOrWhiteSpace(modId))
             throw new ArgumentException("Mod ID cannot be null or whitespace.", nameof(modId));
 
-        var modDirectory = Path.Combine(_pathProvider.GetInstanceModsFolder(instanceId), modId);
+        var modsFolder = _pathProvider.GetInstanceModsFolder(instanceId);
+        if (!Directory.Exists(modsFolder))
+            return Task.CompletedTask;
 
-        if (Directory.Exists(modDirectory))
+        // Ids compare case-insensitively while folder names are case-sensitive
+        // on Linux and macOS, so the folder is resolved by comparison, not by path.
+        var modDirectory = Directory.GetDirectories(modsFolder)
+            .FirstOrDefault(d => ModIds.Equals(Path.GetFileName(d), modId));
+
+        if (modDirectory is not null)
             Directory.Delete(modDirectory, recursive: true);
 
         return Task.CompletedTask;

--- a/src/Borea.Storage/Mods/InstallInfoDto.cs
+++ b/src/Borea.Storage/Mods/InstallInfoDto.cs
@@ -1,0 +1,10 @@
+﻿namespace Borea.Storage.Mods;
+
+/// <summary>
+/// Flat, TOML-serializable representation of an InstallInfo.
+/// </summary>
+public sealed class InstallInfoDto
+{
+    public string Root { get; set; } = string.Empty;
+    public bool Derived { get; set; }
+}

--- a/src/Borea.Storage/Mods/InstallInfoMapper.cs
+++ b/src/Borea.Storage/Mods/InstallInfoMapper.cs
@@ -1,0 +1,14 @@
+﻿using Borea.Core.Mods;
+
+namespace Borea.Storage.Mods;
+
+public static class InstallInfoMapper
+{
+    public static InstallInfoDto ToDto(InstallInfo install) => new()
+    {
+        Root = install.Root,
+        Derived = install.Derived,
+    };
+
+    public static InstallInfo FromDto(InstallInfoDto dto) => new(dto.Root, dto.Derived);
+}

--- a/src/Borea.Storage/Mods/InstalledModDto.cs
+++ b/src/Borea.Storage/Mods/InstalledModDto.cs
@@ -1,17 +1,20 @@
 ﻿namespace Borea.Storage.Mods;
 
 /// <summary>
-/// Flat, TOML-serializable representation of an InstalledMod.
+/// TOML-serializable representation of an InstalledMod.
 /// </summary>
 public sealed class InstalledModDto
 {
     public string ModId { get; set; } = string.Empty;
     public string Version { get; set; } = string.Empty;
 
-    /// <summary>InstallReason as a string — "Manual", "ModPack", or "Dependency".</summary>
+    /// <summary>InstallReason as a string - "Manual", "ModPack", or "Dependency".</summary>
     public string Reason { get; set; } = string.Empty;
 
     public DateTimeOffset InstalledAt { get; set; }
     public string? Checksum { get; set; }
     public ModMetadataDto Metadata { get; set; } = new();
+
+    /// <summary>The dependency list of the installed release, as its release file stamped it.</summary>
+    public List<ModDependencyDto> Dependencies { get; set; } = new();
 }

--- a/src/Borea.Storage/Mods/InstalledModDto.cs
+++ b/src/Borea.Storage/Mods/InstalledModDto.cs
@@ -13,8 +13,7 @@ public sealed class InstalledModDto
 
     public DateTimeOffset InstalledAt { get; set; }
     public string? Checksum { get; set; }
-    public ModMetadataDto Metadata { get; set; } = new();
 
-    /// <summary>The dependency list of the installed release, as its release file stamped it.</summary>
-    public List<ModDependencyDto> Dependencies { get; set; } = new();
+    /// <summary>The release the mod was installed from.</summary>
+    public ModVersionMetadataDto Metadata { get; set; } = new();
 }

--- a/src/Borea.Storage/Mods/InstalledModMapper.cs
+++ b/src/Borea.Storage/Mods/InstalledModMapper.cs
@@ -12,6 +12,7 @@ public static class InstalledModMapper
         InstalledAt = mod.InstalledAt,
         Checksum = mod.Checksum,
         Metadata = ModMetadataMapper.ToDto(mod.Metadata),
+        Dependencies = mod.Dependencies.Select(ModDependencyMapper.ToDto).ToList(),
     };
 
     public static InstalledMod FromDto(InstalledModDto dto) => new(
@@ -20,5 +21,6 @@ public static class InstalledModMapper
         Enum.Parse<InstallReason>(dto.Reason),
         dto.InstalledAt,
         ModMetadataMapper.FromDto(dto.Metadata),
+        dto.Dependencies.Select(ModDependencyMapper.FromDto).ToList(),
         dto.Checksum);
 }

--- a/src/Borea.Storage/Mods/InstalledModMapper.cs
+++ b/src/Borea.Storage/Mods/InstalledModMapper.cs
@@ -11,8 +11,7 @@ public static class InstalledModMapper
         Reason = mod.Reason.ToString(),
         InstalledAt = mod.InstalledAt,
         Checksum = mod.Checksum,
-        Metadata = ModMetadataMapper.ToDto(mod.Metadata),
-        Dependencies = mod.Dependencies.Select(ModDependencyMapper.ToDto).ToList(),
+        Metadata = ModVersionMetadataMapper.ToDto(mod.Metadata),
     };
 
     public static InstalledMod FromDto(InstalledModDto dto) => new(
@@ -20,7 +19,6 @@ public static class InstalledModMapper
         ModVersion.Parse(dto.Version),
         Enum.Parse<InstallReason>(dto.Reason),
         dto.InstalledAt,
-        ModMetadataMapper.FromDto(dto.Metadata),
-        dto.Dependencies.Select(ModDependencyMapper.FromDto).ToList(),
+        ModVersionMetadataMapper.FromDto(dto.Metadata),
         dto.Checksum);
 }

--- a/src/Borea.Storage/Mods/ListingSnapshotDto.cs
+++ b/src/Borea.Storage/Mods/ListingSnapshotDto.cs
@@ -1,0 +1,15 @@
+﻿namespace Borea.Storage.Mods;
+
+/// <summary>
+/// Flat, TOML-serializable representation of a ListingSnapshot.
+/// </summary>
+public sealed class ListingSnapshotDto
+{
+    public string Name { get; set; } = string.Empty;
+    public List<string> Authors { get; set; } = new();
+    public string Abstract { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string License { get; set; } = string.Empty;
+    public List<string> Tags { get; set; } = new();
+    public Dictionary<string, string> Links { get; set; } = new();
+}

--- a/src/Borea.Storage/Mods/ListingSnapshotMapper.cs
+++ b/src/Borea.Storage/Mods/ListingSnapshotMapper.cs
@@ -1,0 +1,26 @@
+﻿using Borea.Core.Mods;
+
+namespace Borea.Storage.Mods;
+
+public static class ListingSnapshotMapper
+{
+    public static ListingSnapshotDto ToDto(ListingSnapshot listing) => new()
+    {
+        Name = listing.Name,
+        Authors = listing.Authors.ToList(),
+        Abstract = listing.Abstract,
+        Description = listing.Description,
+        License = listing.License,
+        Tags = listing.Tags.ToList(),
+        Links = listing.Links.ToDictionary(p => p.Key, p => p.Value),
+    };
+
+    public static ListingSnapshot FromDto(ListingSnapshotDto dto) => new(
+        dto.Name,
+        dto.Authors,
+        dto.Abstract,
+        dto.License,
+        dto.Tags,
+        dto.Links,
+        dto.Description);
+}

--- a/src/Borea.Storage/Mods/LoaderRequirementDto.cs
+++ b/src/Borea.Storage/Mods/LoaderRequirementDto.cs
@@ -1,0 +1,14 @@
+﻿namespace Borea.Storage.Mods;
+
+/// <summary>
+/// Flat, TOML-serializable representation of a LoaderRequirement.
+/// </summary>
+public sealed class LoaderRequirementDto
+{
+    public string LoaderId { get; set; } = string.Empty;
+    public string MinVersion { get; set; } = string.Empty;
+    public string? MaxVersion { get; set; }
+
+    /// <summary>"authored" or "derived" in release data, null in authored metadata.</summary>
+    public string? Source { get; set; }
+}

--- a/src/Borea.Storage/Mods/LoaderRequirementMapper.cs
+++ b/src/Borea.Storage/Mods/LoaderRequirementMapper.cs
@@ -1,0 +1,21 @@
+﻿using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+
+namespace Borea.Storage.Mods;
+
+public static class LoaderRequirementMapper
+{
+    public static LoaderRequirementDto ToDto(LoaderRequirement loader) => new()
+    {
+        LoaderId = loader.LoaderId,
+        MinVersion = loader.MinVersion.ToString(),
+        MaxVersion = loader.MaxVersion?.ToString(),
+        Source = MetadataEnumMapper.ToDto(loader.Source),
+    };
+
+    public static LoaderRequirement FromDto(LoaderRequirementDto dto) => new(
+        dto.LoaderId,
+        ModVersion.Parse(dto.MinVersion),
+        MetadataEnumMapper.ParseVersion(dto.MaxVersion),
+        MetadataEnumMapper.ParseSource(dto.Source));
+}

--- a/src/Borea.Storage/Mods/MetadataEnumMapper.cs
+++ b/src/Borea.Storage/Mods/MetadataEnumMapper.cs
@@ -1,0 +1,102 @@
+﻿using Borea.Core.Mods;
+
+namespace Borea.Storage.Mods;
+
+/// <summary>
+/// String forms of the closed metadata enums, spelled the way the format
+/// writes them, plus the shared version parse helper. Only the spelled
+/// vocabulary maps to a real member; anything else parses to Unknown.
+/// An Unknown value is written back as "unknown", the original token is not
+/// recoverable from disk, so the index snapshot stays the source of truth
+/// for entries a client build did not understand.
+/// </summary>
+public static class MetadataEnumMapper
+{
+    public static string ToDto(ContentType type) => type switch
+    {
+        ContentType.Mod => "mod",
+        ContentType.ModPack => "modpack",
+        ContentType.ModLoader => "mod-loader",
+        _ => "unknown",
+    };
+
+    public static ContentType ParseContentType(string value) => value.ToLowerInvariant() switch
+    {
+        "mod" => ContentType.Mod,
+        "modpack" => ContentType.ModPack,
+        "mod-loader" => ContentType.ModLoader,
+        _ => ContentType.Unknown,
+    };
+
+    public static string ToDto(ModStatus status) => status switch
+    {
+        ModStatus.Active => "active",
+        ModStatus.Deprecated => "deprecated",
+        _ => "unknown",
+    };
+
+    public static ModStatus ParseModStatus(string value) => value.ToLowerInvariant() switch
+    {
+        "active" => ModStatus.Active,
+        "deprecated" => ModStatus.Deprecated,
+        _ => ModStatus.Unknown,
+    };
+
+    public static string ToDto(ReleaseStatus status) => status switch
+    {
+        ReleaseStatus.Stable => "stable",
+        ReleaseStatus.Testing => "testing",
+        ReleaseStatus.Dev => "dev",
+        _ => "unknown",
+    };
+
+    public static ReleaseStatus ParseReleaseStatus(string value) => value.ToLowerInvariant() switch
+    {
+        "stable" => ReleaseStatus.Stable,
+        "testing" => ReleaseStatus.Testing,
+        "dev" => ReleaseStatus.Dev,
+        _ => ReleaseStatus.Unknown,
+    };
+
+    public static string ToDto(Core.Dependencies.ModDependencyKind kind) => kind switch
+    {
+        Core.Dependencies.ModDependencyKind.Required => "required",
+        Core.Dependencies.ModDependencyKind.Optional => "optional",
+        Core.Dependencies.ModDependencyKind.Recommends => "recommends",
+        Core.Dependencies.ModDependencyKind.Suggests => "suggests",
+        Core.Dependencies.ModDependencyKind.Conflict => "conflict",
+        _ => "unknown",
+    };
+
+    public static Core.Dependencies.ModDependencyKind ParseKind(string value) => value.ToLowerInvariant() switch
+    {
+        "required" => Core.Dependencies.ModDependencyKind.Required,
+        "optional" => Core.Dependencies.ModDependencyKind.Optional,
+        "recommends" => Core.Dependencies.ModDependencyKind.Recommends,
+        "suggests" => Core.Dependencies.ModDependencyKind.Suggests,
+        "conflict" => Core.Dependencies.ModDependencyKind.Conflict,
+        _ => Core.Dependencies.ModDependencyKind.Unknown,
+    };
+
+    public static string? ToDto(MetadataSource? source) => source switch
+    {
+        null => null,
+        MetadataSource.Authored => "authored",
+        MetadataSource.Derived => "derived",
+        _ => "unknown",
+    };
+
+    public static MetadataSource? ParseSource(string? value) => value?.ToLowerInvariant() switch
+    {
+        null => null,
+        "authored" => MetadataSource.Authored,
+        "derived" => MetadataSource.Derived,
+        _ => MetadataSource.Unknown,
+    };
+
+    /// <summary>
+    /// Parses an optional version string, null staying null.
+    /// </summary>
+    public static ModVersion? ParseVersion(string? value) =>
+        value is null ? null : ModVersion.Parse(value);
+}

--- a/src/Borea.Storage/Mods/ModDependencyAlternativeDto.cs
+++ b/src/Borea.Storage/Mods/ModDependencyAlternativeDto.cs
@@ -1,0 +1,11 @@
+﻿namespace Borea.Storage.Mods;
+
+/// <summary>
+/// Flat, TOML-serializable representation of one any_of alternative.
+/// </summary>
+public sealed class ModDependencyAlternativeDto
+{
+    public string ModId { get; set; } = string.Empty;
+    public string? MinVersion { get; set; }
+    public string? MaxVersion { get; set; }
+}

--- a/src/Borea.Storage/Mods/ModDependencyAlternativeMapper.cs
+++ b/src/Borea.Storage/Mods/ModDependencyAlternativeMapper.cs
@@ -1,0 +1,18 @@
+﻿using Borea.Core.Dependencies;
+
+namespace Borea.Storage.Mods;
+
+public static class ModDependencyAlternativeMapper
+{
+    public static ModDependencyAlternativeDto ToDto(ModDependencyAlternative alternative) => new()
+    {
+        ModId = alternative.ModId,
+        MinVersion = alternative.MinVersion?.ToString(),
+        MaxVersion = alternative.MaxVersion?.ToString(),
+    };
+
+    public static ModDependencyAlternative FromDto(ModDependencyAlternativeDto dto) => new(
+        dto.ModId,
+        MetadataEnumMapper.ParseVersion(dto.MinVersion),
+        MetadataEnumMapper.ParseVersion(dto.MaxVersion));
+}

--- a/src/Borea.Storage/Mods/ModDependencyDto.cs
+++ b/src/Borea.Storage/Mods/ModDependencyDto.cs
@@ -1,11 +1,22 @@
 ﻿namespace Borea.Storage.Mods;
 
 /// <summary>
-/// Flat, TOML-serializable representation of a ModDependency.
+/// TOML-serializable representation of a ModDependency.
 /// </summary>
 public sealed class ModDependencyDto
 {
-    public string ModId { get; set; } = string.Empty;
-    public string VersionRange { get; set; } = string.Empty;
-    public bool IsOptional { get; set; }
+    /// <summary>Null when this is an any_of entry.</summary>
+    public string? ModId { get; set; }
+
+    /// <summary>The dependency kind, lowercase ("required", "conflict", ...).</summary>
+    public string Kind { get; set; } = string.Empty;
+
+    public string? MinVersion { get; set; }
+    public string? MaxVersion { get; set; }
+
+    /// <summary>"authored" or "derived" in release data, null in authored metadata.</summary>
+    public string? Source { get; set; }
+
+    /// <summary>The alternatives of an any_of entry, null for a single-id entry.</summary>
+    public List<ModDependencyAlternativeDto>? AnyOf { get; set; }
 }

--- a/src/Borea.Storage/Mods/ModDependencyMapper.cs
+++ b/src/Borea.Storage/Mods/ModDependencyMapper.cs
@@ -7,12 +7,35 @@ public static class ModDependencyMapper
     public static ModDependencyDto ToDto(ModDependency dependency) => new()
     {
         ModId = dependency.ModId,
-        VersionRange = dependency.RequiredVersion.ToString(),
-        IsOptional = dependency.IsOptional,
+        Kind = MetadataEnumMapper.ToDto(dependency.Kind),
+        MinVersion = dependency.MinVersion?.ToString(),
+        MaxVersion = dependency.MaxVersion?.ToString(),
+        Source = MetadataEnumMapper.ToDto(dependency.Source),
+        AnyOf = dependency.AnyOf?.Select(ModDependencyAlternativeMapper.ToDto).ToList(),
     };
 
-    public static ModDependency FromDto(ModDependencyDto dto) => new(
-        dto.ModId,
-        Core.Mods.VersionRange.Parse(dto.VersionRange),
-        dto.IsOptional);
+    public static ModDependency FromDto(ModDependencyDto dto)
+    {
+        var kind = MetadataEnumMapper.ParseKind(dto.Kind);
+        var source = MetadataEnumMapper.ParseSource(dto.Source);
+
+        if (dto.AnyOf is not null)
+        {
+            if (dto.AnyOf.Count == 0)
+                throw new FormatException("An any_of list cannot be empty.");
+
+            if (dto.ModId is not null)
+                throw new FormatException("A dependency entry carries a mod id or an any_of list, not both.");
+
+            if (kind is not (ModDependencyKind.Required or ModDependencyKind.Recommends))
+                throw new FormatException($"An any_of dependency entry cannot have kind '{dto.Kind}'.");
+
+            return ModDependency.OfAlternatives(kind, dto.AnyOf.Select(ModDependencyAlternativeMapper.FromDto).ToList(), source);
+        }
+
+        if (dto.ModId is null)
+            throw new FormatException("A dependency entry needs a mod id or an any_of list.");
+
+        return new ModDependency(dto.ModId, kind, MetadataEnumMapper.ParseVersion(dto.MinVersion), MetadataEnumMapper.ParseVersion(dto.MaxVersion), source);
+    }
 }

--- a/src/Borea.Storage/Mods/ModMetadataDto.cs
+++ b/src/Borea.Storage/Mods/ModMetadataDto.cs
@@ -1,21 +1,42 @@
 ﻿namespace Borea.Storage.Mods;
 
 /// <summary>
-/// Flat, TOML-serializable representation of a ModMetadata snapshot.
+/// TOML-serializable representation of the authored ModMetadata.
+/// Absent optional fields stay null so they round-trip as absent.
+/// Mirrors Borea's local persistence, not the RFC 0031 wire format; the index
+/// reader gets its own DTOs.
 /// </summary>
 public sealed class ModMetadataDto
 {
+    public int SpecVersion { get; set; }
     public string ModId { get; set; } = string.Empty;
+
+    /// <summary>The content type, lowercase ("mod", "mod-loader").</summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>Which source this metadata came from. Borea-internal, not a format field.</summary>
     public string Source { get; set; } = string.Empty;
+
     public string Name { get; set; } = string.Empty;
-    public string Author { get; set; } = string.Empty;
-    public string Version { get; set; } = string.Empty;
-    public string BuiltForGameVersion { get; set; } = string.Empty;
-    public string Description { get; set; } = string.Empty;
-    public string? HomepageUrl { get; set; }
-    public string? ChangeLog { get; set; }
-    public System.DateTimeOffset ReleasedAt { get; set; }
-    public long FileSizeBytes { get; set; }
-    public List<ModDependencyDto> Dependencies { get; set; } = new();
+    public List<string> Authors { get; set; } = new();
+    public string Abstract { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string License { get; set; } = string.Empty;
     public List<string> Tags { get; set; } = new();
+
+    /// <summary>The author's listing status, lowercase ("active", "deprecated"). Absent means active.</summary>
+    public string? Status { get; set; }
+
+    public string? SupersededBy { get; set; }
+    public Dictionary<string, string> Links { get; set; } = new();
+    public ReleaseSourceDto? Releases { get; set; }
+    public string GameMin { get; set; } = string.Empty;
+    public string? GameMax { get; set; }
+
+    /// <summary>Null means no known platform restriction.</summary>
+    public List<string>? Os { get; set; }
+
+    public LoaderRequirementDto? Loader { get; set; }
+    public List<ModDependencyDto> Dependencies { get; set; } = new();
+    public string? InstallRootOverride { get; set; }
 }

--- a/src/Borea.Storage/Mods/ModMetadataMapper.cs
+++ b/src/Borea.Storage/Mods/ModMetadataMapper.cs
@@ -1,5 +1,4 @@
 ﻿using Borea.Core.Mods;
-using Borea.Core.Game;
 
 namespace Borea.Storage.Mods;
 
@@ -7,33 +6,53 @@ public static class ModMetadataMapper
 {
     public static ModMetadataDto ToDto(ModMetadata metadata) => new()
     {
+        SpecVersion = metadata.SpecVersion,
         ModId = metadata.ModId,
+        Type = MetadataEnumMapper.ToDto(metadata.Type),
         Source = metadata.Source,
         Name = metadata.Name,
-        Author = metadata.Author,
-        Version = metadata.Version.ToString(),
-        BuiltForGameVersion = metadata.BuiltForGameVersion.ToString(),
+        Authors = metadata.Authors.ToList(),
+        Abstract = metadata.Abstract,
         Description = metadata.Description,
-        HomepageUrl = metadata.HomepageUrl,
-        ChangeLog = metadata.ChangeLog,
-        ReleasedAt = metadata.ReleasedAt,
-        FileSizeBytes = metadata.FileSizeBytes,
-        Dependencies = metadata.Dependencies.Select(ModDependencyMapper.ToDto).ToList(),
+        License = metadata.License,
         Tags = metadata.Tags.ToList(),
+        Status = MetadataEnumMapper.ToDto(metadata.Status),
+        SupersededBy = metadata.SupersededBy,
+        Links = metadata.Links.ToDictionary(p => p.Key, p => p.Value),
+        Releases = metadata.Releases is null ? null : ReleaseSourceMapper.ToDto(metadata.Releases),
+        GameMin = metadata.GameMin,
+        GameMax = metadata.GameMax,
+        Os = metadata.Os?.ToList(),
+        Loader = metadata.Loader is null ? null : LoaderRequirementMapper.ToDto(metadata.Loader),
+        Dependencies = metadata.Dependencies.Select(ModDependencyMapper.ToDto).ToList(),
+        InstallRootOverride = metadata.InstallRootOverride,
     };
 
-    public static ModMetadata FromDto(ModMetadataDto dto) => new(
-        dto.ModId,
-        dto.Source,
-        dto.Name,
-        dto.Author,
-        ModVersion.Parse(dto.Version),
-        GameVersion.Parse(dto.BuiltForGameVersion),
-        dto.Description,
-        dto.ReleasedAt,
-        dto.FileSizeBytes,
-        dto.Dependencies.Select(ModDependencyMapper.FromDto).ToList(),
-        dto.Tags,
-        dto.HomepageUrl,
-        dto.ChangeLog);
+    public static ModMetadata FromDto(ModMetadataDto dto)
+    {
+        if (dto.SpecVersion == 0)
+            throw new FormatException("The metadata file predates the metadata model (no spec version).");
+
+        return new ModMetadata(
+        specVersion: dto.SpecVersion,
+        modId: dto.ModId,
+        source: dto.Source,
+        name: dto.Name,
+        authors: dto.Authors,
+        abstractText: dto.Abstract,
+        license: dto.License,
+        links: dto.Links,
+        gameMin: dto.GameMin,
+        type: MetadataEnumMapper.ParseContentType(dto.Type),
+        tags: dto.Tags,
+        description: dto.Description,
+        status: dto.Status is null ? ModStatus.Active : MetadataEnumMapper.ParseModStatus(dto.Status),
+        supersededBy: dto.SupersededBy,
+        releases: dto.Releases is null ? null : ReleaseSourceMapper.FromDto(dto.Releases),
+        gameMax: dto.GameMax,
+        os: dto.Os,
+        loader: dto.Loader is null ? null : LoaderRequirementMapper.FromDto(dto.Loader),
+        dependencies: dto.Dependencies.Select(ModDependencyMapper.FromDto).ToList(),
+        installRootOverride: dto.InstallRootOverride);
+    }
 }

--- a/src/Borea.Storage/Mods/ModVersionMetadataDto.cs
+++ b/src/Borea.Storage/Mods/ModVersionMetadataDto.cs
@@ -1,0 +1,43 @@
+﻿namespace Borea.Storage.Mods;
+
+/// <summary>
+/// TOML-serializable representation of a ModVersionMetadata release.
+/// Absent optional fields stay null so they round-trip as absent.
+/// Mirrors Borea's local persistence, not the RFC 0031 wire format; the index
+/// reader gets its own DTOs.
+/// </summary>
+public sealed class ModVersionMetadataDto
+{
+    public int SpecVersion { get; set; }
+    public string ModId { get; set; } = string.Empty;
+
+    /// <summary>The content type, lowercase ("mod", "mod-loader").</summary>
+    public string Type { get; set; } = string.Empty;
+
+    public string Version { get; set; } = string.Empty;
+
+    /// <summary>Defaults to "semver", the only value in spec version 1, so an absent key stays readable.</summary>
+    public string VersionScheme { get; set; } = "semver";
+
+    /// <summary>The release maturity, lowercase ("stable", "testing", "dev").</summary>
+    public string ReleaseStatus { get; set; } = string.Empty;
+
+    public DateTimeOffset ReleaseDate { get; set; }
+    public string GameMin { get; set; } = string.Empty;
+    public int GameMinRevision { get; set; }
+    public string? GameMax { get; set; }
+    public int? GameMaxRevision { get; set; }
+
+    /// <summary>Null means no known platform restriction.</summary>
+    public List<string>? Os { get; set; }
+
+    public DownloadInfoDto Download { get; set; } = new();
+    public long InstallSizeBytes { get; set; }
+    public InstallInfoDto? Install { get; set; }
+    public LoaderRequirementDto? Loader { get; set; }
+    public List<ModDependencyDto> Dependencies { get; set; } = new();
+    public string? Changelog { get; set; }
+    public ListingSnapshotDto? Listing { get; set; }
+    public bool Yanked { get; set; }
+    public string? YankedReason { get; set; }
+}

--- a/src/Borea.Storage/Mods/ModVersionMetadataMapper.cs
+++ b/src/Borea.Storage/Mods/ModVersionMetadataMapper.cs
@@ -1,0 +1,60 @@
+﻿using Borea.Core.Mods;
+
+namespace Borea.Storage.Mods;
+
+public static class ModVersionMetadataMapper
+{
+    public static ModVersionMetadataDto ToDto(ModVersionMetadata release) => new()
+    {
+        SpecVersion = release.SpecVersion,
+        ModId = release.ModId,
+        Type = MetadataEnumMapper.ToDto(release.Type),
+        Version = release.Version.ToString(),
+        VersionScheme = release.VersionScheme,
+        ReleaseStatus = MetadataEnumMapper.ToDto(release.ReleaseStatus),
+        ReleaseDate = release.ReleaseDate,
+        GameMin = release.GameMin,
+        GameMinRevision = release.GameMinRevision,
+        GameMax = release.GameMax,
+        GameMaxRevision = release.GameMaxRevision,
+        Os = release.Os?.ToList(),
+        Download = DownloadInfoMapper.ToDto(release.Download),
+        InstallSizeBytes = release.InstallSizeBytes,
+        Install = release.Install is null ? null : InstallInfoMapper.ToDto(release.Install),
+        Loader = release.Loader is null ? null : LoaderRequirementMapper.ToDto(release.Loader),
+        Dependencies = release.Dependencies.Select(ModDependencyMapper.ToDto).ToList(),
+        Changelog = release.Changelog,
+        Listing = release.Listing is null ? null : ListingSnapshotMapper.ToDto(release.Listing),
+        Yanked = release.Yanked,
+        YankedReason = release.YankedReason,
+    };
+
+    public static ModVersionMetadata FromDto(ModVersionMetadataDto dto)
+    {
+        if (dto.SpecVersion == 0)
+            throw new FormatException("The release file predates the metadata model (no spec version).");
+
+        return new ModVersionMetadata(
+        specVersion: dto.SpecVersion,
+        modId: dto.ModId,
+        version: ModVersion.Parse(dto.Version),
+        releaseStatus: MetadataEnumMapper.ParseReleaseStatus(dto.ReleaseStatus),
+        releaseDate: dto.ReleaseDate,
+        gameMin: dto.GameMin,
+        gameMinRevision: dto.GameMinRevision,
+        download: DownloadInfoMapper.FromDto(dto.Download),
+        installSizeBytes: dto.InstallSizeBytes,
+        dependencies: dto.Dependencies.Select(ModDependencyMapper.FromDto).ToList(),
+        type: MetadataEnumMapper.ParseContentType(dto.Type),
+        versionScheme: dto.VersionScheme,
+        gameMax: dto.GameMax,
+        gameMaxRevision: dto.GameMaxRevision,
+        os: dto.Os,
+        install: dto.Install is null ? null : InstallInfoMapper.FromDto(dto.Install),
+        loader: dto.Loader is null ? null : LoaderRequirementMapper.FromDto(dto.Loader),
+        changelog: dto.Changelog,
+        listing: dto.Listing is null ? null : ListingSnapshotMapper.FromDto(dto.Listing),
+        yanked: dto.Yanked,
+        yankedReason: dto.YankedReason);
+    }
+}

--- a/src/Borea.Storage/Mods/ReleaseSourceDto.cs
+++ b/src/Borea.Storage/Mods/ReleaseSourceDto.cs
@@ -1,0 +1,19 @@
+﻿namespace Borea.Storage.Mods;
+
+/// <summary>
+/// TOML-serializable representation of a ReleaseSource.
+/// </summary>
+public sealed class ReleaseSourceDto
+{
+    public List<ReleaseHostDto> Hosts { get; set; } = new();
+    public string? Authority { get; set; }
+}
+
+/// <summary>
+/// One release host entry: the host key and the reference on that host.
+/// </summary>
+public sealed class ReleaseHostDto
+{
+    public string Host { get; set; } = string.Empty;
+    public string Reference { get; set; } = string.Empty;
+}

--- a/src/Borea.Storage/Mods/ReleaseSourceMapper.cs
+++ b/src/Borea.Storage/Mods/ReleaseSourceMapper.cs
@@ -1,0 +1,16 @@
+﻿using Borea.Core.Mods;
+
+namespace Borea.Storage.Mods;
+
+public static class ReleaseSourceMapper
+{
+    public static ReleaseSourceDto ToDto(ReleaseSource source) => new()
+    {
+        Hosts = source.Hosts.Select(h => new ReleaseHostDto { Host = h.Host, Reference = h.Reference }).ToList(),
+        Authority = source.Authority,
+    };
+
+    public static ReleaseSource FromDto(ReleaseSourceDto dto) => new(
+        dto.Hosts.Select(h => new ReleaseHost(h.Host, h.Reference)).ToList(),
+        dto.Authority);
+}

--- a/src/Borea.Storage/State/FileModStateRepository.cs
+++ b/src/Borea.Storage/State/FileModStateRepository.cs
@@ -1,4 +1,5 @@
-﻿using Borea.Core.Paths;
+﻿using Borea.Core.Mods;
+using Borea.Core.Paths;
 using Borea.Core.State;
 using Borea.Storage.Toml;
 
@@ -20,7 +21,7 @@ public sealed class FileModStateRepository : IModStateRepository
     public async Task<bool> IsActiveAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default)
     {
         var manifest = await ReadManifestAsync(instanceId, cancellationToken).ConfigureAwait(false);
-        return manifest.Mods.FirstOrDefault(m => string.Equals(m.Id, modId, StringComparison.Ordinal))?.Enabled ?? false;
+        return manifest.Mods.FirstOrDefault(m => ModIds.Equals(m.Id, modId))?.Enabled ?? false;
     }
 
     public async Task<IReadOnlyList<string>> GetAllActiveModIdsAsync(Guid instanceId, CancellationToken cancellationToken = default)
@@ -32,7 +33,7 @@ public sealed class FileModStateRepository : IModStateRepository
     public async Task SetActiveAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default)
     {
         var manifest = await ReadManifestAsync(instanceId, cancellationToken).ConfigureAwait(false);
-        var entry = manifest.Mods.FirstOrDefault(m => string.Equals(m.Id, modId, StringComparison.Ordinal));
+        var entry = manifest.Mods.FirstOrDefault(m => ModIds.Equals(m.Id, modId));
 
         if (entry is null)
             manifest.Mods.Add(new ModManifestEntryDto { Id = modId, Enabled = true });
@@ -47,7 +48,7 @@ public sealed class FileModStateRepository : IModStateRepository
     public async Task SetInactiveAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default)
     {
         var manifest = await ReadManifestAsync(instanceId, cancellationToken).ConfigureAwait(false);
-        var entry = manifest.Mods.FirstOrDefault(m => string.Equals(m.Id, modId, StringComparison.Ordinal));
+        var entry = manifest.Mods.FirstOrDefault(m => ModIds.Equals(m.Id, modId));
 
         if (entry is null || !entry.Enabled)
             return;

--- a/src/Borea.Storage/Toml/TomlFileStore.cs
+++ b/src/Borea.Storage/Toml/TomlFileStore.cs
@@ -1,4 +1,6 @@
-﻿using Tomlyn;
+﻿using System.Globalization;
+using Tomlyn;
+using Tomlyn.Serialization;
 
 namespace Borea.Storage.Toml;
 
@@ -9,6 +11,11 @@ namespace Borea.Storage.Toml;
 /// </summary>
 public static class TomlFileStore
 {
+    private static readonly TomlSerializerOptions Options = new()
+    {
+        Converters = new TomlConverter[] { RoundTripDateTimeOffsetConverter.Instance },
+    };
+
     /// <summary>
     /// Reads and deserializes the TOML file at <paramref name="path"/> into
     /// <typeparamref name="T"/>, or returns null if the file does not exist.
@@ -20,7 +27,7 @@ public static class TomlFileStore
             return null;
 
         var text = await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
-        return TomlSerializer.Deserialize<T>(text);
+        return TomlSerializer.Deserialize<T>(text, Options);
     }
 
     /// <summary>
@@ -38,7 +45,7 @@ public static class TomlFileStore
         if (!string.IsNullOrEmpty(directory))
             Directory.CreateDirectory(directory);
 
-        var text = TomlSerializer.Serialize(value);
+        var text = TomlSerializer.Serialize(value, Options);
         await File.WriteAllTextAsync(path, text, cancellationToken).ConfigureAwait(false);
     }
 
@@ -50,5 +57,37 @@ public static class TomlFileStore
     {
         if (File.Exists(path))
             File.Delete(path);
+    }
+
+    /// <summary>
+    /// Persists DateTimeOffset as an ISO 8601 round-trip string, because the
+    /// default TOML datetime form drops the fractional seconds. Reads both the
+    /// string form and a plain TOML datetime.
+    /// </summary>
+    private sealed class RoundTripDateTimeOffsetConverter : TomlConverter<DateTimeOffset>
+    {
+        public static RoundTripDateTimeOffsetConverter Instance { get; } = new();
+
+        public override DateTimeOffset Read(TomlReader reader)
+        {
+            if (reader.TokenType == TomlTokenType.String)
+            {
+                var text = reader.GetString();
+                reader.Read();
+                return DateTimeOffset.Parse(text, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+            }
+
+            if (reader.TokenType == TomlTokenType.DateTime)
+            {
+                var value = reader.GetTomlDateTime();
+                reader.Read();
+                return value.DateTime;
+            }
+
+            throw reader.CreateException($"Expected a string or datetime token but was {reader.TokenType}.");
+        }
+
+        public override void Write(TomlWriter writer, DateTimeOffset value)
+            => writer.WriteStringValue(value.ToString("O", CultureInfo.InvariantCulture));
     }
 }

--- a/tests/Borea.Storage.Tests/Instances/FileInstaceRepositoryTests.cs
+++ b/tests/Borea.Storage.Tests/Instances/FileInstaceRepositoryTests.cs
@@ -1,8 +1,8 @@
 ﻿using Borea.Core.Dependencies;
-using Borea.Core.Game;
 using Borea.Core.Instances;
 using Borea.Core.Mods;
 using Borea.Storage.Instances;
+using Borea.Storage.Tests.Mods;
 using Borea.Storage.Tests.Paths;
 
 namespace Borea.Storage.Tests.Instances;
@@ -26,33 +26,21 @@ public sealed class FileInstanceRepositoryTests : IDisposable
         // Create a custom instance.
         var instance = await _repository.CreateAsync("My Test Pack", InstanceSource.Custom.Value);
 
-        // Build a mod with a dependency, attach it, and persist the change.
-        var dependency = new ModDependency("some-other-mod", VersionRange.Parse(">=1.0.0"), isOptional: false);
-        var metadata = new ModMetadata(
-            modId: "test-mod",
-            source: "TestSource",
-            name: "Test Mod",
-            author: "MrJeranimo",
-            version: ModVersion.Parse("1.2.3"),
-            builtForGameVersion: GameVersion.Parse("2026.7.4.2131"),
-            description: "A mod used purely for round-trip testing.",
-            releasedAt: DateTimeOffset.UtcNow,
-            fileSizeBytes: 1024,
-            dependencies: new[] { dependency },
-            tags: new[] { "test", "utility" });
-
+        // Build a mod with a stamped dependency, attach it, and persist the change.
+        var stampedDependency = new ModDependency("some-other-mod", ModDependencyKind.Required, ModVersion.Parse("1.0.0"));
         var installedMod = new InstalledMod(
             modId: "test-mod",
             version: ModVersion.Parse("1.2.3"),
             reason: InstallReason.Manual,
             installedAt: DateTimeOffset.UtcNow,
-            metadata: metadata);
+            metadata: MetadataFixtures.MinimalMetadata("test-mod"),
+            dependencies: new[] { stampedDependency });
 
         instance.AddMod(installedMod);
         instance.SetFavorite(true);
         await _repository.SaveAsync(instance);
 
-        // Reload via a FRESH repository — proves this came from disk, not memory.
+        // Reload via a FRESH repository, proving this came from disk, not memory.
         var freshRepository = new FileInstanceRepository(_pathProvider);
         var reloaded = await freshRepository.GetByIdAsync(instance.InstanceId);
 
@@ -64,14 +52,58 @@ public sealed class FileInstanceRepositoryTests : IDisposable
         var reloadedMod = reloaded.Mods.Single();
         Assert.Equal("test-mod", reloadedMod.ModId);
         Assert.Equal(ModVersion.Parse("1.2.3"), reloadedMod.Version);
-        Assert.Equal(GameVersion.Parse("2026.7.4.2131"), reloadedMod.Metadata.BuiltForGameVersion);
         Assert.Equal(InstallReason.Manual, reloadedMod.Reason);
         Assert.Equal("Test Mod", reloadedMod.Metadata.Name);
-        Assert.Single(reloadedMod.Metadata.Dependencies);
+        Assert.Equal("2026.7", reloadedMod.Metadata.GameMin);
 
-        var reloadedDependency = reloadedMod.Metadata.Dependencies.Single();
+        var reloadedDependency = reloadedMod.Dependencies.Single();
         Assert.Equal("some-other-mod", reloadedDependency.ModId);
-        Assert.False(reloadedDependency.IsOptional);
+        Assert.Equal(ModDependencyKind.Required, reloadedDependency.Kind);
+        Assert.Equal(ModVersion.Parse("1.0.0"), reloadedDependency.MinVersion);
+
+        // The authored list and the stamped list stay separate through the file.
+        Assert.Empty(reloadedMod.Metadata.Dependencies);
+        Assert.Equal(installedMod.InstalledAt, reloadedMod.InstalledAt);
+    }
+
+    [Fact]
+    public async Task RoundTrip_FullMetadataAndTwoMods_SurvivesTheNesting()
+    {
+        var instance = await _repository.CreateAsync("Deep Nesting", InstanceSource.Custom.Value);
+
+        instance.AddMod(new InstalledMod(
+            "test-mod", ModVersion.Parse("1.0.0"), InstallReason.Manual, DateTimeOffset.UtcNow,
+            MetadataFixtures.FullMetadata("test-mod"), Array.Empty<ModDependency>()));
+        instance.AddMod(new InstalledMod(
+            "second-mod", ModVersion.Parse("2.0.0"), InstallReason.Dependency, DateTimeOffset.UtcNow,
+            MetadataFixtures.MinimalMetadata("second-mod"), Array.Empty<ModDependency>()));
+        await _repository.SaveAsync(instance);
+
+        var reloaded = await new FileInstanceRepository(_pathProvider).GetByIdAsync(instance.InstanceId);
+
+        Assert.Equal(2, reloaded!.Mods.Count);
+        var fullMod = reloaded.Mods.Single(m => m.ModId == "test-mod");
+        Assert.Equal(3, fullMod.Metadata.Dependencies.Count);
+        var anyOf = fullMod.Metadata.Dependencies.Single(d => d.IsAnyOf);
+        Assert.Equal(2, anyOf.AnyOf!.Count);
+        Assert.Equal("audio-b", anyOf.AnyOf[1].ModId);
+        Assert.Equal("github", fullMod.Metadata.Releases!.Authority);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_SkipsAnUnreadableInstanceInsteadOfFailing()
+    {
+        var healthy = await _repository.CreateAsync("Healthy", InstanceSource.Custom.Value);
+
+        var brokenId = Guid.NewGuid();
+        var brokenPath = _pathProvider.GetInstanceMetadataPath(brokenId);
+        Directory.CreateDirectory(Path.GetDirectoryName(brokenPath)!);
+        File.WriteAllText(brokenPath, "InstanceId = \"not-even-a-guid\"");
+
+        var all = await _repository.GetAllAsync();
+
+        Assert.Single(all);
+        Assert.Equal(healthy.InstanceId, all[0].InstanceId);
     }
 
     [Fact]

--- a/tests/Borea.Storage.Tests/Instances/FileInstaceRepositoryTests.cs
+++ b/tests/Borea.Storage.Tests/Instances/FileInstaceRepositoryTests.cs
@@ -26,15 +26,14 @@ public sealed class FileInstanceRepositoryTests : IDisposable
         // Create a custom instance.
         var instance = await _repository.CreateAsync("My Test Pack", InstanceSource.Custom.Value);
 
-        // Build a mod with a stamped dependency, attach it, and persist the change.
+        // Build a mod whose release carries a stamped dependency, attach it, and persist the change.
         var stampedDependency = new ModDependency("some-other-mod", ModDependencyKind.Required, ModVersion.Parse("1.0.0"));
         var installedMod = new InstalledMod(
             modId: "test-mod",
             version: ModVersion.Parse("1.2.3"),
             reason: InstallReason.Manual,
             installedAt: DateTimeOffset.UtcNow,
-            metadata: MetadataFixtures.MinimalMetadata("test-mod"),
-            dependencies: new[] { stampedDependency });
+            metadata: MetadataFixtures.MinimalRelease("test-mod", "1.2.3", new[] { stampedDependency }));
 
         instance.AddMod(installedMod);
         instance.SetFavorite(true);
@@ -52,42 +51,49 @@ public sealed class FileInstanceRepositoryTests : IDisposable
         var reloadedMod = reloaded.Mods.Single();
         Assert.Equal("test-mod", reloadedMod.ModId);
         Assert.Equal(ModVersion.Parse("1.2.3"), reloadedMod.Version);
+        Assert.Equal(ModVersion.Parse("1.2.3"), reloadedMod.Metadata.Version);
         Assert.Equal(InstallReason.Manual, reloadedMod.Reason);
-        Assert.Equal("Test Mod", reloadedMod.Metadata.Name);
         Assert.Equal("2026.7", reloadedMod.Metadata.GameMin);
 
-        var reloadedDependency = reloadedMod.Dependencies.Single();
+        var reloadedDependency = reloadedMod.Metadata.Dependencies.Single();
         Assert.Equal("some-other-mod", reloadedDependency.ModId);
         Assert.Equal(ModDependencyKind.Required, reloadedDependency.Kind);
         Assert.Equal(ModVersion.Parse("1.0.0"), reloadedDependency.MinVersion);
 
-        // The authored list and the stamped list stay separate through the file.
-        Assert.Empty(reloadedMod.Metadata.Dependencies);
         Assert.Equal(installedMod.InstalledAt, reloadedMod.InstalledAt);
     }
 
     [Fact]
-    public async Task RoundTrip_FullMetadataAndTwoMods_SurvivesTheNesting()
+    public async Task RoundTrip_FullReleaseAndTwoMods_SurvivesTheNesting()
     {
         var instance = await _repository.CreateAsync("Deep Nesting", InstanceSource.Custom.Value);
 
+        var anyOfDependency = ModDependency.OfAlternatives(ModDependencyKind.Required, new[]
+        {
+            new ModDependencyAlternative("audio-a", ModVersion.Parse("2.0.0")),
+            new ModDependencyAlternative("audio-b"),
+        });
+
         instance.AddMod(new InstalledMod(
-            "test-mod", ModVersion.Parse("1.0.0"), InstallReason.Manual, DateTimeOffset.UtcNow,
-            MetadataFixtures.FullMetadata("test-mod"), Array.Empty<ModDependency>()));
+            "test-mod", ModVersion.Parse("1.2.0-beta.1"), InstallReason.Manual, DateTimeOffset.UtcNow,
+            MetadataFixtures.FullRelease("test-mod")));
         instance.AddMod(new InstalledMod(
             "second-mod", ModVersion.Parse("2.0.0"), InstallReason.Dependency, DateTimeOffset.UtcNow,
-            MetadataFixtures.MinimalMetadata("second-mod"), Array.Empty<ModDependency>()));
+            MetadataFixtures.MinimalRelease("second-mod", "2.0.0", new[] { anyOfDependency })));
         await _repository.SaveAsync(instance);
 
         var reloaded = await new FileInstanceRepository(_pathProvider).GetByIdAsync(instance.InstanceId);
 
         Assert.Equal(2, reloaded!.Mods.Count);
         var fullMod = reloaded.Mods.Single(m => m.ModId == "test-mod");
-        Assert.Equal(3, fullMod.Metadata.Dependencies.Count);
-        var anyOf = fullMod.Metadata.Dependencies.Single(d => d.IsAnyOf);
+        Assert.Equal(2, fullMod.Metadata.Dependencies.Count);
+        Assert.Equal(MetadataSource.Derived, fullMod.Metadata.Dependencies[1].Source);
+        Assert.Equal("https://forums.example/thread/1", fullMod.Metadata.Listing!.Links["forums"]);
+
+        var secondMod = reloaded.Mods.Single(m => m.ModId == "second-mod");
+        var anyOf = secondMod.Metadata.Dependencies.Single(d => d.IsAnyOf);
         Assert.Equal(2, anyOf.AnyOf!.Count);
         Assert.Equal("audio-b", anyOf.AnyOf[1].ModId);
-        Assert.Equal("github", fullMod.Metadata.Releases!.Authority);
     }
 
     [Fact]

--- a/tests/Borea.Storage.Tests/Mods/FileModFavoritesRepositoryTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/FileModFavoritesRepositoryTests.cs
@@ -43,6 +43,20 @@ public sealed class FileModFavoritesRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task Favorites_CompareIdsCaseInsensitively()
+    {
+        await _repository.AddFavoriteAsync("MyMod");
+
+        Assert.True(await _repository.IsFavoriteAsync("mymod"));
+
+        await _repository.AddFavoriteAsync("mymod");
+        Assert.Single(await _repository.GetFavoriteModIdsAsync());
+
+        await _repository.RemoveFavoriteAsync("MYMOD");
+        Assert.False(await _repository.IsFavoriteAsync("MyMod"));
+    }
+
+    [Fact]
     public async Task RemoveFavoriteAsync_RemovesOnlyTheGivenMod()
     {
         await _repository.AddFavoriteAsync("mod-a");

--- a/tests/Borea.Storage.Tests/Mods/MetadataEnumMapperTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/MetadataEnumMapperTests.cs
@@ -1,0 +1,70 @@
+﻿using Borea.Core.Dependencies;
+using Borea.Core.Mods;
+using Borea.Storage.Mods;
+
+namespace Borea.Storage.Tests.Mods;
+
+public sealed class MetadataEnumMapperTests
+{
+    [Theory]
+    [InlineData(ContentType.Mod, "mod")]
+    [InlineData(ContentType.ModPack, "modpack")]
+    [InlineData(ContentType.ModLoader, "mod-loader")]
+    [InlineData(ContentType.Unknown, "unknown")]
+    public void ContentType_WritesTheFormatSpelling(ContentType type, string expected)
+    {
+        Assert.Equal(expected, MetadataEnumMapper.ToDto(type));
+        Assert.Equal(type, MetadataEnumMapper.ParseContentType(expected));
+    }
+
+    [Theory]
+    [InlineData(ModStatus.Active, "active")]
+    [InlineData(ModStatus.Deprecated, "deprecated")]
+    [InlineData(ModStatus.Unknown, "unknown")]
+    public void ModStatus_WritesTheFormatSpelling(ModStatus status, string expected)
+    {
+        Assert.Equal(expected, MetadataEnumMapper.ToDto(status));
+        Assert.Equal(status, MetadataEnumMapper.ParseModStatus(expected));
+    }
+
+    [Theory]
+    [InlineData(ReleaseStatus.Stable, "stable")]
+    [InlineData(ReleaseStatus.Testing, "testing")]
+    [InlineData(ReleaseStatus.Dev, "dev")]
+    [InlineData(ReleaseStatus.Unknown, "unknown")]
+    public void ReleaseStatus_WritesTheFormatSpelling(ReleaseStatus status, string expected)
+    {
+        Assert.Equal(expected, MetadataEnumMapper.ToDto(status));
+        Assert.Equal(status, MetadataEnumMapper.ParseReleaseStatus(expected));
+    }
+
+    [Theory]
+    [InlineData(ModDependencyKind.Required, "required")]
+    [InlineData(ModDependencyKind.Optional, "optional")]
+    [InlineData(ModDependencyKind.Recommends, "recommends")]
+    [InlineData(ModDependencyKind.Suggests, "suggests")]
+    [InlineData(ModDependencyKind.Conflict, "conflict")]
+    [InlineData(ModDependencyKind.Unknown, "unknown")]
+    public void DependencyKind_WritesTheFormatSpelling(ModDependencyKind kind, string expected)
+    {
+        Assert.Equal(expected, MetadataEnumMapper.ToDto(kind));
+        Assert.Equal(kind, MetadataEnumMapper.ParseKind(expected));
+    }
+
+    [Theory]
+    [InlineData(MetadataSource.Authored, "authored")]
+    [InlineData(MetadataSource.Derived, "derived")]
+    [InlineData(MetadataSource.Unknown, "unknown")]
+    public void MetadataSource_WritesTheFormatSpelling(MetadataSource source, string expected)
+    {
+        Assert.Equal(expected, MetadataEnumMapper.ToDto(source));
+        Assert.Equal(source, MetadataEnumMapper.ParseSource(expected));
+    }
+
+    [Fact]
+    public void MetadataSource_NullStaysNull()
+    {
+        Assert.Null(MetadataEnumMapper.ToDto(null));
+        Assert.Null(MetadataEnumMapper.ParseSource(null));
+    }
+}

--- a/tests/Borea.Storage.Tests/Mods/MetadataFixtures.cs
+++ b/tests/Borea.Storage.Tests/Mods/MetadataFixtures.cs
@@ -68,10 +68,10 @@ internal static class MetadataFixtures
     public static DownloadInfo SampleDownload() =>
         new("https://example.com/mod.zip", new string('A', 64), 1024, "application/zip", new[] { "https://mirror.example/mod.zip" });
 
-    public static ModVersionMetadata MinimalRelease(string modId = "test-mod") => new(
+    public static ModVersionMetadata MinimalRelease(string modId = "test-mod", string version = "1.0.0", IReadOnlyList<ModDependency>? dependencies = null) => new(
         specVersion: 1,
         modId: modId,
-        version: ModVersion.Parse("1.0.0"),
+        version: ModVersion.Parse(version),
         releaseStatus: ReleaseStatus.Stable,
         releaseDate: SampleTimestamp(),
         gameMin: "2026.7",
@@ -80,7 +80,7 @@ internal static class MetadataFixtures
         // exercised by the round trip.
         download: new DownloadInfo("https://example.com/mod.zip", new string('b', 64), 512, "application/zip"),
         installSizeBytes: 2048,
-        dependencies: Array.Empty<ModDependency>());
+        dependencies: dependencies ?? Array.Empty<ModDependency>());
 
     public static ModVersionMetadata FullRelease(string modId = "test-mod") => new(
         specVersion: 1,

--- a/tests/Borea.Storage.Tests/Mods/MetadataFixtures.cs
+++ b/tests/Borea.Storage.Tests/Mods/MetadataFixtures.cs
@@ -1,0 +1,116 @@
+﻿using Borea.Core.Dependencies;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+
+namespace Borea.Storage.Tests.Mods;
+
+/// <summary>
+/// Sample metadata builders for the storage round-trip tests: a minimal shape
+/// with every optional absent, and a full shape with every optional set.
+/// </summary>
+internal static class MetadataFixtures
+{
+    public static IReadOnlyDictionary<string, string> SampleLinks() =>
+        new Dictionary<string, string> { ["forums"] = "https://forums.example/thread/1" };
+
+    // Sub-second ticks on purpose, so a serializer that drops fractional
+    // seconds fails the round-trip tests.
+    public static DateTimeOffset SampleTimestamp() =>
+        new DateTimeOffset(2026, 8, 8, 12, 0, 0, TimeSpan.Zero).AddTicks(1234567);
+
+    public static ModMetadata MinimalMetadata(string modId = "test-mod") => new(
+        specVersion: 1,
+        modId: modId,
+        source: "TestSource",
+        name: "Test Mod",
+        authors: new[] { "Author" },
+        abstractText: "Abstract.",
+        license: "MIT",
+        links: SampleLinks(),
+        gameMin: "2026.7");
+
+    public static ModMetadata FullMetadata(string modId = "test-mod") => new(
+        specVersion: 1,
+        modId: modId,
+        source: "TestSource",
+        name: "Test Mod",
+        authors: new[] { "Author A", "Author B" },
+        abstractText: "Abstract.",
+        license: "MIT",
+        links: new Dictionary<string, string>
+        {
+            ["forums"] = "https://forums.example/thread/1",
+            ["repository"] = "https://example.com/repo",
+        },
+        gameMin: "2026.7.4.2131",
+        tags: new[] { "parts", "tools" },
+        description: "A longer CommonMark description.",
+        status: ModStatus.Deprecated,
+        supersededBy: "successor-mod",
+        releases: new ReleaseSource(
+            new[] { new ReleaseHost("github", "owner/repo"), new ReleaseHost("spacedock", "4253") },
+            "github"),
+        gameMax: "2026.8.3.5117",
+        os: new[] { "windows", "linux" },
+        loader: new LoaderRequirement("StarMap", ModVersion.Parse("0.4.5"), ModVersion.Parse("0.5.0")),
+        dependencies: new[]
+        {
+            new ModDependency("cool-lib", ModDependencyKind.Required, ModVersion.Parse("1.0.0"), ModVersion.Parse("2.0.0")),
+            new ModDependency("old-lib", ModDependencyKind.Conflict, ModVersion.Parse("3.0.0")),
+            ModDependency.OfAlternatives(ModDependencyKind.Recommends, new[]
+            {
+                new ModDependencyAlternative("audio-a", ModVersion.Parse("2.0.0")),
+                new ModDependencyAlternative("audio-b"),
+            }),
+        },
+        installRootOverride: "UnusualRoot");
+
+    public static DownloadInfo SampleDownload() =>
+        new("https://example.com/mod.zip", new string('A', 64), 1024, "application/zip", new[] { "https://mirror.example/mod.zip" });
+
+    public static ModVersionMetadata MinimalRelease(string modId = "test-mod") => new(
+        specVersion: 1,
+        modId: modId,
+        version: ModVersion.Parse("1.0.0"),
+        releaseStatus: ReleaseStatus.Stable,
+        releaseDate: SampleTimestamp(),
+        gameMin: "2026.7",
+        gameMinRevision: 2131,
+        // Lowercase digest on purpose, so the uppercase normalization is
+        // exercised by the round trip.
+        download: new DownloadInfo("https://example.com/mod.zip", new string('b', 64), 512, "application/zip"),
+        installSizeBytes: 2048,
+        dependencies: Array.Empty<ModDependency>());
+
+    public static ModVersionMetadata FullRelease(string modId = "test-mod") => new(
+        specVersion: 1,
+        modId: modId,
+        version: ModVersion.Parse("1.2.0-beta.1"),
+        releaseStatus: ReleaseStatus.Testing,
+        releaseDate: SampleTimestamp(),
+        gameMin: "2026.7.4.2131",
+        gameMinRevision: 2131,
+        download: SampleDownload(),
+        installSizeBytes: 4096,
+        dependencies: new[]
+        {
+            new ModDependency("cool-lib", ModDependencyKind.Required, ModVersion.Parse("1.0.0"), source: MetadataSource.Authored),
+            new ModDependency("kitten-ext", ModDependencyKind.Optional, source: MetadataSource.Derived),
+        },
+        gameMax: "2026.8.3.5117",
+        gameMaxRevision: 5117,
+        os: new[] { "windows" },
+        install: new InstallInfo(modId, derived: true),
+        loader: new LoaderRequirement("StarMap", ModVersion.Parse("0.4.5"), source: MetadataSource.Authored),
+        changelog: "https://example.com/changelog",
+        listing: new ListingSnapshot(
+            "Test Mod",
+            new[] { "Author" },
+            "Abstract at stamp time.",
+            "MIT",
+            new[] { "parts" },
+            SampleLinks(),
+            "Description at stamp time."),
+        yanked: true,
+        yankedReason: "Broken above revision 5117.");
+}

--- a/tests/Borea.Storage.Tests/Mods/ModDependencyMapperTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/ModDependencyMapperTests.cs
@@ -1,0 +1,111 @@
+﻿using Borea.Core.Dependencies;
+using Borea.Core.Mods;
+using Borea.Storage.Mods;
+
+namespace Borea.Storage.Tests.Mods;
+
+public sealed class ModDependencyMapperTests
+{
+    [Fact]
+    public void RoundTrip_SingleIdEntry_PreservesEveryField()
+    {
+        var original = new ModDependency("cool-lib", ModDependencyKind.Conflict, ModVersion.Parse("1.0.0"), ModVersion.Parse("2.0.0"), MetadataSource.Derived);
+
+        var reloaded = ModDependencyMapper.FromDto(ModDependencyMapper.ToDto(original));
+
+        Assert.Equal(original.ModId, reloaded.ModId);
+        Assert.Equal(ModDependencyKind.Conflict, reloaded.Kind);
+        Assert.Equal(original.MinVersion, reloaded.MinVersion);
+        Assert.Equal(original.MaxVersion, reloaded.MaxVersion);
+        Assert.Equal(MetadataSource.Derived, reloaded.Source);
+        Assert.False(reloaded.IsAnyOf);
+    }
+
+    [Fact]
+    public void RoundTrip_AnyOfEntry_PreservesAlternatives()
+    {
+        var original = ModDependency.OfAlternatives(ModDependencyKind.Required, new[]
+        {
+            new ModDependencyAlternative("lib-a", ModVersion.Parse("2.0.0"), ModVersion.Parse("3.0.0")),
+            new ModDependencyAlternative("lib-b"),
+        });
+
+        var reloaded = ModDependencyMapper.FromDto(ModDependencyMapper.ToDto(original));
+
+        Assert.True(reloaded.IsAnyOf);
+        Assert.Null(reloaded.ModId);
+        Assert.Equal(2, reloaded.AnyOf!.Count);
+        Assert.Equal("lib-a", reloaded.AnyOf[0].ModId);
+        Assert.Equal(ModVersion.Parse("3.0.0"), reloaded.AnyOf[0].MaxVersion);
+        Assert.Null(reloaded.AnyOf[1].MinVersion);
+    }
+
+    [Fact]
+    public void FromDto_UnknownKind_ParsesToUnknown()
+    {
+        var dto = new ModDependencyDto { ModId = "cool-lib", Kind = "breaks" };
+
+        Assert.Equal(ModDependencyKind.Unknown, ModDependencyMapper.FromDto(dto).Kind);
+    }
+
+    [Fact]
+    public void FromDto_UnknownSource_ParsesToUnknown()
+    {
+        var dto = new ModDependencyDto { ModId = "cool-lib", Kind = "required", Source = "handwritten" };
+
+        Assert.Equal(MetadataSource.Unknown, ModDependencyMapper.FromDto(dto).Source);
+    }
+
+    [Fact]
+    public void FromDto_NoModIdAndNoAnyOf_ThrowsFormatException()
+    {
+        var dto = new ModDependencyDto { Kind = "required" };
+
+        Assert.Throws<FormatException>(() => ModDependencyMapper.FromDto(dto));
+    }
+
+    [Fact]
+    public void FromDto_BothModIdAndAnyOf_ThrowsFormatException()
+    {
+        var dto = new ModDependencyDto
+        {
+            ModId = "cool-lib",
+            Kind = "required",
+            AnyOf = new List<ModDependencyAlternativeDto> { new() { ModId = "lib-a" } },
+        };
+
+        Assert.Throws<FormatException>(() => ModDependencyMapper.FromDto(dto));
+    }
+
+    [Fact]
+    public void FromDto_EmptyAnyOfList_ThrowsFormatException()
+    {
+        var dto = new ModDependencyDto { Kind = "required", AnyOf = new List<ModDependencyAlternativeDto>() };
+
+        Assert.Throws<FormatException>(() => ModDependencyMapper.FromDto(dto));
+    }
+
+    [Fact]
+    public void FromDto_AnyOfWithUnknownKind_ThrowsFormatExceptionInsteadOfArgumentException()
+    {
+        var dto = new ModDependencyDto
+        {
+            Kind = "breaks",
+            AnyOf = new List<ModDependencyAlternativeDto> { new() { ModId = "lib-a" } },
+        };
+
+        var exception = Assert.Throws<FormatException>(() => ModDependencyMapper.FromDto(dto));
+        Assert.Contains("breaks", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("4")]
+    [InlineData("required,optional")]
+    public void FromDto_NumericOrCompositeKindTokens_ParseToUnknown(string kind)
+    {
+        var dto = new ModDependencyDto { ModId = "cool-lib", Kind = kind };
+
+        Assert.Equal(ModDependencyKind.Unknown, ModDependencyMapper.FromDto(dto).Kind);
+    }
+}

--- a/tests/Borea.Storage.Tests/Mods/ModMetadataMapperTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/ModMetadataMapperTests.cs
@@ -1,0 +1,164 @@
+﻿using Borea.Core.Mods;
+using Borea.Storage.Mods;
+using Borea.Storage.Toml;
+
+namespace Borea.Storage.Tests.Mods;
+
+public sealed class ModMetadataMapperTests : IDisposable
+{
+    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+
+    private async Task<(ModMetadata Reloaded, ModMetadataDto ReloadedDto, string TomlText)> RoundTripAsync(ModMetadata original)
+    {
+        var path = Path.Combine(_tempRoot, "metadata.toml");
+        await TomlFileStore.WriteAsync(path, ModMetadataMapper.ToDto(original));
+        var reloadedDto = await TomlFileStore.ReadAsync<ModMetadataDto>(path);
+        return (ModMetadataMapper.FromDto(reloadedDto!), reloadedDto!, await File.ReadAllTextAsync(path));
+    }
+
+    [Fact]
+    public async Task RoundTrip_FullShape_PreservesEveryField()
+    {
+        var original = MetadataFixtures.FullMetadata();
+
+        var (reloaded, _, tomlText) = await RoundTripAsync(original);
+
+        Assert.Equal(original.SpecVersion, reloaded.SpecVersion);
+        Assert.Equal(original.ModId, reloaded.ModId);
+        Assert.Equal(original.Type, reloaded.Type);
+        Assert.Equal(original.Source, reloaded.Source);
+        Assert.Equal(original.Name, reloaded.Name);
+        Assert.Equal(original.Authors, reloaded.Authors);
+        Assert.Equal(original.Abstract, reloaded.Abstract);
+        Assert.Equal(original.Description, reloaded.Description);
+        Assert.Equal(original.License, reloaded.License);
+        Assert.Equal(original.Tags, reloaded.Tags);
+        Assert.Equal(ModStatus.Deprecated, reloaded.Status);
+        Assert.Equal(original.SupersededBy, reloaded.SupersededBy);
+        Assert.Equal(original.ForumUrl, reloaded.ForumUrl);
+        Assert.Equal(original.Links["repository"], reloaded.Links["repository"]);
+        Assert.Equal(original.GameMin, reloaded.GameMin);
+        Assert.Equal(original.GameMax, reloaded.GameMax);
+        Assert.Equal(original.Os, reloaded.Os);
+        Assert.Equal(original.InstallRootOverride, reloaded.InstallRootOverride);
+
+        Assert.NotNull(reloaded.Releases);
+        Assert.Equal("github", reloaded.Releases!.Authority);
+        Assert.Equal(2, reloaded.Releases.Hosts.Count);
+        Assert.Equal("owner/repo", reloaded.Releases.AuthorityHost.Reference);
+
+        Assert.NotNull(reloaded.Loader);
+        Assert.Equal(original.Loader!.LoaderId, reloaded.Loader!.LoaderId);
+        Assert.Equal(original.Loader.MinVersion, reloaded.Loader.MinVersion);
+        Assert.Equal(original.Loader.MaxVersion, reloaded.Loader.MaxVersion);
+
+        Assert.Equal(3, reloaded.Dependencies.Count);
+        Assert.Equal(original.Dependencies[0].MinVersion, reloaded.Dependencies[0].MinVersion);
+        Assert.Equal(original.Dependencies[1].Kind, reloaded.Dependencies[1].Kind);
+        Assert.True(reloaded.Dependencies[2].IsAnyOf);
+        Assert.Equal(2, reloaded.Dependencies[2].AnyOf!.Count);
+        Assert.Null(reloaded.Dependencies[2].AnyOf![1].MinVersion);
+
+        // The optional keys are really in the file when set, proving the
+        // absence assertions in the minimal test can fail.
+        Assert.Contains("Description", tomlText);
+        Assert.Contains("SupersededBy", tomlText);
+        Assert.Contains("GameMax", tomlText);
+        Assert.Contains("Os = ", tomlText);
+        Assert.Contains("InstallRootOverride", tomlText);
+
+        // The enum vocabulary on disk stays the format's lowercase spelling.
+        Assert.Contains("Status = \"deprecated\"", tomlText);
+        Assert.Contains("Kind = \"conflict\"", tomlText);
+        Assert.Contains("Kind = \"recommends\"", tomlText);
+        Assert.Contains("Type = \"mod\"", tomlText);
+    }
+
+    [Fact]
+    public async Task RoundTrip_MinimalShape_AbsentOptionalsStayAbsent()
+    {
+        var original = MetadataFixtures.MinimalMetadata();
+
+        var (reloaded, reloadedDto, tomlText) = await RoundTripAsync(original);
+
+        Assert.Null(reloadedDto.Description);
+        Assert.Null(reloadedDto.SupersededBy);
+        Assert.Null(reloadedDto.Releases);
+        Assert.Null(reloadedDto.GameMax);
+        Assert.Null(reloadedDto.Os);
+        Assert.Null(reloadedDto.Loader);
+        Assert.Null(reloadedDto.InstallRootOverride);
+
+        Assert.Null(reloaded.Description);
+        Assert.Null(reloaded.GameMax);
+        Assert.Null(reloaded.Os);
+        Assert.Empty(reloaded.Dependencies);
+        Assert.Empty(reloaded.Tags);
+        Assert.Equal(ModStatus.Active, reloaded.Status);
+
+        Assert.DoesNotContain("Description", tomlText);
+        Assert.DoesNotContain("SupersededBy", tomlText);
+        Assert.DoesNotContain("GameMax", tomlText);
+        Assert.DoesNotContain("Os = ", tomlText);
+        Assert.DoesNotContain("InstallRootOverride", tomlText);
+    }
+
+    [Fact]
+    public async Task RoundTrip_EmptyOsList_StaysEmptyInsteadOfAbsent()
+    {
+        var original = new ModMetadata(
+            specVersion: 1,
+            modId: "test-mod",
+            source: "TestSource",
+            name: "Test Mod",
+            authors: new[] { "Author" },
+            abstractText: "Abstract.",
+            license: "MIT",
+            links: MetadataFixtures.SampleLinks(),
+            gameMin: "2026.7",
+            os: Array.Empty<string>());
+
+        var (reloaded, _, _) = await RoundTripAsync(original);
+
+        Assert.NotNull(reloaded.Os);
+        Assert.Empty(reloaded.Os!);
+    }
+
+    [Fact]
+    public void FromDto_AbsentStatus_IsActive()
+    {
+        var dto = ModMetadataMapper.ToDto(MetadataFixtures.MinimalMetadata());
+        dto.Status = null;
+
+        Assert.Equal(ModStatus.Active, ModMetadataMapper.FromDto(dto).Status);
+    }
+
+    [Fact]
+    public void FromDto_UnknownStatusAndType_ParseToUnknown()
+    {
+        var dto = ModMetadataMapper.ToDto(MetadataFixtures.MinimalMetadata());
+        dto.Status = "frozen";
+        dto.Type = "vehicle";
+
+        var reloaded = ModMetadataMapper.FromDto(dto);
+
+        Assert.Equal(ModStatus.Unknown, reloaded.Status);
+        Assert.Equal(ContentType.Unknown, reloaded.Type);
+    }
+
+    [Fact]
+    public void FromDto_MissingSpecVersion_NamesThePreModelShape()
+    {
+        var dto = ModMetadataMapper.ToDto(MetadataFixtures.MinimalMetadata());
+        dto.SpecVersion = 0;
+
+        var exception = Assert.Throws<FormatException>(() => ModMetadataMapper.FromDto(dto));
+        Assert.Contains("spec version", exception.Message);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+}

--- a/tests/Borea.Storage.Tests/Mods/ModVersionMetadataMapperTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/ModVersionMetadataMapperTests.cs
@@ -1,0 +1,191 @@
+﻿using Borea.Core.Dependencies;
+using Borea.Core.Mods;
+using Borea.Storage.Mods;
+using Borea.Storage.Toml;
+
+namespace Borea.Storage.Tests.Mods;
+
+public sealed class ModVersionMetadataMapperTests : IDisposable
+{
+    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+
+    private async Task<(ModVersionMetadata Reloaded, ModVersionMetadataDto ReloadedDto, string TomlText)> RoundTripAsync(ModVersionMetadata original)
+    {
+        var path = Path.Combine(_tempRoot, "release.toml");
+        await TomlFileStore.WriteAsync(path, ModVersionMetadataMapper.ToDto(original));
+        var reloadedDto = await TomlFileStore.ReadAsync<ModVersionMetadataDto>(path);
+        return (ModVersionMetadataMapper.FromDto(reloadedDto!), reloadedDto!, await File.ReadAllTextAsync(path));
+    }
+
+    [Fact]
+    public async Task RoundTrip_FullShape_PreservesEveryField()
+    {
+        var original = MetadataFixtures.FullRelease();
+
+        var (reloaded, _, tomlText) = await RoundTripAsync(original);
+
+        Assert.Equal(original.SpecVersion, reloaded.SpecVersion);
+        Assert.Equal(original.ModId, reloaded.ModId);
+        Assert.Equal(original.Type, reloaded.Type);
+        Assert.Equal(original.Version, reloaded.Version);
+        Assert.Equal(original.VersionScheme, reloaded.VersionScheme);
+        Assert.Equal(ReleaseStatus.Testing, reloaded.ReleaseStatus);
+        Assert.Equal(original.ReleaseDate, reloaded.ReleaseDate);
+        Assert.Equal(original.GameMin, reloaded.GameMin);
+        Assert.Equal(original.GameMinRevision, reloaded.GameMinRevision);
+        Assert.Equal(original.GameMax, reloaded.GameMax);
+        Assert.Equal(original.GameMaxRevision, reloaded.GameMaxRevision);
+        Assert.Equal(original.Os, reloaded.Os);
+        Assert.Equal(original.InstallSizeBytes, reloaded.InstallSizeBytes);
+        Assert.Equal(original.Changelog, reloaded.Changelog);
+        Assert.True(reloaded.Yanked);
+        Assert.Equal(original.YankedReason, reloaded.YankedReason);
+
+        Assert.Equal(original.Download.Url, reloaded.Download.Url);
+        Assert.Equal(original.Download.Sha256, reloaded.Download.Sha256);
+        Assert.Equal(original.Download.SizeBytes, reloaded.Download.SizeBytes);
+        Assert.Equal(original.Download.ContentType, reloaded.Download.ContentType);
+        Assert.Equal(original.Download.Mirrors, reloaded.Download.Mirrors);
+
+        Assert.NotNull(reloaded.Install);
+        Assert.Equal(original.Install!.Root, reloaded.Install!.Root);
+        Assert.True(reloaded.Install.Derived);
+
+        Assert.NotNull(reloaded.Loader);
+        Assert.Equal(MetadataSource.Authored, reloaded.Loader!.Source);
+
+        Assert.Equal(2, reloaded.Dependencies.Count);
+        Assert.Equal(MetadataSource.Authored, reloaded.Dependencies[0].Source);
+        Assert.Equal(MetadataSource.Derived, reloaded.Dependencies[1].Source);
+
+        Assert.NotNull(reloaded.Listing);
+        Assert.Equal(original.Listing!.Name, reloaded.Listing!.Name);
+        Assert.Equal(original.Listing.Description, reloaded.Listing.Description);
+        Assert.Equal(original.Listing.Links["forums"], reloaded.Listing.Links["forums"]);
+
+        // The optional keys are really in the file when set, proving the
+        // absence assertions in the minimal test can fail.
+        Assert.Contains("GameMax", tomlText);
+        Assert.Contains("Os = ", tomlText);
+        Assert.Contains("Changelog", tomlText);
+        Assert.Contains("Listing", tomlText);
+        Assert.Contains("YankedReason", tomlText);
+
+        // The enum vocabulary on disk stays the format's lowercase spelling.
+        Assert.Contains("ReleaseStatus = \"testing\"", tomlText);
+        Assert.Contains("Kind = \"required\"", tomlText);
+        Assert.Contains("Source = \"derived\"", tomlText);
+    }
+
+    [Fact]
+    public async Task RoundTrip_MinimalShape_AbsentOptionalsStayAbsent()
+    {
+        var original = MetadataFixtures.MinimalRelease();
+
+        var (reloaded, reloadedDto, tomlText) = await RoundTripAsync(original);
+
+        Assert.Null(reloadedDto.GameMax);
+        Assert.Null(reloadedDto.GameMaxRevision);
+        Assert.Null(reloadedDto.Os);
+        Assert.Null(reloadedDto.Install);
+        Assert.Null(reloadedDto.Loader);
+        Assert.Null(reloadedDto.Changelog);
+        Assert.Null(reloadedDto.Listing);
+        Assert.Null(reloadedDto.YankedReason);
+
+        Assert.Null(reloaded.GameMax);
+        Assert.Null(reloaded.GameMaxRevision);
+        Assert.Null(reloaded.Os);
+        Assert.Null(reloaded.Install);
+        Assert.Null(reloaded.Loader);
+        Assert.False(reloaded.Yanked);
+        Assert.Empty(reloaded.Dependencies);
+        Assert.Empty(reloaded.Download.Mirrors);
+
+        Assert.DoesNotContain("GameMax", tomlText);
+        Assert.DoesNotContain("Os = ", tomlText);
+        Assert.DoesNotContain("Changelog", tomlText);
+        Assert.DoesNotContain("Listing", tomlText);
+        Assert.DoesNotContain("YankedReason", tomlText);
+    }
+
+    [Fact]
+    public async Task RoundTrip_TimestampKeepsSubSecondPrecision()
+    {
+        var original = MetadataFixtures.MinimalRelease();
+
+        var (reloaded, _, _) = await RoundTripAsync(original);
+
+        Assert.Equal(MetadataFixtures.SampleTimestamp(), reloaded.ReleaseDate);
+        Assert.Equal(MetadataFixtures.SampleTimestamp().Ticks, reloaded.ReleaseDate.Ticks);
+    }
+
+    [Fact]
+    public async Task RoundTrip_LowercaseDigest_ComesBackNormalized()
+    {
+        var original = MetadataFixtures.MinimalRelease();
+
+        var (reloaded, _, _) = await RoundTripAsync(original);
+
+        Assert.Equal(new string('B', 64), reloaded.Download.Sha256);
+        Assert.True(reloaded.Download.HashMatches(new string('b', 64)));
+    }
+
+    [Fact]
+    public async Task RoundTrip_ModLoaderRelease_KeepsItsType()
+    {
+        var original = new ModVersionMetadata(
+            specVersion: 1,
+            modId: "StarMap",
+            version: ModVersion.Parse("0.4.6"),
+            releaseStatus: ReleaseStatus.Stable,
+            releaseDate: MetadataFixtures.SampleTimestamp(),
+            gameMin: "2026.7",
+            gameMinRevision: 2131,
+            download: MetadataFixtures.SampleDownload(),
+            installSizeBytes: 1024,
+            dependencies: Array.Empty<ModDependency>(),
+            type: ContentType.ModLoader);
+
+        var (reloaded, _, tomlText) = await RoundTripAsync(original);
+
+        Assert.Equal(ContentType.ModLoader, reloaded.Type);
+        Assert.Null(reloaded.Install);
+        Assert.Contains("Type = \"mod-loader\"", tomlText);
+    }
+
+    [Fact]
+    public void FromDto_AbsentVersionScheme_DefaultsToSemver()
+    {
+        var dto = ModVersionMetadataMapper.ToDto(MetadataFixtures.MinimalRelease());
+        dto.VersionScheme = "semver";
+
+        Assert.Equal("semver", ModVersionMetadataMapper.FromDto(dto).VersionScheme);
+        Assert.Equal("semver", new ModVersionMetadataDto().VersionScheme);
+    }
+
+    [Fact]
+    public void FromDto_UnknownReleaseStatus_ParsesToUnknown()
+    {
+        var dto = ModVersionMetadataMapper.ToDto(MetadataFixtures.MinimalRelease());
+        dto.ReleaseStatus = "nightly";
+
+        Assert.Equal(ReleaseStatus.Unknown, ModVersionMetadataMapper.FromDto(dto).ReleaseStatus);
+    }
+
+    [Fact]
+    public void FromDto_MissingSpecVersion_NamesThePreModelShape()
+    {
+        var dto = ModVersionMetadataMapper.ToDto(MetadataFixtures.MinimalRelease());
+        dto.SpecVersion = 0;
+
+        var exception = Assert.Throws<FormatException>(() => ModVersionMetadataMapper.FromDto(dto));
+        Assert.Contains("spec version", exception.Message);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+}

--- a/tests/Borea.Storage.Tests/State/FileModStateRepositoryTests.cs
+++ b/tests/Borea.Storage.Tests/State/FileModStateRepositoryTests.cs
@@ -38,6 +38,13 @@ public sealed class FileModStateRepositoryTests : IDisposable
 
         var active = await _repository.GetAllActiveModIdsAsync(_instanceId);
         Assert.Equal(new[] { "Core" }, active);
+
+        // Ids compare case-insensitively, matching the folder-name identity.
+        Assert.True(await _repository.IsActiveAsync(_instanceId, "core"));
+
+        await _repository.SetInactiveAsync(_instanceId, "CORE");
+        Assert.False(await _repository.IsActiveAsync(_instanceId, "Core"));
+        Assert.Empty(await _repository.GetAllActiveModIdsAsync(_instanceId));
     }
 
     [Fact]


### PR DESCRIPTION
Implements #26 on top of #32: the storage layer for the new metadata model, one DTO plus one mapper per type, following the `TomlFileStore` pattern.

**What changes**

- DTOs and mappers for `ModMetadata` and `ModVersionMetadata` with their support types (dependencies including `any_of`, loader, release source, download, install, listing snapshot). Absent optional fields are nullable and round-trip as absent, guarded by tests on both the reloaded objects and the serialized text.
- `DateTimeOffset` is persisted as an ISO 8601 round-trip string through a converter in `TomlFileStore`, because the plain TOML datetime form drops fractional seconds; this also fixes the existing `InstalledAt`/`CreatedAt` precision loss.
- The enum vocabulary is written in the format's lowercase spelling through one explicit mapper with Unknown fallbacks for unrecognized values, an absent `status` reads as active and an absent `version_scheme` as semver, matching [RFC 0031](https://github.com/KSAModding/content-manager-design/blob/main/rfcs/0031-content-metadata-format.md)'s defaults.
- Stored ids compare case-insensitively everywhere (manifest state, both favorites stores, and the uninstaller, which now resolves the mod folder by comparison for case-sensitive filesystems).
- `GetAllAsync` skips an instance whose file cannot be read instead of failing the whole list, and a file without a spec version gets a precise "predates the metadata model" error.

**Migration**: nothing has shipped. The manifest, favorites, and active-instance files are unchanged; `instances.toml` did change shape, so a pre-branch file on a dev machine fails its direct load with the error above (and is skipped in the list) and should simply be deleted.

These DTOs mirror Borea's local persistence, not the RFC wire format; the index reader in #27 gets its own.
Borea.Storage builds clean and its suite passes with 104 tests. SemVer build metadata in `ModVersion` stays #30.
