### PR TITLE
Network: map SpaceDock data onto the new metadata types

### DIFF
--- a/src/Borea.Core/Mods/DownloadInfo.cs
+++ b/src/Borea.Core/Mods/DownloadInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 
 namespace Borea.Core.Mods;
 
@@ -13,14 +13,15 @@ public sealed class DownloadInfo
     public string Url { get; }
 
     /// <summary>
-    /// Hex SHA-256 of the archive, normalized to uppercase. Verifies the download and keys caches.
+    /// Hex SHA-256 of the archive, normalized to uppercase. Null when the
+    /// source provides no checksum.
     /// </summary>
-    public string Sha256 { get; }
+    public string? Sha256 { get; }
 
     /// <summary>
-    /// Archive size in bytes.
+    /// Archive size in bytes. Null when the source does not expose it.
     /// </summary>
-    public long SizeBytes { get; }
+    public long? SizeBytes { get; }
 
     /// <summary>
     /// The archive format, such as "application/zip".
@@ -32,29 +33,31 @@ public sealed class DownloadInfo
     /// </summary>
     public IReadOnlyList<string> Mirrors { get; }
 
-    public DownloadInfo(string url, string sha256, long sizeBytes, string contentType, IReadOnlyList<string>? mirrors = null)
+    public DownloadInfo(string url, string? sha256, long? sizeBytes, string contentType, IReadOnlyList<string>? mirrors = null)
     {
         if (string.IsNullOrWhiteSpace(url))
             throw new ArgumentException("Download url cannot be empty.", nameof(url));
 
-        if (sha256 is null || sha256.Length != 64 || !sha256.All(Uri.IsHexDigit))
+        if (sha256 is not null && (sha256.Length != 64 || !sha256.All(Uri.IsHexDigit)))
             throw new ArgumentException("Sha256 must be 64 hex characters.", nameof(sha256));
 
-        if (sizeBytes < 0)
+        if (sizeBytes is < 0)
             throw new ArgumentOutOfRangeException(nameof(sizeBytes), "Size cannot be negative.");
 
         if (string.IsNullOrWhiteSpace(contentType))
             throw new ArgumentException("Content type cannot be empty.", nameof(contentType));
 
         Url = url;
-        Sha256 = sha256.ToUpperInvariant();
+        Sha256 = sha256?.ToUpperInvariant();
         SizeBytes = sizeBytes;
         ContentType = contentType;
         Mirrors = mirrors is null ? Array.Empty<string>() : new ReadOnlyCollection<string>(mirrors.ToArray());
     }
 
     /// <summary>
-    /// Whether the given hex digest names the same bytes, compared case-insensitively.
+    /// Whether the given hex digest names the same bytes, compared
+    /// case-insensitively. False when no checksum is known.
     /// </summary>
-    public bool HashMatches(string hexDigest) => string.Equals(Sha256, hexDigest, StringComparison.OrdinalIgnoreCase);
+    public bool HashMatches(string hexDigest) =>
+        Sha256 is not null && string.Equals(Sha256, hexDigest, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Borea.Core/Mods/IModRepository.cs
+++ b/src/Borea.Core/Mods/IModRepository.cs
@@ -1,38 +1,39 @@
-﻿namespace Borea.Core.Mods;
+namespace Borea.Core.Mods;
 
 /// <summary>
-/// Provides read access to mods available from Borea's mod source (e.g. the
-/// KSA mod registry). Only reflects currently-available, non-removed mods
-/// and versions — installed mods retain their own metadata snapshot via
-/// <see cref="InstalledMod.Metadata"/> independent of this interface.
+/// Read access to the content available from one of Borea's sources. Listing
+/// methods return the live <see cref="ModMetadata"/>; release methods return
+/// the stamped <see cref="ModVersionMetadata"/> of one concrete version.
+/// Installed mods keep their own snapshot via <see cref="InstalledMod.Metadata"/>.
 /// </summary>
 public interface IModRepository
 {
     /// <summary>
-    /// Retrieves all mods currently available from the source.
+    /// Retrieves the listings of all mods currently available from the source.
     /// </summary>
     Task<IReadOnlyList<ModMetadata>> GetAvailableModsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Retrieves metadata for a specific mod at its latest available version,
-    /// or null if the mod is not currently available (removed/unlisted/unknown).
+    /// Retrieves the newest available release of a mod, skipping yanked
+    /// releases, or null if the mod has no usable release.
     /// </summary>
-    Task<ModMetadata?> GetLatestAsync(string modId, CancellationToken cancellationToken = default);
+    Task<ModVersionMetadata?> GetLatestReleaseAsync(string modId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Retrieves metadata for a specific mod at a specific version, or null
-    /// if that mod/version is not currently available.
+    /// Retrieves one specific release of a mod, or null if that version is not
+    /// available. A yanked release is returned as-is, because an already
+    /// installed copy may still need its data.
     /// </summary>
-    Task<ModMetadata?> GetVersionAsync(string modId, ModVersion version, CancellationToken cancellationToken = default);
+    Task<ModVersionMetadata?> GetReleaseAsync(string modId, ModVersion version, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Retrieves all versions currently available for a given mod, ordered
+    /// Retrieves all versions with a usable release for a given mod, ordered
     /// newest-first. Empty if the mod is not currently available.
     /// </summary>
     Task<IReadOnlyList<ModVersion>> GetAvailableVersionsAsync(string modId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Searches available mods by name/tag/description text.
+    /// Searches available mod listings by name/tag/description text.
     /// </summary>
     Task<IReadOnlyList<ModMetadata>> SearchAsync(string query, CancellationToken cancellationToken = default);
 }

--- a/src/Borea.Core/Mods/InstallInfo.cs
+++ b/src/Borea.Core/Mods/InstallInfo.cs
@@ -20,7 +20,9 @@ public sealed class InstallInfo
         if (string.IsNullOrWhiteSpace(root))
             throw new ArgumentException("Install root cannot be empty.", nameof(root));
 
-        if (Path.IsPathRooted(root) || root.Split('/', '\\').Any(s => s == ".."))
+        // Platform-independent on purpose: the archive is built and consumed
+        // on different systems, so Windows-rooted forms are rejected everywhere.
+        if (root.StartsWith('/') || root.StartsWith('\\') || root.Contains(':') || root.Split('/', '\\').Any(s => s == ".."))
             throw new ArgumentException("Install root must be a relative path inside the archive.", nameof(root));
 
         Root = root;

--- a/src/Borea.Core/Mods/ModVersionMetadata.cs
+++ b/src/Borea.Core/Mods/ModVersionMetadata.cs
@@ -76,9 +76,14 @@ public sealed class ModVersionMetadata
     public DownloadInfo Download { get; }
 
     /// <summary>
-    /// Unpacked size in bytes. Download and install size differ on purpose.
+    /// Which source this release came from. Borea-internal, not a format field.
     /// </summary>
-    public long InstallSizeBytes { get; }
+    public string? Source { get; }
+
+    /// <summary>
+    /// Unpacked size in bytes. Null when the source does not expose it.
+    /// </summary>
+    public long? InstallSizeBytes { get; }
 
     /// <summary>
     /// The install directive. Null for content that installs by its own mechanism.
@@ -124,7 +129,7 @@ public sealed class ModVersionMetadata
         string gameMin,
         int gameMinRevision,
         DownloadInfo download,
-        long installSizeBytes,
+        long? installSizeBytes,
         IReadOnlyList<ModDependency> dependencies,
         ContentType type = ContentType.Mod,
         string versionScheme = "semver",
@@ -136,7 +141,8 @@ public sealed class ModVersionMetadata
         string? changelog = null,
         ListingSnapshot? listing = null,
         bool yanked = false,
-        string? yankedReason = null)
+        string? yankedReason = null,
+        string? source = null)
     {
         if (specVersion < 1)
             throw new ArgumentOutOfRangeException(nameof(specVersion), "Spec version must be a positive integer.");
@@ -182,7 +188,7 @@ public sealed class ModVersionMetadata
         if (dependencies is null)
             throw new ArgumentNullException(nameof(dependencies));
 
-        if (installSizeBytes < 0)
+        if (installSizeBytes is < 0)
             throw new ArgumentOutOfRangeException(nameof(installSizeBytes), "Install size cannot be negative.");
 
         SpecVersion = specVersion;
@@ -206,5 +212,6 @@ public sealed class ModVersionMetadata
         Listing = listing;
         Yanked = yanked;
         YankedReason = yankedReason;
+        Source = source;
     }
 }

--- a/src/Borea.Network/Sources/CompositeModRepository.cs
+++ b/src/Borea.Network/Sources/CompositeModRepository.cs
@@ -1,10 +1,10 @@
-﻿using Borea.Core.Mods;
+using Borea.Core.Mods;
 
 namespace Borea.Network.Sources;
 
 /// <summary>
-/// Queries every registered source and merges results, tagging each
-/// ModMetadata with its originating source via ModMetadata.Source. Which
+/// Queries every registered source and merges results, tagging each listing
+/// and release with its originating source via the Source property. Which
 /// sources are active is entirely determined by what's registered at
 /// construction.
 /// </summary>
@@ -28,24 +28,24 @@ public sealed class CompositeModRepository : IModRepository
         return results;
     }
 
-    public async Task<ModMetadata?> GetLatestAsync(string modId, CancellationToken cancellationToken = default)
+    public async Task<ModVersionMetadata?> GetLatestReleaseAsync(string modId, CancellationToken cancellationToken = default)
     {
         foreach (var (source, repository) in _sources)
         {
-            var result = await repository.GetLatestAsync(modId, cancellationToken).ConfigureAwait(false);
-            if (result is not null)
-                return Tag(result, source);
+            var release = await repository.GetLatestReleaseAsync(modId, cancellationToken).ConfigureAwait(false);
+            if (release is not null)
+                return Tag(release, source);
         }
         return null;
     }
 
-    public async Task<ModMetadata?> GetVersionAsync(string modId, ModVersion version, CancellationToken cancellationToken = default)
+    public async Task<ModVersionMetadata?> GetReleaseAsync(string modId, ModVersion version, CancellationToken cancellationToken = default)
     {
         foreach (var (source, repository) in _sources)
         {
-            var result = await repository.GetVersionAsync(modId, version, cancellationToken).ConfigureAwait(false);
-            if (result is not null)
-                return Tag(result, source);
+            var release = await repository.GetReleaseAsync(modId, version, cancellationToken).ConfigureAwait(false);
+            if (release is not null)
+                return Tag(release, source);
         }
         return null;
     }
@@ -73,7 +73,48 @@ public sealed class CompositeModRepository : IModRepository
     }
 
     private static ModMetadata Tag(ModMetadata original, string source) => new(
-        original.ModId, source, original.Name, original.Author, original.Version, original.BuiltForGameVersion,
-        original.Description, original.ReleasedAt, original.FileSizeBytes, original.Dependencies,
-        original.Tags, original.HomepageUrl, original.ChangeLog);
+        original.SpecVersion,
+        original.ModId,
+        source,
+        original.Name,
+        original.Authors,
+        original.Abstract,
+        original.License,
+        original.Links,
+        original.GameMin,
+        original.Type,
+        original.Tags,
+        original.Description,
+        original.Status,
+        original.SupersededBy,
+        original.Releases,
+        original.GameMax,
+        original.Os,
+        original.Loader,
+        original.Dependencies,
+        original.InstallRootOverride);
+
+    private static ModVersionMetadata Tag(ModVersionMetadata original, string source) => new(
+        original.SpecVersion,
+        original.ModId,
+        original.Version,
+        original.ReleaseStatus,
+        original.ReleaseDate,
+        original.GameMin,
+        original.GameMinRevision,
+        original.Download,
+        original.InstallSizeBytes,
+        original.Dependencies,
+        original.Type,
+        original.VersionScheme,
+        original.GameMax,
+        original.GameMaxRevision,
+        original.Os,
+        original.Install,
+        original.Loader,
+        original.Changelog,
+        original.Listing,
+        original.Yanked,
+        original.YankedReason,
+        source);
 }

--- a/src/Borea.Network/SpaceDock/SpaceDockModRepository .cs
+++ b/src/Borea.Network/SpaceDock/SpaceDockModRepository .cs
@@ -1,21 +1,39 @@
-﻿using System.Globalization;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Borea.Core.Dependencies;
 using Borea.Core.Game;
 using Borea.Core.Mods;
 
 namespace Borea.Network.SpaceDock;
 
 /// <summary>
-/// IModRepository implementation against SpaceDock's public API.
-/// ModId returned here is a placeholder: SpaceDock's own numeric mod ID,
-/// stringified.
+/// IModRepository against SpaceDock's public API, mapping its data onto the
+/// RFC 0031 metadata types. SpaceDock cannot provide most authored facts, so
+/// the mapping fills in:
+///
+/// - The id is a placeholder, SpaceDock's numeric mod id stringified; the
+///   true id is only knowable after a download (SpaceDockResolver).
+/// - An empty dependency list and a null loader mean unknown, not none.
+/// - The forums link is the website when it points at the KSA forums,
+///   otherwise the SpaceDock page stands in (the model requires one).
+/// - game_min is the oldest game version any release claims (RFC 0017).
+/// - Checksum and sizes are null; the API does not expose them.
+///
+/// A KSA listing whose data does not parse still surfaces with placeholder
+/// fields; only its unusable releases are skipped by the release accessors.
 /// </summary>
 public sealed class SpaceDockModRepository : IModRepository
 {
     // SpaceDock's internal database ID for KSA.
     private const int KsaGameId = 22409;
+
+    private const string SourceName = "spacedock";
+    private const string BaseUrl = "https://spacedock.info";
+    private const string KsaForumsHost = "forums.ahwoo.com";
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -33,131 +51,209 @@ public sealed class SpaceDockModRepository : IModRepository
 
     public async Task<IReadOnlyList<ModMetadata>> GetAvailableModsAsync(CancellationToken cancellationToken = default)
     {
-        // Single page for now — SpaceDock's /api/browse is paginated (up to
-        // 500/page) and IModRepository has no paging concept. Revisit if
-        // KSA's catalog grows past one page's worth of results.
+        // Single page: /api/browse pages at 500 and IModRepository has no
+        // paging concept. Revisit if KSA's catalog outgrows one page.
         var response = await _httpClient.GetFromJsonAsync<SpaceDockBrowseResponseDto>(
             $"api/browse?game_id={KsaGameId}&count=500", JsonOptions, cancellationToken).ConfigureAwait(false);
 
-        return (response?.Result ?? new()).Select(TryMapToMetadata).Where(m => m is not null).Select(m => m!).ToList();
+        return (response?.Result ?? new()).Where(IsKsaMod).Select(MapToListing).ToList();
     }
 
-    public async Task<ModMetadata?> GetLatestAsync(string modId, CancellationToken cancellationToken = default)
+    public async Task<ModVersionMetadata?> GetLatestReleaseAsync(string modId, CancellationToken cancellationToken = default)
     {
-        if (!_resolver.TryResolveId(modId, out var spaceDockId))
+        var dto = await GetModAsync(modId, cancellationToken).ConfigureAwait(false);
+        if (dto is null)
             return null;
 
-        var dto = await _httpClient.GetFromJsonAsync<SpaceDockModDto>(
-            $"api/mod/{spaceDockId}", JsonOptions, cancellationToken).ConfigureAwait(false);
-
-        return dto is null ? null : TryMapToMetadata(dto);
+        // Newest mappable release; the author-selected default version only
+        // breaks ties between rows normalizing to the same version.
+        return MappableReleases(dto)
+            .OrderByDescending(pair => pair.Parsed)
+            .ThenByDescending(pair => pair.Row.Id == dto.DefaultVersionId)
+            .Select(pair => pair.Release)
+            .FirstOrDefault();
     }
 
-    public async Task<ModMetadata?> GetVersionAsync(string modId, ModVersion version, CancellationToken cancellationToken = default)
+    public async Task<ModVersionMetadata?> GetReleaseAsync(string modId, ModVersion version, CancellationToken cancellationToken = default)
     {
-        if (!_resolver.TryResolveId(modId, out var spaceDockId))
+        var dto = await GetModAsync(modId, cancellationToken).ConfigureAwait(false);
+        if (dto is null)
             return null;
 
-        var dto = await _httpClient.GetFromJsonAsync<SpaceDockModDto>(
-            $"api/mod/{spaceDockId}", JsonOptions, cancellationToken).ConfigureAwait(false);
-
-        if (dto is null || !IsKsaMod(dto))
-            return null;
-
-        var matchingVersion = dto.Versions.FirstOrDefault(v =>
-            SpaceDockVersionParsing.TryNormalize(v.FriendlyVersion, out var parsed) && parsed.Equals(version));
-
-        return matchingVersion is null ? null : TryMapToMetadata(dto, matchingVersion);
+        // Same mappable set as the version list, so every listed version
+        // yields a release; ties resolve like the latest accessor.
+        return MappableReleases(dto)
+            .Where(pair => pair.Parsed.Equals(version))
+            .OrderByDescending(pair => pair.Row.Id == dto.DefaultVersionId)
+            .Select(pair => pair.Release)
+            .FirstOrDefault();
     }
 
     public async Task<IReadOnlyList<ModVersion>> GetAvailableVersionsAsync(string modId, CancellationToken cancellationToken = default)
     {
-        if (!_resolver.TryResolveId(modId, out var spaceDockId))
+        var dto = await GetModAsync(modId, cancellationToken).ConfigureAwait(false);
+        if (dto is null)
             return Array.Empty<ModVersion>();
 
-        var dto = await _httpClient.GetFromJsonAsync<SpaceDockModDto>(
-            $"api/mod/{spaceDockId}", JsonOptions, cancellationToken).ConfigureAwait(false);
-
-        if (dto is null || !IsKsaMod(dto))
-            return Array.Empty<ModVersion>();
-
-        return dto.Versions
-            .Select(v => SpaceDockVersionParsing.TryNormalize(v.FriendlyVersion, out var parsed) ? (ModVersion?)parsed : null)
-            .Where(v => v.HasValue)
-            .Select(v => v!.Value)
+        // Only versions with a usable release, newest first; Distinct because
+        // different strings can normalize to one version.
+        return MappableReleases(dto)
+            .Select(pair => pair.Parsed)
+            .Distinct()
+            .OrderByDescending(v => v)
             .ToList();
     }
 
     public async Task<IReadOnlyList<ModMetadata>> SearchAsync(string query, CancellationToken cancellationToken = default)
     {
-        // Live results include game_id directly per mod (undocumented in
-        // api.md, confirmed by real response) — IsKsaMod filters on it.
+        // Live search results carry game_id per mod (undocumented in api.md,
+        // confirmed by real response); IsKsaMod filters on it.
         var results = await _httpClient.GetFromJsonAsync<List<SpaceDockModDto>>(
             $"api/search/mod?query={Uri.EscapeDataString(query)}", JsonOptions, cancellationToken).ConfigureAwait(false);
 
-        return (results ?? new())
-            .Where(IsKsaMod)
-            .Select(TryMapToMetadata)
-            .Where(m => m is not null)
-            .Select(m => m!)
-            .ToList();
+        return (results ?? new()).Where(IsKsaMod).Select(MapToListing).ToList();
+    }
+
+    private async Task<SpaceDockModDto?> GetModAsync(string modId, CancellationToken cancellationToken)
+    {
+        if (!_resolver.TryResolveId(modId, out var spaceDockId))
+            return null;
+
+        try
+        {
+            var dto = await _httpClient.GetFromJsonAsync<SpaceDockModDto>(
+                $"api/mod/{spaceDockId}", JsonOptions, cancellationToken).ConfigureAwait(false);
+
+            return dto is null || !IsKsaMod(dto) ? null : dto;
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            // A deleted or unknown id answers 404: not available, not an error.
+            return null;
+        }
     }
 
     /// <summary>
-    /// True if this listing is for KSA. Primary check is the GameId field
-    /// when present (confirmed present on search results; unconfirmed on
-    /// browse/mod-detail, so treated as optional here). GameId == 0 (unset/
-    /// missing on this endpoint) falls back to no game_id, in which case
-    /// TryMapToMetadata's GameVersion parsing acts as the fallback filter.
+    /// True if this listing is for KSA. A missing game_id passes, because
+    /// dropping a listing over an absent field is what this repository must
+    /// not do.
     /// </summary>
     private static bool IsKsaMod(SpaceDockModDto dto) => dto.GameId is null or KsaGameId;
 
-    private static ModMetadata? TryMapToMetadata(SpaceDockModDto dto)
+    private static ModMetadata MapToListing(SpaceDockModDto dto)
     {
-        if (!IsKsaMod(dto))
-            return null;
+        var modId = dto.Id.ToString(CultureInfo.InvariantCulture);
+        var pageUrl = !string.IsNullOrWhiteSpace(dto.Url) ? $"{BaseUrl}{dto.Url}" : $"{BaseUrl}/mod/{dto.Id}";
+        var website = string.IsNullOrWhiteSpace(dto.Website) ? null : dto.Website;
 
-        var defaultVersion = dto.Versions.FirstOrDefault(v => v.Id == dto.DefaultVersionId);
-        var ordered = defaultVersion is null
-            ? dto.Versions
-            : new[] { defaultVersion }.Concat(dto.Versions.Where(v => v != defaultVersion));
-
-        foreach (var candidate in ordered)
+        var links = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            var mapped = TryMapToMetadata(dto, candidate);
-            if (mapped is not null)
-                return mapped;
+            // Authors commonly put their forums thread into the website field.
+            ["forums"] = website is not null && IsKsaForumsUrl(website) ? website : pageUrl,
+            ["spacedock"] = pageUrl,
+        };
+
+        if (website is not null)
+            links.TryAdd("homepage", website);
+
+        if (!string.IsNullOrWhiteSpace(dto.SourceCode))
+            links.TryAdd("repository", dto.SourceCode);
+
+        // Oldest game version any release claims, since game_min means
+        // "oldest known to work" and only a too-high bound blocks an install.
+        // With no parseable game version the raw string stays, so
+        // compatibility evaluates to unknown.
+        string? oldestRaw = null;
+        var oldestRevision = int.MaxValue;
+        foreach (var candidate in dto.Versions)
+        {
+            if (GameVersion.TryParse(candidate.RawGameVersion, out var parsed) && parsed.Revision < oldestRevision)
+            {
+                oldestRevision = parsed.Revision;
+                oldestRaw = candidate.RawGameVersion;
+            }
         }
 
-        return null;
-    }
-
-    private static ModMetadata? TryMapToMetadata(SpaceDockModDto dto, SpaceDockVersionDto version)
-    {
-        if (!SpaceDockVersionParsing.TryNormalize(version.FriendlyVersion, out var modVersion))
-            return null;
-
-        if (!GameVersion.TryParse(version.RawGameVersion, out var gameVersion))
-            return null;
-
-        var releasedAt = version.Created ?? DateTimeOffset.UtcNow;
-        var homepageUrl = !string.IsNullOrWhiteSpace(dto.Website) ? dto.Website
-            : !string.IsNullOrWhiteSpace(dto.Url) ? $"https://spacedock.info{dto.Url}"
-            : null;
+        var defaultVersion = dto.Versions.FirstOrDefault(v => v.Id == dto.DefaultVersionId) ?? dto.Versions.FirstOrDefault();
+        var gameMin = oldestRaw
+            ?? (defaultVersion is not null && !string.IsNullOrWhiteSpace(defaultVersion.RawGameVersion)
+                ? defaultVersion.RawGameVersion
+                : "unknown");
 
         return new ModMetadata(
-            dto.Id.ToString(CultureInfo.InvariantCulture),
-            source: "spacedock",
-            name: dto.Name,
-            author: dto.Author,
-            version: modVersion,
-            builtForGameVersion: gameVersion,
-            description: dto.Description ?? dto.ShortDescription ?? string.Empty,
-            releasedAt: releasedAt,
-            fileSizeBytes: 0, // Still not exposed anywhere in the API.
-            homepageUrl: homepageUrl,
-            changeLog: version.Changelog);
+            specVersion: 1,
+            modId: modId,
+            source: SourceName,
+            name: string.IsNullOrWhiteSpace(dto.Name) ? $"SpaceDock mod {dto.Id}" : dto.Name,
+            authors: new[] { string.IsNullOrWhiteSpace(dto.Author) ? "Unknown" : dto.Author },
+            abstractText: dto.ShortDescription ?? string.Empty,
+            license: string.IsNullOrWhiteSpace(dto.License) ? "Unknown" : dto.License,
+            links: links,
+            gameMin: gameMin,
+            description: string.IsNullOrWhiteSpace(dto.Description) ? null : dto.Description,
+            releases: new ReleaseSource(new[] { new ReleaseHost("spacedock", modId) }));
     }
+
+    private static IEnumerable<(ModVersion Parsed, ModVersionMetadata Release, SpaceDockVersionDto Row)> MappableReleases(SpaceDockModDto dto)
+    {
+        foreach (var candidate in dto.Versions)
+        {
+            if (SpaceDockVersionParsing.TryNormalize(candidate.FriendlyVersion, out var parsed)
+                && TryMapRelease(dto, candidate, out var release))
+            {
+                yield return (parsed, release, candidate);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Maps one SpaceDock version onto a release. An unusable version string,
+    /// game version, release date, or download path yields no release; the
+    /// listing itself stays visible either way.
+    /// </summary>
+    private static bool TryMapRelease(SpaceDockModDto dto, SpaceDockVersionDto version, [NotNullWhen(true)] out ModVersionMetadata? release)
+    {
+        release = null;
+
+        if (!SpaceDockVersionParsing.TryNormalize(version.FriendlyVersion, out var modVersion))
+            return false;
+
+        if (!GameVersion.TryParse(version.RawGameVersion, out var gameVersion))
+            return false;
+
+        if (version.Created is not { } releaseDate)
+            return false;
+
+        if (string.IsNullOrWhiteSpace(version.DownloadPath))
+            return false;
+
+        // No checksum and no sizes: the API does not expose them.
+        var download = new DownloadInfo(
+            url: $"{BaseUrl}{version.DownloadPath}",
+            sha256: null,
+            sizeBytes: null,
+            contentType: "application/zip");
+
+        release = new ModVersionMetadata(
+            specVersion: 1,
+            modId: dto.Id.ToString(CultureInfo.InvariantCulture),
+            version: modVersion,
+            releaseStatus: modVersion.PreRelease is null ? ReleaseStatus.Stable : ReleaseStatus.Testing,
+            releaseDate: releaseDate,
+            gameMin: version.RawGameVersion,
+            gameMinRevision: gameVersion.Revision,
+            download: download,
+            installSizeBytes: null,
+            dependencies: Array.Empty<ModDependency>(),
+            changelog: string.IsNullOrWhiteSpace(version.Changelog) ? null : version.Changelog,
+            source: SourceName);
+
+        return true;
+    }
+
+    private static bool IsKsaForumsUrl(string url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var parsed)
+        && string.Equals(parsed.Host, KsaForumsHost, StringComparison.OrdinalIgnoreCase);
 }
 
 internal sealed class SpaceDockBrowseResponseDto
@@ -175,14 +271,15 @@ internal sealed class SpaceDockModDto
     public string Author { get; set; } = string.Empty;
     public string? ShortDescription { get; set; }
     public string? Description { get; set; }
+    public string? License { get; set; }
     public int DefaultVersionId { get; set; }
     public List<SpaceDockVersionDto> Versions { get; set; } = new();
     public string? Updated { get; set; }
     public string? Url { get; set; }
     public string? Website { get; set; }
+    public string? SourceCode { get; set; }
 
-    // Confirmed present on /api/search/mod results; unconfirmed elsewhere,
-    // hence nullable — see IsKsaMod's fallback behavior.
+    // Nullable: not guaranteed on every endpoint; see IsKsaMod.
     public int? GameId { get; set; }
 }
 

--- a/src/Borea.Network/SpaceDock/SpaceDockResolver.cs
+++ b/src/Borea.Network/SpaceDock/SpaceDockResolver.cs
@@ -1,4 +1,6 @@
-﻿namespace Borea.Network.SpaceDock;
+﻿using Borea.Core.Mods;
+
+namespace Borea.Network.SpaceDock;
 
 /// <summary>
 /// Maps a mod's true, permanent ModId (confirmed by reading mod.toml after
@@ -10,7 +12,7 @@
 /// </summary>
 public sealed class SpaceDockResolver
 {
-    private readonly Dictionary<string, int> _map = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, int> _map = new(ModIds.Comparer);
 
     /// <summary>
     /// Maps a mod's true, permanent ModId (confirmed by reading mod.toml) to SpaceDock's own numeric mod ID. No-op if the modId is already registered.

--- a/src/Borea.Network/SpaceDock/SpaceDockVersionParsing.cs
+++ b/src/Borea.Network/SpaceDock/SpaceDockVersionParsing.cs
@@ -1,15 +1,17 @@
-﻿using Borea.Core.Mods;
+using Borea.Core.Mods;
 
 namespace Borea.Network.SpaceDock;
 
 /// <summary>
 /// Best-effort coercion of SpaceDock's free-text friendly_version into
-/// ModVersion's strict Major.Minor.Patch shape.
+/// ModVersion's strict SemVer shape.
 /// </summary>
 internal static class SpaceDockVersionParsing
 {
     /// <summary>
-    /// Attempts to normalize SpaceDock's free-text friendly_version into ModVersion's strict Major.Minor.Patch shape.
+    /// Normalizes a friendly_version into a ModVersion: a leading "v" is
+    /// stripped, full SemVer parses as-is, short numeric forms such as "1.2"
+    /// or "7" are padded with zeros.
     /// </summary>
     public static bool TryNormalize(string raw, out ModVersion version)
     {
@@ -21,15 +23,29 @@ internal static class SpaceDockVersionParsing
         if (trimmed.StartsWith("v", StringComparison.OrdinalIgnoreCase))
             trimmed = trimmed[1..];
 
-        var parts = trimmed.Split('.');
+        if (ModVersion.TryParse(trimmed, out version))
+            return true;
+
+        // Carry a pre-release label through the padding branches, so
+        // "1.2-beta" does not pose as a stable release.
+        var core = trimmed;
+        var suffix = string.Empty;
+        var dash = trimmed.IndexOf('-');
+        if (dash >= 0)
+        {
+            core = trimmed[..dash];
+            suffix = trimmed[dash..];
+        }
+
+        var parts = core.Split('.');
         if (parts.Length >= 3 && parts.Take(3).All(p => int.TryParse(p, out _)))
-            return ModVersion.TryParse($"{parts[0]}.{parts[1]}.{parts[2]}", out version);
+            return ModVersion.TryParse($"{parts[0]}.{parts[1]}.{parts[2]}{suffix}", out version);
 
         if (parts.Length == 2 && parts.All(p => int.TryParse(p, out _)))
-            return ModVersion.TryParse($"{parts[0]}.{parts[1]}.0", out version);
+            return ModVersion.TryParse($"{parts[0]}.{parts[1]}.0{suffix}", out version);
 
         if (parts.Length == 1 && int.TryParse(parts[0], out _))
-            return ModVersion.TryParse($"{parts[0]}.0.0", out version);
+            return ModVersion.TryParse($"{parts[0]}.0.0{suffix}", out version);
 
         return false;
     }

--- a/src/Borea.Storage/Mods/DownloadInfoDto.cs
+++ b/src/Borea.Storage/Mods/DownloadInfoDto.cs
@@ -6,8 +6,8 @@
 public sealed class DownloadInfoDto
 {
     public string Url { get; set; } = string.Empty;
-    public string Sha256 { get; set; } = string.Empty;
-    public long SizeBytes { get; set; }
+    public string? Sha256 { get; set; }
+    public long? SizeBytes { get; set; }
     public string ContentType { get; set; } = string.Empty;
     public List<string> Mirrors { get; set; } = new();
 }

--- a/src/Borea.Storage/Mods/ModVersionMetadataDto.cs
+++ b/src/Borea.Storage/Mods/ModVersionMetadataDto.cs
@@ -32,7 +32,9 @@ public sealed class ModVersionMetadataDto
     public List<string>? Os { get; set; }
 
     public DownloadInfoDto Download { get; set; } = new();
-    public long InstallSizeBytes { get; set; }
+
+    /// <summary>Null means the source did not expose the unpacked size.</summary>
+    public long? InstallSizeBytes { get; set; }
     public InstallInfoDto? Install { get; set; }
     public LoaderRequirementDto? Loader { get; set; }
     public List<ModDependencyDto> Dependencies { get; set; } = new();
@@ -40,4 +42,7 @@ public sealed class ModVersionMetadataDto
     public ListingSnapshotDto? Listing { get; set; }
     public bool Yanked { get; set; }
     public string? YankedReason { get; set; }
+
+    /// <summary>Borea-internal source tag, not a format field. Null when unknown.</summary>
+    public string? Source { get; set; }
 }

--- a/src/Borea.Storage/Mods/ModVersionMetadataMapper.cs
+++ b/src/Borea.Storage/Mods/ModVersionMetadataMapper.cs
@@ -27,6 +27,7 @@ public static class ModVersionMetadataMapper
         Listing = release.Listing is null ? null : ListingSnapshotMapper.ToDto(release.Listing),
         Yanked = release.Yanked,
         YankedReason = release.YankedReason,
+        Source = release.Source,
     };
 
     public static ModVersionMetadata FromDto(ModVersionMetadataDto dto)
@@ -55,6 +56,7 @@ public static class ModVersionMetadataMapper
         changelog: dto.Changelog,
         listing: dto.Listing is null ? null : ListingSnapshotMapper.FromDto(dto.Listing),
         yanked: dto.Yanked,
-        yankedReason: dto.YankedReason);
+        yankedReason: dto.YankedReason,
+        source: dto.Source);
     }
 }

--- a/tests/Borea.Core.Tests/Mods/ReleaseFileTypesTests.cs
+++ b/tests/Borea.Core.Tests/Mods/ReleaseFileTypesTests.cs
@@ -100,7 +100,9 @@ public sealed class InstallInfoTests
     [InlineData("../escape")]
     [InlineData("nested/../../escape")]
     [InlineData("/absolute")]
+    [InlineData("\\absolute")]
     [InlineData("C:\\Windows")]
+    [InlineData("C:relative")]
     public void Constructor_EscapingOrRootedRoot_ThrowsArgumentException(string root)
     {
         Assert.Throws<ArgumentException>(() => new InstallInfo(root, derived: false));

--- a/tests/Borea.Network.Tests/Sources/CompositeModRepositoryTests.cs
+++ b/tests/Borea.Network.Tests/Sources/CompositeModRepositoryTests.cs
@@ -1,4 +1,4 @@
-﻿using Borea.Core.Mods;
+using Borea.Core.Mods;
 using Borea.Network.Sources;
 using Borea.Network.Tests.Temp;
 
@@ -45,9 +45,104 @@ public sealed class CompositeModRepositoryTests
     }
 
     [Fact]
-    public async Task GetLatestAsync_ReturnsFirstMatchingSource_TaggedCorrectly()
+    public async Task Tag_PreservesEveryListingFact()
     {
-        var spaceDock = new FakeModRepository(TestFixtures.SampleModMetadata("mod-a", "irrelevant"));
+        // The fixture populates every optional field, so dropping any
+        // argument from the Tag copy makes an assertion below fail.
+        var original = TestFixtures.FullModMetadata();
+        var composite = new CompositeModRepository(new Dictionary<string, IModRepository>
+        {
+            ["spacedock"] = new FakeModRepository(original),
+        });
+
+        var tagged = (await composite.GetAvailableModsAsync())[0];
+
+        Assert.Equal("spacedock", tagged.Source);
+        Assert.Equal(original.SpecVersion, tagged.SpecVersion);
+        Assert.Equal(original.ModId, tagged.ModId);
+        Assert.Equal(original.Type, tagged.Type);
+        Assert.Equal(original.Name, tagged.Name);
+        Assert.Equal(original.Authors, tagged.Authors);
+        Assert.Equal(original.Abstract, tagged.Abstract);
+        Assert.Equal(original.Description, tagged.Description);
+        Assert.Equal(original.License, tagged.License);
+        Assert.Equal(original.Tags, tagged.Tags);
+        Assert.Equal(original.Status, tagged.Status);
+        Assert.Equal(original.SupersededBy, tagged.SupersededBy);
+        Assert.Equal(original.Links.Count, tagged.Links.Count);
+        Assert.Equal(original.ForumUrl, tagged.ForumUrl);
+        Assert.Equal(original.Links["repository"], tagged.Links["repository"]);
+        Assert.NotNull(tagged.Releases);
+        Assert.Equal(original.Releases!.Authority, tagged.Releases!.Authority);
+        Assert.Equal(original.Releases.Hosts.Count, tagged.Releases.Hosts.Count);
+        Assert.Equal(original.GameMin, tagged.GameMin);
+        Assert.Equal(original.GameMax, tagged.GameMax);
+        Assert.Equal(original.Os, tagged.Os);
+        Assert.NotNull(tagged.Loader);
+        Assert.Equal(original.Loader!.LoaderId, tagged.Loader!.LoaderId);
+        Assert.Equal(original.Loader.MinVersion, tagged.Loader.MinVersion);
+        Assert.Equal(original.Loader.MaxVersion, tagged.Loader.MaxVersion);
+        Assert.Equal(original.Dependencies.Count, tagged.Dependencies.Count);
+        Assert.Equal(original.Dependencies[0].ModId, tagged.Dependencies[0].ModId);
+        Assert.True(tagged.Dependencies[1].IsAnyOf);
+        Assert.Equal(original.InstallRootOverride, tagged.InstallRootOverride);
+    }
+
+    [Fact]
+    public async Task Tag_PreservesEveryReleaseFact()
+    {
+        // FullRelease is yanked, so GetReleaseAsync is the accessor under
+        // test here, which returns yanked releases as-is by contract.
+        var original = TestFixtures.FullRelease();
+        var composite = new CompositeModRepository(new Dictionary<string, IModRepository>
+        {
+            ["spacedock"] = new FakeModRepository(Array.Empty<ModMetadata>(), new[] { original }),
+        });
+
+        var tagged = await composite.GetReleaseAsync(original.ModId, original.Version);
+
+        Assert.NotNull(tagged);
+        Assert.Equal("spacedock", tagged!.Source);
+        Assert.Equal(original.SpecVersion, tagged.SpecVersion);
+        Assert.Equal(original.ModId, tagged.ModId);
+        Assert.Equal(original.Type, tagged.Type);
+        Assert.Equal(original.Version, tagged.Version);
+        Assert.Equal(original.VersionScheme, tagged.VersionScheme);
+        Assert.Equal(original.ReleaseStatus, tagged.ReleaseStatus);
+        Assert.Equal(original.ReleaseDate, tagged.ReleaseDate);
+        Assert.Equal(original.GameMin, tagged.GameMin);
+        Assert.Equal(original.GameMinRevision, tagged.GameMinRevision);
+        Assert.Equal(original.GameMax, tagged.GameMax);
+        Assert.Equal(original.GameMaxRevision, tagged.GameMaxRevision);
+        Assert.Equal(original.Os, tagged.Os);
+        Assert.Equal(original.Download.Url, tagged.Download.Url);
+        Assert.Equal(original.Download.Sha256, tagged.Download.Sha256);
+        Assert.Equal(original.Download.SizeBytes, tagged.Download.SizeBytes);
+        Assert.Equal(original.Download.ContentType, tagged.Download.ContentType);
+        Assert.Equal(original.Download.Mirrors, tagged.Download.Mirrors);
+        Assert.Equal(original.InstallSizeBytes, tagged.InstallSizeBytes);
+        Assert.NotNull(tagged.Install);
+        Assert.Equal(original.Install!.Root, tagged.Install!.Root);
+        Assert.Equal(original.Install.Derived, tagged.Install.Derived);
+        Assert.NotNull(tagged.Loader);
+        Assert.Equal(original.Loader!.LoaderId, tagged.Loader!.LoaderId);
+        Assert.Equal(original.Loader.Source, tagged.Loader.Source);
+        Assert.Equal(original.Dependencies.Count, tagged.Dependencies.Count);
+        Assert.Equal(original.Dependencies[0].Source, tagged.Dependencies[0].Source);
+        Assert.Equal(original.Changelog, tagged.Changelog);
+        Assert.NotNull(tagged.Listing);
+        Assert.Equal(original.Listing!.Name, tagged.Listing!.Name);
+        Assert.Equal(original.Listing.Description, tagged.Listing.Description);
+        Assert.True(tagged.Yanked);
+        Assert.Equal(original.YankedReason, tagged.YankedReason);
+    }
+
+    [Fact]
+    public async Task GetLatestReleaseAsync_ReturnsFirstMatchingSource_TaggedCorrectly()
+    {
+        var spaceDock = new FakeModRepository(
+            new[] { TestFixtures.SampleModMetadata("mod-a", "irrelevant") },
+            new[] { TestFixtures.SampleRelease("mod-a") });
         var borea = new FakeModRepository();
         var composite = new CompositeModRepository(new Dictionary<string, IModRepository>
         {
@@ -55,46 +150,52 @@ public sealed class CompositeModRepositoryTests
             ["borea"] = borea,
         });
 
-        var result = await composite.GetLatestAsync("mod-a");
+        var release = await composite.GetLatestReleaseAsync("mod-a");
 
-        Assert.NotNull(result);
-        Assert.Equal("spacedock", result!.Source);
+        Assert.NotNull(release);
+        Assert.Equal("spacedock", release!.Source);
+        Assert.Equal(ModVersion.Parse("1.0.0"), release.Version);
     }
 
     [Fact]
-    public async Task GetLatestAsync_NoSourceHasIt_ReturnsNull()
+    public async Task GetLatestReleaseAsync_NoSourceHasIt_ReturnsNull()
     {
         var composite = new CompositeModRepository(new Dictionary<string, IModRepository>
         {
             ["spacedock"] = new FakeModRepository(),
         });
 
-        var result = await composite.GetLatestAsync("never-exists");
+        var release = await composite.GetLatestReleaseAsync("never-exists");
 
-        Assert.Null(result);
+        Assert.Null(release);
     }
 
     [Fact]
-    public async Task GetVersionAsync_MatchesOnBothModIdAndVersion()
+    public async Task GetReleaseAsync_MatchesOnBothModIdAndVersion()
     {
-        var spaceDock = new FakeModRepository(TestFixtures.SampleModMetadata("mod-a", "spacedock", version: "1.0.0"));
+        var spaceDock = new FakeModRepository(
+            Array.Empty<ModMetadata>(),
+            new[] { TestFixtures.SampleRelease("mod-a", "1.0.0") });
         var composite = new CompositeModRepository(new Dictionary<string, IModRepository>
         {
             ["spacedock"] = spaceDock,
         });
 
-        var wrongVersion = await composite.GetVersionAsync("mod-a", ModVersion.Parse("2.0.0"));
-        var rightVersion = await composite.GetVersionAsync("mod-a", ModVersion.Parse("1.0.0"));
+        var wrongVersion = await composite.GetReleaseAsync("mod-a", ModVersion.Parse("2.0.0"));
+        var rightVersion = await composite.GetReleaseAsync("mod-a", ModVersion.Parse("1.0.0"));
 
         Assert.Null(wrongVersion);
         Assert.NotNull(rightVersion);
+        Assert.Equal("spacedock", rightVersion!.Source);
     }
 
     [Fact]
     public async Task GetAvailableVersionsAsync_ReturnsFirstNonEmptySourceResult()
     {
-        var spaceDock = new FakeModRepository(); // No versions for "mod-a".
-        var borea = new FakeModRepository(TestFixtures.SampleModMetadata("mod-a", "borea"));
+        var spaceDock = new FakeModRepository(); // No releases for "mod-a".
+        var borea = new FakeModRepository(
+            Array.Empty<ModMetadata>(),
+            new[] { TestFixtures.SampleRelease("mod-a") });
         var composite = new CompositeModRepository(new Dictionary<string, IModRepository>
         {
             ["spacedock"] = spaceDock,
@@ -130,13 +231,15 @@ public sealed class CompositeModRepositoryTests
         // queried, no special retirement handling needed.
         var composite = new CompositeModRepository(new Dictionary<string, IModRepository>
         {
-            ["borea"] = new FakeModRepository(TestFixtures.SampleModMetadata("mod-a", "borea")),
+            ["borea"] = new FakeModRepository(
+                new[] { TestFixtures.SampleModMetadata("mod-a", "borea") },
+                new[] { TestFixtures.SampleRelease("mod-a") }),
             // "spacedock" deliberately absent.
         });
 
-        var result = await composite.GetLatestAsync("mod-a");
+        var release = await composite.GetLatestReleaseAsync("mod-a");
 
-        Assert.NotNull(result);
-        Assert.Equal("borea", result!.Source);
+        Assert.NotNull(release);
+        Assert.Equal("borea", release!.Source);
     }
 }

--- a/tests/Borea.Network.Tests/SpaceDock/SpaceDockModRepositoryTests.cs
+++ b/tests/Borea.Network.Tests/SpaceDock/SpaceDockModRepositoryTests.cs
@@ -1,4 +1,3 @@
-﻿using Borea.Core.Game;
 using Borea.Core.Mods;
 using Borea.Network.SpaceDock;
 
@@ -6,23 +5,27 @@ namespace Borea.Network.Tests;
 
 public sealed class SpaceDockModRepositoryTests
 {
-    // Trimmed/adapted from the real /api/search/mod response for "MPFX".
-    private const string RealMpfxSearchJson = """
-        [{"name":"MPFX","id":4165,"game":"Kitten Space Agency","game_id":22409,
-          "short_description":"Simple post processing","author":"AMPW",
-          "default_version_id":24490,"url":"/mod/4165/MPFX","website":null,
-          "versions":[
-            {"friendly_version":"v0.3.1","game_version":"2026.7.10.5056","id":24490,
-             "created":"2026-07-23T20:02:32.835271+00:00",
-             "download_path":"/mod/4165/MPFX/download/v0.3.1","changelog":"Built for KSA"},
-            {"friendly_version":"v0.2.0","game_version":"2026.3.3.3759","id":23419,
-             "created":"2026-03-08T13:08:17.822477+00:00",
-             "download_path":"/mod/4165/MPFX/download/v0.2.0","changelog":"Profile support"}
-          ]}]
+    // Trimmed/adapted from the real /api/mod/4165 response for "MPFX".
+    private const string RealMpfxModJson = """
+        {"name":"MPFX","id":4165,"game":"Kitten Space Agency","game_id":22409,
+         "short_description":"Simple post processing","author":"AMPW","license":"MIT",
+         "website":"https://forums.ahwoo.com/threads/mpfx-v0-1-0-simple-post-processing-effects.812/",
+         "source_code":"https://github.com/AMPW-german/MPFX",
+         "default_version_id":24490,"url":"/mod/4165/MPFX",
+         "versions":[
+           {"friendly_version":"v0.3.1","game_version":"2026.7.10.5056","id":24490,
+            "created":"2026-07-23T20:02:32.835271+00:00",
+            "download_path":"/mod/4165/MPFX/download/v0.3.1","changelog":"Built for KSA"},
+           {"friendly_version":"v0.2.0","game_version":"2026.3.3.3759","id":23419,
+            "created":"2026-03-08T13:08:17.822477+00:00",
+            "download_path":"/mod/4165/MPFX/download/v0.2.0","changelog":"Profile support"}
+         ]}
         """;
 
+    private const string RealMpfxSearchJson = $"[{RealMpfxModJson}]";
+
     [Fact]
-    public async Task SearchAsync_RealMpfxResponse_MapsCorrectly()
+    public async Task SearchAsync_RealMpfxResponse_MapsTheListing()
     {
         var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(RealMpfxSearchJson), out _);
         var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
@@ -32,12 +35,97 @@ public sealed class SpaceDockModRepositoryTests
         var mod = Assert.Single(results);
         Assert.Equal("4165", mod.ModId); // Placeholder = SpaceDock's numeric id, stringified.
         Assert.Equal("spacedock", mod.Source);
+        Assert.Equal(ContentType.Mod, mod.Type);
         Assert.Equal("MPFX", mod.Name);
-        Assert.Equal("AMPW", mod.Author);
-        Assert.Equal(ModVersion.Parse("0.3.1"), mod.Version); // "v0.3.1" -> stripped 'v'.
-        Assert.Equal(GameVersion.Parse("2026.7.10.5056"), mod.BuiltForGameVersion);
-        Assert.Equal("Built for KSA", mod.ChangeLog);
-        Assert.Equal("https://spacedock.info/mod/4165/MPFX", mod.HomepageUrl);
+        Assert.Equal(new[] { "AMPW" }, mod.Authors);
+        Assert.Equal("Simple post processing", mod.Abstract);
+        Assert.Equal("MIT", mod.License);
+        // The oldest game version any release claims, not the newest:
+        // v0.2.0 was built for 2026.3.3.3759.
+        Assert.Equal("2026.3.3.3759", mod.GameMin);
+        Assert.Equal("https://github.com/AMPW-german/MPFX", mod.Links["repository"]);
+        Assert.Equal("https://spacedock.info/mod/4165/MPFX", mod.Links["spacedock"]);
+        var releases = Assert.IsType<ReleaseSource>(mod.Releases);
+        Assert.Equal("spacedock", releases.AuthorityHost.Host);
+        Assert.Equal("4165", releases.AuthorityHost.Reference);
+    }
+
+    [Fact]
+    public async Task SearchAsync_WebsiteOnKsaForums_BecomesTheForumsLink()
+    {
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(RealMpfxSearchJson), out _);
+        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
+
+        var results = await repository.SearchAsync("MPFX");
+
+        Assert.Equal("https://forums.ahwoo.com/threads/mpfx-v0-1-0-simple-post-processing-effects.812/", results[0].ForumUrl);
+    }
+
+    [Fact]
+    public async Task SearchAsync_WebsiteElsewhere_SpaceDockPageStandsInAsForumsLink()
+    {
+        var json = """
+            [{"name":"Mod","id":7,"game_id":22409,"author":"a","default_version_id":1,
+              "website":"https://example.com/my-mod","url":"/mod/7/Mod",
+              "versions":[{"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":1,
+                           "created":"2026-01-01T00:00:00+00:00","download_path":"/mod/7/Mod/download/1.0.0"}]}]
+            """;
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
+        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
+
+        var results = await repository.SearchAsync("Mod");
+
+        Assert.Equal("https://spacedock.info/mod/7/Mod", results[0].ForumUrl);
+        Assert.Equal("https://example.com/my-mod", results[0].Links["homepage"]);
+    }
+
+    [Fact]
+    public async Task SearchAsync_MissingLicense_MapsToUnknownPlaceholder()
+    {
+        var json = """
+            [{"name":"Mod","id":7,"game_id":22409,"author":"a","default_version_id":1,
+              "versions":[{"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":1}]}]
+            """;
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
+        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
+
+        var results = await repository.SearchAsync("Mod");
+
+        Assert.Equal("Unknown", results[0].License);
+    }
+
+    [Fact]
+    public async Task SearchAsync_UnparseableVersionData_StillSurfacesTheListing()
+    {
+        // A mod whose version data does not parse must survive as a listing.
+        var json = """
+            [{"name":"Weird Mod","id":9,"game_id":22409,"author":"a","default_version_id":1,
+              "versions":[{"friendly_version":"not-a-version","game_version":"garbage","id":1}]}]
+            """;
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
+        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
+
+        var results = await repository.SearchAsync("Weird");
+
+        var mod = Assert.Single(results);
+        Assert.Equal("Weird Mod", mod.Name);
+        Assert.Equal("garbage", mod.GameMin); // Raw string kept; evaluates as unknown downstream.
+        Assert.Empty(mod.Dependencies); // Unknown, not none: SpaceDock carries no dependency data.
+        Assert.Null(mod.Loader);
+    }
+
+    [Fact]
+    public async Task SearchAsync_NoVersionsAtAll_StillSurfacesTheListing()
+    {
+        var json = """
+            [{"name":"Empty Mod","id":11,"game_id":22409,"author":"a","default_version_id":0,"versions":[]}]
+            """;
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
+        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
+
+        var results = await repository.SearchAsync("Empty");
+
+        Assert.Equal("unknown", Assert.Single(results).GameMin);
     }
 
     [Fact]
@@ -61,62 +149,6 @@ public sealed class SpaceDockModRepositoryTests
     }
 
     [Fact]
-    public async Task SearchAsync_MissingGameId_FallsBackToGameVersionHeuristic()
-    {
-        // No game_id field at all — KSP-shaped version should be excluded,
-        // KSA-shaped version should be included, purely by GameVersion parse success.
-        var json = """
-            [
-              {"name":"KSA-shaped","id":1,"author":"a","default_version_id":1,
-               "versions":[{"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":1}]},
-              {"name":"KSP-shaped","id":2,"author":"b","default_version_id":2,
-               "versions":[{"friendly_version":"1.0.0","game_version":"0.24.2","id":2}]}
-            ]
-            """;
-        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
-        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
-
-        var results = await repository.SearchAsync("query");
-
-        var mod = Assert.Single(results);
-        Assert.Equal("KSA-shaped", mod.Name);
-    }
-
-    [Theory]
-    [InlineData("v1.2.3", "1.2.3")]
-    [InlineData("13.0", "13.0.0")]
-    [InlineData("7", "7.0.0")]
-    [InlineData("V2.0.0", "2.0.0")]
-    public async Task VersionNormalization_HandlesRealWorldFormats(string friendlyVersion, string expectedNormalized)
-    {
-        var json = $$"""
-            [{"name":"Mod","id":1,"game_id":22409,"author":"a","default_version_id":1,
-              "versions":[{"friendly_version":"{{friendlyVersion}}","game_version":"2026.1.1.1","id":1}]}]
-            """;
-        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
-        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
-
-        var results = await repository.SearchAsync("query");
-
-        Assert.Equal(ModVersion.Parse(expectedNormalized), results[0].Version);
-    }
-
-    [Fact]
-    public async Task VersionNormalization_UnparseableFriendlyVersion_ExcludesMod()
-    {
-        var json = """
-            [{"name":"Mod","id":1,"game_id":22409,"author":"a","default_version_id":1,
-              "versions":[{"friendly_version":"not-a-version-at-all","game_version":"2026.1.1.1","id":1}]}]
-            """;
-        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
-        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
-
-        var results = await repository.SearchAsync("query");
-
-        Assert.Empty(results);
-    }
-
-    [Fact]
     public async Task GetAvailableModsAsync_RequestsCorrectUrlWithKsaGameId()
     {
         var client = FakeHttpMessageHandler.BuildClient(
@@ -130,7 +162,90 @@ public sealed class SpaceDockModRepositoryTests
     }
 
     [Fact]
-    public async Task GetLatestAsync_UnresolvableModId_ReturnsNullWithoutMakingRequest()
+    public async Task GetLatestReleaseAsync_MapsTheNewestRelease()
+    {
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(RealMpfxModJson), out _);
+        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
+
+        var release = await repository.GetLatestReleaseAsync("4165");
+
+        Assert.NotNull(release);
+        Assert.Equal("4165", release!.ModId);
+        Assert.Equal("spacedock", release.Source);
+        Assert.Equal(ModVersion.Parse("0.3.1"), release.Version);
+        Assert.Equal(ReleaseStatus.Stable, release.ReleaseStatus);
+        Assert.Equal("2026.7.10.5056", release.GameMin);
+        Assert.Equal(5056, release.GameMinRevision);
+        Assert.Equal("https://spacedock.info/mod/4165/MPFX/download/v0.3.1", release.Download.Url);
+        Assert.Null(release.Download.Sha256); // SpaceDock exposes no checksum; null means unverifiable.
+        Assert.Null(release.Download.SizeBytes);
+        Assert.Null(release.InstallSizeBytes);
+        Assert.Equal("Built for KSA", release.Changelog);
+        Assert.Equal(new DateTimeOffset(2026, 7, 23, 20, 2, 32, TimeSpan.Zero), release.ReleaseDate, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task GetLatestReleaseAsync_UnusableDefaultVersion_FallsBackToNewestMappable()
+    {
+        var json = """
+            {"name":"Mod","id":1,"game_id":22409,"author":"a","default_version_id":99,
+             "versions":[
+               {"friendly_version":"broken","game_version":"2026.1.1.1","id":99,
+                "created":"2026-01-03T00:00:00+00:00","download_path":"/d/99"},
+               {"friendly_version":"1.1.0","game_version":"2026.1.1.1","id":2,
+                "created":"2026-01-02T00:00:00+00:00","download_path":"/d/2"},
+               {"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":1,
+                "created":"2026-01-01T00:00:00+00:00","download_path":"/d/1"}
+             ]}
+            """;
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
+        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
+
+        var release = await repository.GetLatestReleaseAsync("1");
+
+        Assert.Equal(ModVersion.Parse("1.1.0"), release!.Version);
+    }
+
+    [Fact]
+    public async Task GetLatestReleaseAsync_DefaultOlderThanNewest_ReturnsNewest()
+    {
+        // default_version_id is author-selectable; the contract says newest.
+        var json = """
+            {"name":"Mod","id":1,"game_id":22409,"author":"a","default_version_id":1,
+             "versions":[
+               {"friendly_version":"2.0.0","game_version":"2026.1.1.1","id":2,
+                "created":"2026-01-02T00:00:00+00:00","download_path":"/d/2"},
+               {"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":1,
+                "created":"2026-01-01T00:00:00+00:00","download_path":"/d/1"}
+             ]}
+            """;
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
+        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
+
+        var release = await repository.GetLatestReleaseAsync("1");
+
+        Assert.Equal(ModVersion.Parse("2.0.0"), release!.Version);
+    }
+
+    [Fact]
+    public async Task GetLatestReleaseAsync_PreReleaseVersion_MapsAsTesting()
+    {
+        var json = """
+            {"name":"Mod","id":1,"game_id":22409,"author":"a","default_version_id":1,
+             "versions":[{"friendly_version":"v1.2.0-beta.1","game_version":"2026.1.1.1","id":1,
+                          "created":"2026-01-01T00:00:00+00:00","download_path":"/d/1"}]}
+            """;
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
+        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
+
+        var release = await repository.GetLatestReleaseAsync("1");
+
+        Assert.Equal(ModVersion.Parse("1.2.0-beta.1"), release!.Version);
+        Assert.Equal(ReleaseStatus.Testing, release.ReleaseStatus);
+    }
+
+    [Fact]
+    public async Task GetLatestReleaseAsync_UnresolvableModId_ReturnsNullWithoutMakingRequest()
     {
         var called = false;
         var client = FakeHttpMessageHandler.BuildClient(_ =>
@@ -140,86 +255,101 @@ public sealed class SpaceDockModRepositoryTests
         }, out _);
         var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
 
-        var result = await repository.GetLatestAsync("some-true-modid-never-registered");
+        var result = await repository.GetLatestReleaseAsync("some-true-modid-never-registered");
 
         Assert.Null(result);
-        Assert.False(called); // No resolver entry — should short-circuit, not hit the network.
+        Assert.False(called); // No resolver entry: short-circuit, do not hit the network.
     }
 
     [Fact]
-    public async Task GetLatestAsync_NumericModId_UsedDirectlyAsSpaceDockId()
-    {
-        var json = """
-            {"name":"Mod","id":42,"game_id":22409,"author":"a","default_version_id":1,
-             "versions":[{"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":1}]}
-            """;
-        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out var handler);
-        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
-
-        await repository.GetLatestAsync("42");
-
-        Assert.Contains("api/mod/42", handler.LastRequest!.RequestUri!.ToString());
-    }
-
-    [Fact]
-    public async Task GetLatestAsync_ResolverRegisteredModId_ResolvesToCorrectSpaceDockId()
+    public async Task GetLatestReleaseAsync_ResolverRegisteredModId_ResolvesToCorrectSpaceDockId()
     {
         var json = """
             {"name":"Mod","id":999,"game_id":22409,"author":"a","default_version_id":1,
-             "versions":[{"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":1}]}
+             "versions":[{"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":1,
+                          "created":"2026-01-01T00:00:00+00:00","download_path":"/d/1"}]}
             """;
         var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out var handler);
         var resolver = new SpaceDockResolver();
         resolver.Register("true-mod-id-from-mod-toml", 999);
         var repository = new SpaceDockModRepository(client, resolver);
 
-        await repository.GetLatestAsync("true-mod-id-from-mod-toml");
+        await repository.GetLatestReleaseAsync("true-mod-id-from-mod-toml");
 
         Assert.Contains("api/mod/999", handler.LastRequest!.RequestUri!.ToString());
     }
 
     [Fact]
-    public async Task GetVersionAsync_MatchingVersionExists_ReturnsIt()
+    public async Task GetReleaseAsync_MatchingVersionExists_ReturnsIt()
     {
         var json = """
             {"name":"Mod","id":1,"game_id":22409,"author":"a","default_version_id":10,
              "versions":[
-               {"friendly_version":"2.0.0","game_version":"2026.1.1.1","id":10},
-               {"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":11}
+               {"friendly_version":"2.0.0","game_version":"2026.1.1.1","id":10,
+                "created":"2026-01-02T00:00:00+00:00","download_path":"/d/10"},
+               {"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":11,
+                "created":"2026-01-01T00:00:00+00:00","download_path":"/d/11"}
              ]}
             """;
         var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
         var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
 
-        var result = await repository.GetVersionAsync("1", ModVersion.Parse("1.0.0"));
+        var result = await repository.GetReleaseAsync("1", ModVersion.Parse("1.0.0"));
 
         Assert.NotNull(result);
         Assert.Equal(ModVersion.Parse("1.0.0"), result!.Version);
+        Assert.Equal("https://spacedock.info/d/11", result.Download.Url);
     }
 
     [Fact]
-    public async Task GetVersionAsync_NoMatchingVersion_ReturnsNull()
+    public async Task GetReleaseAsync_NoMatchingVersion_ReturnsNull()
     {
         var json = """
             {"name":"Mod","id":1,"game_id":22409,"author":"a","default_version_id":10,
-             "versions":[{"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":10}]}
+             "versions":[{"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":10,
+                          "created":"2026-01-01T00:00:00+00:00","download_path":"/d/10"}]}
             """;
         var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
         var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
 
-        var result = await repository.GetVersionAsync("1", ModVersion.Parse("9.9.9"));
+        var result = await repository.GetReleaseAsync("1", ModVersion.Parse("9.9.9"));
 
         Assert.Null(result);
     }
 
     [Fact]
-    public async Task GetAvailableVersionsAsync_SkipsUnparseableEntries()
+    public async Task GetReleaseAsync_CollidingVersionStrings_ResolvesToTheUsableRow()
+    {
+        // "1.0" and "1.0.0" normalize to the same ModVersion; resolution must
+        // fall through the unmappable first row to the usable one.
+        var json = """
+            {"name":"Mod","id":1,"game_id":22409,"author":"a","default_version_id":2,
+             "versions":[
+               {"friendly_version":"1.0","game_version":"garbage","id":1,
+                "created":"2026-01-01T00:00:00+00:00","download_path":"/d/1"},
+               {"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":2,
+                "created":"2026-01-01T00:00:00+00:00","download_path":"/d/2"}
+             ]}
+            """;
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
+        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
+
+        var result = await repository.GetReleaseAsync("1", ModVersion.Parse("1.0.0"));
+
+        Assert.NotNull(result);
+        Assert.Equal("https://spacedock.info/d/2", result!.Download.Url);
+    }
+
+    [Fact]
+    public async Task GetAvailableVersionsAsync_CollapsesDuplicateNormalizedVersions()
     {
         var json = """
             {"name":"Mod","id":1,"game_id":22409,"author":"a","default_version_id":1,
              "versions":[
-               {"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":1},
-               {"friendly_version":"garbage","game_version":"2026.1.1.1","id":2}
+               {"friendly_version":"1.0","game_version":"2026.1.1.1","id":1,
+                "created":"2026-01-01T00:00:00+00:00","download_path":"/d/1"},
+               {"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":2,
+                "created":"2026-01-01T00:00:00+00:00","download_path":"/d/2"}
              ]}
             """;
         var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
@@ -227,8 +357,84 @@ public sealed class SpaceDockModRepositoryTests
 
         var versions = await repository.GetAvailableVersionsAsync("1");
 
-        Assert.Single(versions);
-        Assert.Equal(ModVersion.Parse("1.0.0"), versions[0]);
+        Assert.Equal(new[] { ModVersion.Parse("1.0.0") }, versions);
+    }
+
+    [Fact]
+    public async Task ReleaseAccessors_UnknownId_ReturnNullOn404()
+    {
+        // 404 means not available, not an exception.
+        var client = FakeHttpMessageHandler.BuildClient(
+            _ => new HttpResponseMessage(System.Net.HttpStatusCode.NotFound), out _);
+        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
+
+        Assert.Null(await repository.GetLatestReleaseAsync("99999999"));
+        Assert.Null(await repository.GetReleaseAsync("99999999", ModVersion.Parse("1.0.0")));
+        Assert.Empty(await repository.GetAvailableVersionsAsync("99999999"));
+    }
+
+    [Fact]
+    public async Task GetReleaseAsync_UnparseableGameVersion_ReturnsNull()
+    {
+        // A release without a resolvable game revision cannot be stamped.
+        var json = """
+            {"name":"Mod","id":1,"game_id":22409,"author":"a","default_version_id":10,
+             "versions":[{"friendly_version":"1.0.0","game_version":"0.24.2","id":10,
+                          "created":"2026-01-01T00:00:00+00:00","download_path":"/d/10"}]}
+            """;
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
+        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
+
+        var result = await repository.GetReleaseAsync("1", ModVersion.Parse("1.0.0"));
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetAvailableVersionsAsync_ListsOnlyMappableReleases_NewestFirst()
+    {
+        var json = """
+            {"name":"Mod","id":1,"game_id":22409,"author":"a","default_version_id":1,
+             "versions":[
+               {"friendly_version":"1.0.0","game_version":"2026.1.1.1","id":1,
+                "created":"2026-01-01T00:00:00+00:00","download_path":"/d/1"},
+               {"friendly_version":"2.0.0","game_version":"2026.1.1.1","id":2,
+                "created":"2026-01-02T00:00:00+00:00","download_path":"/d/2"},
+               {"friendly_version":"garbage","game_version":"2026.1.1.1","id":3,
+                "created":"2026-01-03T00:00:00+00:00","download_path":"/d/3"},
+               {"friendly_version":"3.0.0","game_version":"not-ksa","id":4,
+                "created":"2026-01-04T00:00:00+00:00","download_path":"/d/4"}
+             ]}
+            """;
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
+        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
+
+        var versions = await repository.GetAvailableVersionsAsync("1");
+
+        Assert.Equal(new[] { ModVersion.Parse("2.0.0"), ModVersion.Parse("1.0.0") }, versions);
+    }
+
+    [Theory]
+    [InlineData("v1.2.3", "1.2.3")]
+    [InlineData("13.0", "13.0.0")]
+    [InlineData("7", "7.0.0")]
+    [InlineData("V2.0.0", "2.0.0")]
+    [InlineData("1.2.3-rc.1", "1.2.3-rc.1")]
+    [InlineData("1.2.3.4-rc1", "1.2.3-rc1")]
+    [InlineData("1.2-beta", "1.2.0-beta")]
+    public async Task VersionNormalization_HandlesRealWorldFormats(string friendlyVersion, string expectedNormalized)
+    {
+        var json = $$"""
+            {"name":"Mod","id":1,"game_id":22409,"author":"a","default_version_id":1,
+             "versions":[{"friendly_version":"{{friendlyVersion}}","game_version":"2026.1.1.1","id":1,
+                          "created":"2026-01-01T00:00:00+00:00","download_path":"/d/1"}]}
+            """;
+        var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse(json), out _);
+        var repository = new SpaceDockModRepository(client, new SpaceDockResolver());
+
+        var release = await repository.GetLatestReleaseAsync("1");
+
+        Assert.Equal(ModVersion.Parse(expectedNormalized), release!.Version);
     }
 
     [Fact]
@@ -236,7 +442,7 @@ public sealed class SpaceDockModRepositoryTests
     {
         var client = FakeHttpMessageHandler.BuildClient(_ => FakeHttpMessageHandler.JsonResponse("{}"), out _);
 
-        Assert.Throws<System.ArgumentNullException>(() => new SpaceDockModRepository(null!, new SpaceDockResolver()));
-        Assert.Throws<System.ArgumentNullException>(() => new SpaceDockModRepository(client, null!));
+        Assert.Throws<ArgumentNullException>(() => new SpaceDockModRepository(null!, new SpaceDockResolver()));
+        Assert.Throws<ArgumentNullException>(() => new SpaceDockModRepository(client, null!));
     }
 }

--- a/tests/Borea.Network.Tests/SpaceDock/SpaceDockResolverTests.cs
+++ b/tests/Borea.Network.Tests/SpaceDock/SpaceDockResolverTests.cs
@@ -53,6 +53,20 @@ public sealed class SpaceDockResolverTests
     }
 
     [Fact]
+    public void TryResolve_ComparesIdsCaseInsensitively()
+    {
+        // Ids compare case-insensitively everywhere (ModIds.Comparer), so a
+        // lookup must not miss over casing.
+        var resolver = new SpaceDockResolver();
+
+        resolver.Register("MyMod", 42);
+        var success = resolver.TryResolve("mymod", out var spaceDockId);
+
+        Assert.True(success);
+        Assert.Equal(42, spaceDockId);
+    }
+
+    [Fact]
     public void MultipleMods_ResolveIndependently()
     {
         var resolver = new SpaceDockResolver();

--- a/tests/Borea.Network.Tests/Temp/FakeModRepositor.cs
+++ b/tests/Borea.Network.Tests/Temp/FakeModRepositor.cs
@@ -1,4 +1,4 @@
-﻿using Borea.Core.Mods;
+using Borea.Core.Mods;
 
 namespace Borea.Network.Tests.Temp;
 
@@ -8,22 +8,39 @@ namespace Borea.Network.Tests.Temp;
 /// </summary>
 internal sealed class FakeModRepository : IModRepository
 {
-    private readonly List<ModMetadata> _mods;
+    private readonly List<ModMetadata> _listings;
+    private readonly List<ModVersionMetadata> _releases;
 
-    public FakeModRepository(params ModMetadata[] mods) => _mods = mods.ToList();
+    public FakeModRepository(params ModMetadata[] listings)
+        : this(listings, Array.Empty<ModVersionMetadata>())
+    {
+    }
+
+    public FakeModRepository(IReadOnlyList<ModMetadata> listings, IReadOnlyList<ModVersionMetadata> releases)
+    {
+        _listings = listings.ToList();
+        _releases = releases.ToList();
+    }
 
     public Task<IReadOnlyList<ModMetadata>> GetAvailableModsAsync(CancellationToken cancellationToken = default) =>
-        Task.FromResult<IReadOnlyList<ModMetadata>>(_mods);
+        Task.FromResult<IReadOnlyList<ModMetadata>>(_listings);
 
-    public Task<ModMetadata?> GetLatestAsync(string modId, CancellationToken cancellationToken = default) =>
-        Task.FromResult(_mods.FirstOrDefault(m => m.ModId == modId));
+    public Task<ModVersionMetadata?> GetLatestReleaseAsync(string modId, CancellationToken cancellationToken = default) =>
+        Task.FromResult(_releases
+            .Where(r => ModIds.Equals(r.ModId, modId) && !r.Yanked)
+            .OrderByDescending(r => r.Version)
+            .FirstOrDefault());
 
-    public Task<ModMetadata?> GetVersionAsync(string modId, ModVersion version, CancellationToken cancellationToken = default) =>
-        Task.FromResult(_mods.FirstOrDefault(m => m.ModId == modId && m.Version.Equals(version)));
+    public Task<ModVersionMetadata?> GetReleaseAsync(string modId, ModVersion version, CancellationToken cancellationToken = default) =>
+        Task.FromResult(_releases.FirstOrDefault(r => ModIds.Equals(r.ModId, modId) && r.Version.Equals(version)));
 
     public Task<IReadOnlyList<ModVersion>> GetAvailableVersionsAsync(string modId, CancellationToken cancellationToken = default) =>
-        Task.FromResult<IReadOnlyList<ModVersion>>(_mods.Where(m => m.ModId == modId).Select(m => m.Version).ToList());
+        Task.FromResult<IReadOnlyList<ModVersion>>(_releases
+            .Where(r => ModIds.Equals(r.ModId, modId))
+            .Select(r => r.Version)
+            .OrderDescending()
+            .ToList());
 
     public Task<IReadOnlyList<ModMetadata>> SearchAsync(string query, CancellationToken cancellationToken = default) =>
-        Task.FromResult<IReadOnlyList<ModMetadata>>(_mods.Where(m => m.Name.Contains(query, StringComparison.OrdinalIgnoreCase)).ToList());
+        Task.FromResult<IReadOnlyList<ModMetadata>>(_listings.Where(m => m.Name.Contains(query, StringComparison.OrdinalIgnoreCase)).ToList());
 }

--- a/tests/Borea.Network.Tests/Temp/TestFixture.cs
+++ b/tests/Borea.Network.Tests/Temp/TestFixture.cs
@@ -1,4 +1,5 @@
-﻿using Borea.Core.Game;
+using Borea.Core.Dependencies;
+using Borea.Core.ModLoaders;
 using Borea.Core.Mods;
 
 namespace Borea.Network.Tests.Temp;
@@ -6,15 +7,108 @@ namespace Borea.Network.Tests.Temp;
 internal static class TestFixtures
 {
     public static ModMetadata SampleModMetadata(
-        string modId, string source, string name = "Test Mod", string version = "1.0.0") =>
+        string modId, string source, string name = "Test Mod") =>
         new(
-            modId,
-            source,
-            name,
-            author: "Test Author",
+            specVersion: 1,
+            modId: modId,
+            source: source,
+            name: name,
+            authors: new[] { "Test Author" },
+            abstractText: "A mod used for testing.",
+            license: "MIT",
+            links: new Dictionary<string, string> { ["forums"] = "https://forums.example/thread/1" },
+            gameMin: "2026.7.4.2131");
+
+    public static ModVersionMetadata SampleRelease(
+        string modId, string version = "1.0.0", string? source = null) =>
+        new(
+            specVersion: 1,
+            modId: modId,
             version: ModVersion.Parse(version),
-            builtForGameVersion: GameVersion.Parse("2026.7.4.2131"),
-            description: "Description.",
-            releasedAt: DateTimeOffset.UtcNow,
-            fileSizeBytes: 1024);
+            releaseStatus: ReleaseStatus.Stable,
+            releaseDate: new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero),
+            gameMin: "2026.7.4.2131",
+            gameMinRevision: 2131,
+            download: new DownloadInfo("https://example.com/mod.zip", new string('A', 64), 1024, "application/zip"),
+            installSizeBytes: 2048,
+            dependencies: Array.Empty<ModDependency>(),
+            source: source);
+
+    /// <summary>
+    /// A listing with every optional field populated, for field-by-field copy assertions.
+    /// </summary>
+    public static ModMetadata FullModMetadata(string modId = "mod-full", string source = "original") =>
+        new(
+            specVersion: 1,
+            modId: modId,
+            source: source,
+            name: "Full Mod",
+            authors: new[] { "Author A", "Author B" },
+            abstractText: "Abstract.",
+            license: "MIT",
+            links: new Dictionary<string, string>
+            {
+                ["forums"] = "https://forums.example/thread/1",
+                ["repository"] = "https://example.com/repo",
+            },
+            gameMin: "2026.7.4.2131",
+            tags: new[] { "parts", "tools" },
+            description: "A longer description.",
+            status: ModStatus.Deprecated,
+            supersededBy: "successor-mod",
+            releases: new ReleaseSource(
+                new[] { new ReleaseHost("github", "owner/repo"), new ReleaseHost("spacedock", "4253") },
+                "github"),
+            gameMax: "2026.8.3.5117",
+            os: new[] { "windows", "linux" },
+            loader: new LoaderRequirement("StarMap", ModVersion.Parse("0.4.5"), ModVersion.Parse("0.5.0")),
+            dependencies: new[]
+            {
+                new ModDependency("cool-lib", ModDependencyKind.Required, ModVersion.Parse("1.0.0")),
+                ModDependency.OfAlternatives(ModDependencyKind.Recommends, new[]
+                {
+                    new ModDependencyAlternative("audio-a", ModVersion.Parse("2.0.0")),
+                    new ModDependencyAlternative("audio-b"),
+                }),
+            },
+            installRootOverride: "UnusualRoot");
+
+    /// <summary>
+    /// A release with every optional field populated, including yanked.
+    /// </summary>
+    public static ModVersionMetadata FullRelease(string modId = "mod-full", string source = "original") =>
+        new(
+            specVersion: 1,
+            modId: modId,
+            version: ModVersion.Parse("1.2.0-beta.1"),
+            releaseStatus: ReleaseStatus.Testing,
+            releaseDate: new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero),
+            gameMin: "2026.7.4.2131",
+            gameMinRevision: 2131,
+            download: new DownloadInfo(
+                "https://example.com/mod.zip", new string('A', 64), 1024, "application/zip",
+                new[] { "https://mirror.example/mod.zip" }),
+            installSizeBytes: 2048,
+            dependencies: new[]
+            {
+                new ModDependency("cool-lib", ModDependencyKind.Required, ModVersion.Parse("1.0.0"), source: MetadataSource.Authored),
+                new ModDependency("kitten-ext", ModDependencyKind.Optional, source: MetadataSource.Derived),
+            },
+            gameMax: "2026.8.3.5117",
+            gameMaxRevision: 5117,
+            os: new[] { "windows" },
+            install: new InstallInfo(modId, derived: true),
+            loader: new LoaderRequirement("StarMap", ModVersion.Parse("0.4.5"), source: MetadataSource.Authored),
+            changelog: "https://example.com/changelog",
+            listing: new ListingSnapshot(
+                "Full Mod",
+                new[] { "Author A" },
+                "Abstract at stamp time.",
+                "MIT",
+                new[] { "parts" },
+                new Dictionary<string, string> { ["forums"] = "https://forums.example/thread/1" },
+                "Description at stamp time."),
+            yanked: true,
+            yankedReason: "Broken above revision 5117.",
+            source: source);
 }

--- a/tests/Borea.Storage.Tests/Mods/MetadataFixtures.cs
+++ b/tests/Borea.Storage.Tests/Mods/MetadataFixtures.cs
@@ -112,5 +112,6 @@ internal static class MetadataFixtures
             SampleLinks(),
             "Description at stamp time."),
         yanked: true,
-        yankedReason: "Broken above revision 5117.");
+        yankedReason: "Broken above revision 5117.",
+        source: "TestSource");
 }

--- a/tests/Borea.Storage.Tests/Mods/ModVersionMetadataMapperTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/ModVersionMetadataMapperTests.cs
@@ -40,6 +40,7 @@ public sealed class ModVersionMetadataMapperTests : IDisposable
         Assert.Equal(original.Changelog, reloaded.Changelog);
         Assert.True(reloaded.Yanked);
         Assert.Equal(original.YankedReason, reloaded.YankedReason);
+        Assert.Equal("TestSource", reloaded.Source);
 
         Assert.Equal(original.Download.Url, reloaded.Download.Url);
         Assert.Equal(original.Download.Sha256, reloaded.Download.Sha256);
@@ -99,6 +100,7 @@ public sealed class ModVersionMetadataMapperTests : IDisposable
         Assert.Null(reloaded.Install);
         Assert.Null(reloaded.Loader);
         Assert.False(reloaded.Yanked);
+        Assert.Null(reloaded.Source);
         Assert.Empty(reloaded.Dependencies);
         Assert.Empty(reloaded.Download.Mirrors);
 
@@ -152,6 +154,33 @@ public sealed class ModVersionMetadataMapperTests : IDisposable
         Assert.Equal(ContentType.ModLoader, reloaded.Type);
         Assert.Null(reloaded.Install);
         Assert.Contains("Type = \"mod-loader\"", tomlText);
+    }
+
+    [Fact]
+    public async Task RoundTrip_UnknownChecksumAndSizes_StayAbsent()
+    {
+        // Facts a source cannot provide persist as absent, never as zero.
+        var original = new ModVersionMetadata(
+            specVersion: 1,
+            modId: "test-mod",
+            version: ModVersion.Parse("1.0.0"),
+            releaseStatus: ReleaseStatus.Stable,
+            releaseDate: MetadataFixtures.SampleTimestamp(),
+            gameMin: "2026.7.4.2131",
+            gameMinRevision: 2131,
+            download: new DownloadInfo("https://example.com/mod.zip", sha256: null, sizeBytes: null, "application/zip"),
+            installSizeBytes: null,
+            dependencies: Array.Empty<ModDependency>());
+
+        var (reloaded, reloadedDto, tomlText) = await RoundTripAsync(original);
+
+        Assert.Null(reloaded.Download.Sha256);
+        Assert.Null(reloaded.Download.SizeBytes);
+        Assert.Null(reloaded.InstallSizeBytes);
+        Assert.False(reloaded.Download.HashMatches(new string('A', 64)));
+        Assert.Null(reloadedDto.Download.Sha256);
+        Assert.DoesNotContain("Sha256", tomlText);
+        Assert.DoesNotContain("SizeBytes", tomlText);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #27, stacked on #33, using the IModRepository shape agreed on #25.

**What changes**

- `IModRepository` splits into listing and release accessors: `GetLatestReleaseAsync` and `GetReleaseAsync` return `ModVersionMetadata` (latest skips yanked), listings stay `ModMetadata`, and releases carry the Borea-internal `Source` tag, persisted by storage.
- `SpaceDockModRepository` maps every KSA listing instead of dropping unparseable ones. The per-field placeholder and unknown decisions are documented at the class level: the license comes from the API, the forums link falls back to the SpaceDock page, `game_min` is the oldest game version any release claims, and an empty dependency list means unknown, not none.
- Facts SpaceDock cannot provide are explicit unknowns: `DownloadInfo.Sha256`/`SizeBytes` and `InstallSizeBytes` are nullable, never faked.
- Version parsing tries full SemVer first, so pre-releases survive and stamp as `testing`; all release accessors resolve through one mappable set, and a 404 answers null.

**Review notes**

Four commits, each a reviewable unit; the head builds clean, 411 tests pass, format is clean.
The search-side "KSP-shaped game version" fallback filter is gone on purpose: it dropped listings, which #27 forbids, and KSA filtering rides on `game_id`.
Deliberate follow-ups, not in here: an unknown marker for dependencies and loader plus a nullable game revision (Core model decisions), and Composite source precedence once the index source exists.
