### PR TITLE
ModVersion: SemVer 2.0.0 ordering and build metadata

### DIFF
--- a/src/Borea.Core/Mods/ModVersion.cs
+++ b/src/Borea.Core/Mods/ModVersion.cs
@@ -1,8 +1,14 @@
-﻿namespace Borea.Core.Mods
+﻿using System.Globalization;
+
+namespace Borea.Core.Mods
 {
     /// <summary>
-    /// A semantic version (Major.Minor.Patch[-PreRelease]) used for mod versioning
-    /// and dependency comparisons throughout Borea.Core.
+    /// A SemVer 2.0.0 version (Major.Minor.Patch[-PreRelease]) used for mod
+    /// versioning and dependency comparisons throughout Borea.Core.
+    /// Build metadata is accepted on parse and discarded: it never takes part
+    /// in precedence, and Borea stores versions in their canonical form.
+    /// Core components are int-sized; pre-release identifiers compare without
+    /// a size limit.
     /// </summary>
     public readonly record struct ModVersion : IComparable<ModVersion>
     {
@@ -11,24 +17,32 @@
         public int Patch { get; }
 
         /// <summary>
-        /// Optional pre-release label (e.g. "beta.1"). A version with a pre-release
-        /// label is considered lower precedence than the same version without one,
-        /// per standard semver rules.
+        /// Optional pre-release label (e.g. "beta.1"). A version with a
+        /// pre-release label ranks below the same version without one.
         /// </summary>
         public string? PreRelease { get; }
 
         public ModVersion(int major, int minor, int patch, string? preRelease = null)
         {
-            if (major < 0 || minor < 0 || patch < 0)
+            if (major < 0)
+                throw new ArgumentOutOfRangeException(nameof(major), "Version components cannot be negative.");
+
+            if (minor < 0)
+                throw new ArgumentOutOfRangeException(nameof(minor), "Version components cannot be negative.");
+
+            if (patch < 0)
+                throw new ArgumentOutOfRangeException(nameof(patch), "Version components cannot be negative.");
+
+            if (!string.IsNullOrEmpty(preRelease) && !IsValidPreRelease(preRelease))
             {
-                throw new ArgumentOutOfRangeException(
-                    nameof(major), "Version components cannot be negative.");
+                throw new ArgumentException(
+                    $"'{preRelease}' is not a valid SemVer pre-release label.", nameof(preRelease));
             }
 
             Major = major;
             Minor = minor;
             Patch = patch;
-            PreRelease = string.IsNullOrWhiteSpace(preRelease) ? null : preRelease;
+            PreRelease = string.IsNullOrEmpty(preRelease) ? null : preRelease;
         }
 
         public static ModVersion Parse(string value)
@@ -50,6 +64,19 @@
                 return false;
             }
 
+            // Build metadata comes after the pre-release, so it is cut first;
+            // a '-' after the '+' belongs to the build, not the pre-release.
+            var plusIndex = value.IndexOf('+');
+            if (plusIndex >= 0)
+            {
+                if (!AreValidIdentifiers(value[(plusIndex + 1)..], allowLeadingZeros: true))
+                {
+                    return false;
+                }
+
+                value = value[..plusIndex];
+            }
+
             var corePart = value;
             string? preRelease = null;
 
@@ -59,7 +86,7 @@
                 corePart = value[..dashIndex];
                 preRelease = value[(dashIndex + 1)..];
 
-                if (string.IsNullOrWhiteSpace(preRelease))
+                if (!IsValidPreRelease(preRelease))
                 {
                     return false;
                 }
@@ -71,20 +98,36 @@
                 return false;
             }
 
-            if (!int.TryParse(parts[0], out var major) ||
-                !int.TryParse(parts[1], out var minor) ||
-                !int.TryParse(parts[2], out var patch))
-            {
-                return false;
-            }
-
-            if (major < 0 || minor < 0 || patch < 0)
+            if (!TryParseComponent(parts[0], out var major) ||
+                !TryParseComponent(parts[1], out var minor) ||
+                !TryParseComponent(parts[2], out var patch))
             {
                 return false;
             }
 
             result = new ModVersion(major, minor, patch, preRelease);
             return true;
+        }
+
+        /// <summary>
+        /// A core component is digits only, without a leading zero, sign, or
+        /// whitespace (SemVer 2.0.0 item 2), and must fit an int.
+        /// </summary>
+        private static bool TryParseComponent(string part, out int value)
+        {
+            value = 0;
+
+            if (!IsNumericIdentifier(part))
+            {
+                return false;
+            }
+
+            if (part.Length > 1 && part[0] == '0')
+            {
+                return false;
+            }
+
+            return int.TryParse(part, NumberStyles.None, CultureInfo.InvariantCulture, out value);
         }
 
         public int CompareTo(ModVersion other)
@@ -103,7 +146,99 @@
             if (PreRelease is null) return 1;
             if (other.PreRelease is null) return -1;
 
-            return string.CompareOrdinal(PreRelease, other.PreRelease);
+            return ComparePreRelease(PreRelease, other.PreRelease);
+        }
+
+        /// <summary>
+        /// SemVer 2.0.0 pre-release precedence: identifier by identifier,
+        /// numeric identifiers compare numerically and rank below
+        /// alphanumeric ones, and with an equal prefix the shorter list ranks
+        /// lower ("beta" before "beta.2", "beta.9" before "beta.10").
+        /// </summary>
+        private static int ComparePreRelease(string left, string right)
+        {
+            var leftIds = left.Split('.');
+            var rightIds = right.Split('.');
+            var shared = Math.Min(leftIds.Length, rightIds.Length);
+
+            for (var i = 0; i < shared; i++)
+            {
+                var l = leftIds[i];
+                var r = rightIds[i];
+                var leftNumeric = IsNumericIdentifier(l);
+                var rightNumeric = IsNumericIdentifier(r);
+
+                int compare;
+                if (leftNumeric && rightNumeric)
+                {
+                    // No leading zeros, so more digits means a larger number.
+                    compare = l.Length != r.Length ? l.Length.CompareTo(r.Length) : string.CompareOrdinal(l, r);
+                }
+                else if (leftNumeric != rightNumeric)
+                {
+                    compare = leftNumeric ? -1 : 1;
+                }
+                else
+                {
+                    compare = string.CompareOrdinal(l, r);
+                }
+
+                if (compare != 0) return compare;
+            }
+
+            return leftIds.Length.CompareTo(rightIds.Length);
+        }
+
+        private static bool IsValidPreRelease(string label) =>
+            AreValidIdentifiers(label, allowLeadingZeros: false);
+
+        /// <summary>
+        /// Dot-separated identifiers of ASCII letters, digits, and hyphens,
+        /// none empty. Numeric pre-release identifiers must not have leading
+        /// zeros, so their numeric comparison stays unambiguous.
+        /// </summary>
+        private static bool AreValidIdentifiers(string label, bool allowLeadingZeros)
+        {
+            if (label.Length == 0)
+            {
+                return false;
+            }
+
+            foreach (var identifier in label.Split('.'))
+            {
+                if (identifier.Length == 0)
+                {
+                    return false;
+                }
+
+                foreach (var c in identifier)
+                {
+                    if (!char.IsAsciiLetterOrDigit(c) && c != '-')
+                    {
+                        return false;
+                    }
+                }
+
+                if (!allowLeadingZeros && identifier.Length > 1 && identifier[0] == '0' && IsNumericIdentifier(identifier))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsNumericIdentifier(string identifier)
+        {
+            foreach (var c in identifier)
+            {
+                if (!char.IsAsciiDigit(c))
+                {
+                    return false;
+                }
+            }
+
+            return identifier.Length > 0;
         }
 
         public static bool operator <(ModVersion left, ModVersion right) => left.CompareTo(right) < 0;

--- a/src/Borea.Network/SpaceDock/SpaceDockModDownloader.cs
+++ b/src/Borea.Network/SpaceDock/SpaceDockModDownloader.cs
@@ -49,8 +49,12 @@ public sealed class SpaceDockModDownloader : IModDownloader
             $"api/mod/{spaceDockId}", JsonOptions, cancellationToken).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"SpaceDock mod '{spaceDockId}' not found.");
 
-        var matchingVersion = dto.Versions.FirstOrDefault(v =>
-            SpaceDockVersionParsing.TryNormalize(v.FriendlyVersion, out var parsed) && parsed.Equals(version))
+        // Rows can normalize to the same version; the default row wins the
+        // tie, matching how SpaceDockModRepository resolves releases.
+        var matchingVersion = dto.Versions
+            .Where(v => SpaceDockVersionParsing.TryNormalize(v.FriendlyVersion, out var parsed) && parsed.Equals(version))
+            .OrderByDescending(v => v.Id == dto.DefaultVersionId)
+            .FirstOrDefault()
             ?? throw new InvalidOperationException($"Version '{version}' not found for SpaceDock mod '{spaceDockId}'.");
 
         using var response = await _httpClient.GetAsync(

--- a/src/Borea.Network/SpaceDock/SpaceDockVersionParsing.cs
+++ b/src/Borea.Network/SpaceDock/SpaceDockVersionParsing.cs
@@ -4,14 +4,18 @@ namespace Borea.Network.SpaceDock;
 
 /// <summary>
 /// Best-effort coercion of SpaceDock's free-text friendly_version into
-/// ModVersion's strict SemVer shape.
+/// ModVersion's strict SemVer shape. Rejection here is pure data loss (the
+/// release row is skipped with no author-facing feedback), so anything that
+/// plausibly names a version is coerced rather than dropped.
 /// </summary>
 internal static class SpaceDockVersionParsing
 {
     /// <summary>
     /// Normalizes a friendly_version into a ModVersion: a leading "v" is
-    /// stripped, full SemVer parses as-is, short numeric forms such as "1.2"
-    /// or "7" are padded with zeros.
+    /// stripped and full SemVer parses as-is. Everything else is coerced:
+    /// build metadata is cut, short numeric cores such as "1.2" or "7" are
+    /// padded with zeros, and a pre-release label is sanitized into the
+    /// SemVer identifier charset.
     /// </summary>
     public static bool TryNormalize(string raw, out ModVersion version)
     {
@@ -26,27 +30,72 @@ internal static class SpaceDockVersionParsing
         if (ModVersion.TryParse(trimmed, out version))
             return true;
 
-        // Carry a pre-release label through the padding branches, so
-        // "1.2-beta" does not pose as a stable release.
+        // Build metadata is cut before the label split, because a '-' after
+        // the '+' belongs to the build, not the pre-release.
+        var plus = trimmed.IndexOf('+');
+        if (plus >= 0)
+            trimmed = trimmed[..plus];
+
         var core = trimmed;
-        var suffix = string.Empty;
+        string? label = null;
         var dash = trimmed.IndexOf('-');
         if (dash >= 0)
         {
             core = trimmed[..dash];
-            suffix = trimmed[dash..];
+            label = trimmed[(dash + 1)..];
         }
 
+        if (!TryCoerceCore(core, out var major, out var minor, out var patch))
+            return false;
+
+        version = new ModVersion(major, minor, patch, label is null ? null : SanitizeLabel(label));
+        return true;
+    }
+
+    private static bool TryCoerceCore(string core, out int major, out int minor, out int patch)
+    {
+        major = 0;
+        minor = 0;
+        patch = 0;
+
         var parts = core.Split('.');
-        if (parts.Length >= 3 && parts.Take(3).All(p => int.TryParse(p, out _)))
-            return ModVersion.TryParse($"{parts[0]}.{parts[1]}.{parts[2]}{suffix}", out version);
+        if (parts.Length >= 3)
+            return int.TryParse(parts[0], out major) && int.TryParse(parts[1], out minor) && int.TryParse(parts[2], out patch);
 
-        if (parts.Length == 2 && parts.All(p => int.TryParse(p, out _)))
-            return ModVersion.TryParse($"{parts[0]}.{parts[1]}.0{suffix}", out version);
+        if (parts.Length == 2)
+            return int.TryParse(parts[0], out major) && int.TryParse(parts[1], out minor);
 
-        if (parts.Length == 1 && int.TryParse(parts[0], out _))
-            return ModVersion.TryParse($"{parts[0]}.0.0{suffix}", out version);
+        return int.TryParse(parts[0], out major);
+    }
 
-        return false;
+    /// <summary>
+    /// Coerces a free-text label into valid SemVer identifiers: characters
+    /// outside the charset become hyphens, numeric identifiers lose leading
+    /// zeros, and empty identifiers are dropped. Null when nothing survives.
+    /// </summary>
+    private static string? SanitizeLabel(string label)
+    {
+        var identifiers = new List<string>();
+
+        foreach (var identifier in label.Split('.'))
+        {
+            var cleaned = new string(identifier.Trim()
+                .Select(c => char.IsAsciiLetterOrDigit(c) || c == '-' ? c : '-')
+                .ToArray());
+
+            if (cleaned.Length == 0)
+                continue;
+
+            if (cleaned.All(char.IsAsciiDigit))
+            {
+                cleaned = cleaned.TrimStart('0');
+                if (cleaned.Length == 0)
+                    cleaned = "0";
+            }
+
+            identifiers.Add(cleaned);
+        }
+
+        return identifiers.Count == 0 ? null : string.Join('.', identifiers);
     }
 }

--- a/tests/Borea.Core.Tests/Mods/ModVersionTests.cs
+++ b/tests/Borea.Core.Tests/Mods/ModVersionTests.cs
@@ -8,7 +8,10 @@ public sealed class ModVersionTests
     [InlineData("1.2.3", 1, 2, 3, null)]
     [InlineData("0.0.0", 0, 0, 0, null)]
     [InlineData("1.2.3-beta.1", 1, 2, 3, "beta.1")]
-    [InlineData("10.20.30-rc-1", 10, 20, 30, "rc-1")] // First '-' only splits the core; remainder (including further dashes) is the pre-release label verbatim.
+    [InlineData("10.20.30-rc-1", 10, 20, 30, "rc-1")] // Hyphens are valid inside a pre-release identifier.
+    [InlineData("1.0.0+build", 1, 0, 0, null)] // Build metadata is accepted and discarded.
+    [InlineData("1.0.0-beta+exp.sha-5114f85", 1, 0, 0, "beta")] // Build metadata never joins the pre-release.
+    [InlineData("1.0.0+0.01", 1, 0, 0, null)] // Build identifiers may have leading zeros, unlike pre-release ones.
     public void TryParse_ValidInput_ProducesExpectedComponents(string input, int major, int minor, int patch, string? preRelease)
     {
         var success = ModVersion.TryParse(input, out var result);
@@ -28,7 +31,16 @@ public sealed class ModVersionTests
     [InlineData("1.2.3.4")]       // Too many components.
     [InlineData("a.b.c")]         // Non-numeric.
     [InlineData("1.2.")]          // Trailing dot, empty component.
+    [InlineData("01.2.3")]        // Leading zero in a core component.
+    [InlineData("1.0.01")]        // Same, in the patch position.
+    [InlineData(" 1.2.3")]        // Whitespace inside the core.
+    [InlineData("1.2.3 ")]
     [InlineData("1.2.3-")]        // Dash with no pre-release text.
+    [InlineData("1.2.3+")]        // Plus with no build metadata.
+    [InlineData("1.2.3+bad_meta")] // Underscore is outside the identifier charset.
+    [InlineData("1.2.3-beta..1")] // Empty pre-release identifier.
+    [InlineData("1.2.3-01")]      // Numeric identifier with a leading zero.
+    [InlineData("1.2.3- hotfix")] // Free text is not a pre-release label.
     public void TryParse_InvalidInput_ReturnsFalse(string? input)
     {
         var success = ModVersion.TryParse(input, out _);
@@ -51,20 +63,32 @@ public sealed class ModVersionTests
     }
 
     [Theory]
-    [InlineData(-1, 0, 0)]
-    [InlineData(0, -1, 0)]
-    [InlineData(0, 0, -1)]
-    public void Constructor_NegativeComponent_ThrowsArgumentOutOfRangeException(int major, int minor, int patch)
+    [InlineData(-1, 0, 0, "major")]
+    [InlineData(0, -1, 0, "minor")]
+    [InlineData(0, 0, -1, "patch")]
+    public void Constructor_NegativeComponent_ThrowsNamingTheComponent(int major, int minor, int patch, string paramName)
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new ModVersion(major, minor, patch));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new ModVersion(major, minor, patch));
+
+        Assert.Equal(paramName, exception.ParamName);
     }
 
     [Fact]
-    public void Constructor_WhitespacePreRelease_IsTreatedAsNull()
+    public void Constructor_EmptyPreRelease_IsTreatedAsNull()
     {
-        var version = new ModVersion(1, 0, 0, "   ");
+        var version = new ModVersion(1, 0, 0, "");
 
         Assert.Null(version.PreRelease);
+    }
+
+    [Theory]
+    [InlineData("   ")]
+    [InlineData(" hotfix")]
+    [InlineData("beta..1")]
+    [InlineData("01")]
+    public void Constructor_InvalidPreRelease_ThrowsArgumentException(string preRelease)
+    {
+        Assert.Throws<ArgumentException>(() => new ModVersion(1, 0, 0, preRelease));
     }
 
     [Theory]
@@ -72,7 +96,10 @@ public sealed class ModVersionTests
     [InlineData("1.0.0", "1.1.0")] // Minor bump.
     [InlineData("1.0.0", "2.0.0")] // Major bump.
     [InlineData("1.0.0-beta", "1.0.0")] // No pre-release outranks any pre-release.
-    [InlineData("1.0.0-alpha", "1.0.0-beta")] // Pre-release labels compare ordinally.
+    [InlineData("1.0.0-alpha", "1.0.0-beta")] // Alphanumeric identifiers compare ordinally.
+    [InlineData("1.0.0-beta.9", "1.0.0-beta.10")] // Numeric identifiers compare numerically.
+    [InlineData("1.0.0-1", "1.0.0-alpha")] // Numeric ranks below alphanumeric.
+    [InlineData("1.0.0-beta", "1.0.0-beta.2")] // Equal prefix: the shorter list ranks lower.
     public void CompareTo_LesserVersionComesFirst(string lesser, string greater)
     {
         var left = ModVersion.Parse(lesser);
@@ -101,11 +128,52 @@ public sealed class ModVersionTests
     [Theory]
     [InlineData("1.2.3", "1.2.3")]
     [InlineData("1.2.3-beta.1", "1.2.3-beta.1")]
+    [InlineData("1.0.0-beta+exp", "1.0.0-beta")] // Build metadata is gone after the first parse.
     public void ToString_RoundTripsThroughParse(string input, string expected)
     {
         var version = ModVersion.Parse(input);
 
         Assert.Equal(expected, version.ToString());
+        Assert.Equal(version, ModVersion.Parse(version.ToString()));
+    }
+
+    [Fact]
+    public void CompareTo_FollowsTheSemVerOrderingTable()
+    {
+        // The example chain from the SemVer 2.0.0 spec, item 11.
+        var ordered = new[]
+        {
+            "1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.beta",
+            "1.0.0-beta", "1.0.0-beta.2", "1.0.0-beta.11", "1.0.0-rc.1", "1.0.0",
+        };
+
+        for (var i = 0; i < ordered.Length - 1; i++)
+        {
+            Assert.True(
+                ModVersion.Parse(ordered[i]) < ModVersion.Parse(ordered[i + 1]),
+                $"{ordered[i]} should rank below {ordered[i + 1]}");
+        }
+    }
+
+    [Fact]
+    public void CompareTo_IgnoresBuildMetadata()
+    {
+        var plain = ModVersion.Parse("1.0.0-beta");
+        var withBuild = ModVersion.Parse("1.0.0-beta+exp.sha-5114f85");
+
+        Assert.Equal(0, plain.CompareTo(withBuild));
+        Assert.Equal(plain, withBuild);
+    }
+
+    [Fact]
+    public void CompareTo_LargeNumericIdentifiers_CompareNumerically()
+    {
+        // Timestamp-sized identifiers exceed int range; length-then-ordinal
+        // comparison must still order them correctly.
+        var older = ModVersion.Parse("1.0.0-alpha.20250101120000");
+        var newer = ModVersion.Parse("1.0.0-alpha.20260101120000");
+
+        Assert.True(older < newer);
     }
 
     [Fact]

--- a/tests/Borea.Network.Tests/SpaceDock/SpaceDockModRepositoryTests.cs
+++ b/tests/Borea.Network.Tests/SpaceDock/SpaceDockModRepositoryTests.cs
@@ -422,6 +422,12 @@ public sealed class SpaceDockModRepositoryTests
     [InlineData("1.2.3-rc.1", "1.2.3-rc.1")]
     [InlineData("1.2.3.4-rc1", "1.2.3-rc1")]
     [InlineData("1.2-beta", "1.2.0-beta")]
+    [InlineData("1.2.3-rc.01", "1.2.3-rc.1")] // Leading zero coerced away, not dropped.
+    [InlineData("1.0-beta_2", "1.0.0-beta-2")] // Out-of-charset characters become hyphens.
+    [InlineData("1.4.0-alpha (hotfix)", "1.4.0-alpha--hotfix-")] // Free text survives as a label.
+    [InlineData("1.2.3.4+build-1", "1.2.3")] // The '+' cut precedes the label split, so build metadata is never a pre-release.
+    [InlineData("1.2+build", "1.2.0")]
+    [InlineData("01.2.3", "1.2.3")] // Core leading zeros normalize away in coercion.
     public async Task VersionNormalization_HandlesRealWorldFormats(string friendlyVersion, string expectedNormalized)
     {
         var json = $$"""


### PR DESCRIPTION
Closes #30, stacked on #35.

**What changes**

- `ModVersion.CompareTo` resolves pre-release precedence per SemVer 2.0.0 item 11: numeric identifiers compare numerically (`beta.9` < `beta.10`) and rank below alphanumeric ones, and with an equal prefix the shorter list ranks lower.
- `TryParse` accepts and discards build metadata (`1.0.0+build`, `1.0.0-beta+exp`) and validates labels per the spec grammar: identifier charset, no empty identifiers, no leading zeros on numeric ones. Core components are digits-only and culture-independent.
- `SpaceDockVersionParsing` becomes a real coercion layer, because rejection there is silent data loss: free-text labels are sanitized into the identifier charset instead of dropping the release, and the `+` cut precedes the label split so build metadata can never pose as a pre-release.
- `SpaceDockModDownloader` breaks version-collision ties toward the default row, matching the repository, so the shown release and the downloaded archive cannot diverge.
