### PR TITLE
Carry the install descriptor from RFC 0035 in InstallInfo

### DIFF
--- a/src/Borea.Core/Mods/InstallAnchor.cs
+++ b/src/Borea.Core/Mods/InstallAnchor.cs
@@ -1,0 +1,23 @@
+namespace Borea.Core.Mods;
+
+/// <summary>
+/// Where installed content is written, per RFC 0035. A manager resolves the
+/// anchor at install time, so the metadata never carries an absolute path.
+/// </summary>
+public enum InstallAnchor
+{
+    /// <summary>The game's mods folder. Moves with the profile under an instance path override.</summary>
+    Mods = 0,
+
+    /// <summary>The game's user data root: saves, vehicles, settings, manifest.</summary>
+    UserData = 1,
+
+    /// <summary>The directory holding the game executable.</summary>
+    GameRoot = 2,
+
+    /// <summary>A directory of the manager's own choosing, outside the other three.</summary>
+    Standalone = 3,
+
+    /// <summary>A value this client version does not know. A manager must not guess.</summary>
+    Unknown = 4,
+}

--- a/src/Borea.Core/Mods/InstallInfo.cs
+++ b/src/Borea.Core/Mods/InstallInfo.cs
@@ -1,31 +1,56 @@
 ﻿namespace Borea.Core.Mods;
 
 /// <summary>
-/// Which directory inside the archive becomes the installed mod folder.
+/// The install directive stamped into a release file (RFC 0031, extended by RFC 0035).
 /// </summary>
 public sealed class InstallInfo
 {
     /// <summary>
-    /// The directory inside the archive whose contents become the installed folder.
+    /// The directory inside the archive that becomes the installed content.
+    /// Null means the archive root, never "unknown".
     /// </summary>
-    public string Root { get; }
+    public string? Root { get; }
 
-    /// <summary>
-    /// True when tooling derived the root from the standard archive layout.
-    /// </summary>
+    /// <summary>True when tooling derived the root from the standard archive layout.</summary>
     public bool Derived { get; }
 
-    public InstallInfo(string root, bool derived)
+    /// <summary>
+    /// The anchor the content is written to. Null means the type default: a mod
+    /// goes into the mods folder, a mod loader is undescribed.
+    /// </summary>
+    public InstallAnchor? Target { get; }
+
+    /// <summary>The path below the anchor. Null means the anchor itself.</summary>
+    public string? Path { get; }
+
+    public InstallInfo(string? root, bool derived, InstallAnchor? target = null, string? path = null)
     {
-        if (string.IsNullOrWhiteSpace(root))
-            throw new ArgumentException("Install root cannot be empty.", nameof(root));
-
-        // Platform-independent on purpose: the archive is built and consumed
-        // on different systems, so Windows-rooted forms are rejected everywhere.
-        if (root.StartsWith('/') || root.StartsWith('\\') || root.Contains(':') || root.Split('/', '\\').Any(s => s == ".."))
-            throw new ArgumentException("Install root must be a relative path inside the archive.", nameof(root));
-
-        Root = root;
+        Root = Contained(root, nameof(root));
         Derived = derived;
+        Target = target;
+        Path = Contained(path, nameof(path));
+    }
+
+    /// <summary>
+    /// The value as a relative, '/' separated path that stays inside its anchor
+    /// (RFC 0035 rules 1 and 2). Null passes through, empty does not. A backslash
+    /// is rejected rather than read as a separator, the way the index stamps it.
+    /// </summary>
+    private static string? Contained(string? value, string paramName)
+    {
+        if (value is null)
+            return null;
+
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("A stated path cannot be empty, leave it absent instead.", paramName);
+
+        if (value.StartsWith('/') || value.StartsWith('~') || value.Contains('\\') ||
+            value.Contains(':') || value.Split('/').Any(segment => segment == ".."))
+        {
+            throw new ArgumentException(
+                "A path must be relative, '/' separated, and must stay inside its anchor.", paramName);
+        }
+
+        return value;
     }
 }

--- a/src/Borea.Core/Mods/ModVersionMetadata.cs
+++ b/src/Borea.Core/Mods/ModVersionMetadata.cs
@@ -86,7 +86,7 @@ public sealed class ModVersionMetadata
     public long? InstallSizeBytes { get; }
 
     /// <summary>
-    /// The install directive. Null for content that installs by its own mechanism.
+    /// The install directive. Null leaves the type default in force.
     /// </summary>
     public InstallInfo? Install { get; }
 
@@ -154,9 +154,6 @@ public sealed class ModVersionMetadata
 
         if (loader is not null && type != ContentType.Mod)
             throw new ArgumentException("Only a mod can declare a loader requirement.", nameof(loader));
-
-        if (install is not null && type == ContentType.ModLoader)
-            throw new ArgumentException("A mod loader installs by its own mechanism and carries no install directive.", nameof(install));
 
         if (string.IsNullOrWhiteSpace(versionScheme))
             throw new ArgumentException("Version scheme cannot be null or whitespace.", nameof(versionScheme));

--- a/tests/Borea.Core.Tests/Mods/ModVersionMetadataTests.cs
+++ b/tests/Borea.Core.Tests/Mods/ModVersionMetadataTests.cs
@@ -92,9 +92,15 @@ public sealed class ModVersionMetadataTests
     }
 
     [Fact]
-    public void Constructor_InstallOnModLoader_ThrowsArgumentException()
+    public void Constructor_InstallOnModLoader_IsAccepted()
     {
-        Assert.Throws<ArgumentException>(() => Build(type: ContentType.ModLoader, install: new InstallInfo("test-mod", derived: true)));
+        // The shape the index stamps for StarMap.
+        var install = new InstallInfo(null, derived: true, InstallAnchor.Standalone);
+
+        var metadata = Build(type: ContentType.ModLoader, install: install);
+
+        Assert.Null(metadata.Install!.Root);
+        Assert.Equal(InstallAnchor.Standalone, metadata.Install.Target);
     }
 
     [Fact]

--- a/tests/Borea.Core.Tests/Mods/ReleaseFileTypesTests.cs
+++ b/tests/Borea.Core.Tests/Mods/ReleaseFileTypesTests.cs
@@ -96,15 +96,98 @@ public sealed class InstallInfoTests
         Assert.True(install.Derived);
     }
 
+    [Fact]
+    public void Constructor_AbsentTargetAndPath_LeaveTheTypeDefaultInForce()
+    {
+        var install = new InstallInfo("MyMod", derived: true);
+
+        Assert.Null(install.Target);
+        Assert.Null(install.Path);
+    }
+
+    [Fact]
+    public void Constructor_AbsentRoot_MeansTheArchiveRoot()
+    {
+        var install = new InstallInfo(null, derived: true, InstallAnchor.Standalone);
+
+        Assert.Null(install.Root);
+        Assert.Equal(InstallAnchor.Standalone, install.Target);
+    }
+
+    [Fact]
+    public void Constructor_TargetAndPath_AreCarried()
+    {
+        var install = new InstallInfo("build/Mod", derived: false, InstallAnchor.UserData, "Vehicles");
+
+        Assert.Equal("build/Mod", install.Root);
+        Assert.Equal(InstallAnchor.UserData, install.Target);
+        Assert.Equal("Vehicles", install.Path);
+    }
+
+    [Fact]
+    public void Constructor_AnchorThisBuildDoesNotKnow_IsCarriedRatherThanRejected()
+    {
+        // The entry still has to survive; only the guess is forbidden.
+        var install = new InstallInfo("MyMod", derived: true, InstallAnchor.Unknown);
+
+        Assert.Equal(InstallAnchor.Unknown, install.Target);
+    }
+
     [Theory]
     [InlineData("../escape")]
     [InlineData("nested/../../escape")]
     [InlineData("/absolute")]
     [InlineData("\\absolute")]
+    [InlineData("~/home")]
     [InlineData("C:\\Windows")]
     [InlineData("C:relative")]
+    // A separator on Windows, a directory name on Linux, so RFC 0035 rule 2
+    // fixes it to '/'.
+    [InlineData("build\\Mod")]
     public void Constructor_EscapingOrRootedRoot_ThrowsArgumentException(string root)
     {
         Assert.Throws<ArgumentException>(() => new InstallInfo(root, derived: false));
+    }
+
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("nested/../../escape")]
+    [InlineData("/absolute")]
+    [InlineData("\\absolute")]
+    [InlineData("~/home")]
+    [InlineData("C:\\Windows")]
+    [InlineData("C:relative")]
+    [InlineData("build\\Mod")]
+    public void Constructor_EscapingOrRootedPath_ThrowsArgumentException(string path)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new InstallInfo("MyMod", derived: false, InstallAnchor.UserData, path));
+    }
+
+    [Fact]
+    public void Constructor_NestedRelativeRoot_IsAccepted()
+    {
+        // The one archive layout RFC 0031 needs an authored root for.
+        var install = new InstallInfo("build/AdvancedFlightComputer", derived: false);
+
+        Assert.Equal("build/AdvancedFlightComputer", install.Root);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_EmptyRoot_ThrowsArgumentException(string root)
+    {
+        // Absent means the archive root; empty is a stamp that lost its value.
+        Assert.Throws<ArgumentException>(() => new InstallInfo(root, derived: false));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_EmptyPath_ThrowsArgumentException(string path)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new InstallInfo("MyMod", derived: false, InstallAnchor.UserData, path));
     }
 }


### PR DESCRIPTION
Part of #41 .

The index already stamps `"install": { "derived": true, "target": "standalone" }` for StarMap, and Borea rejects that shape twice over: `ModVersionMetadata` throws for an install object on a `mod-loader`, and `InstallInfo` requires a non-empty `Root` the shape does not have.

`Root` becomes nullable, where absent means the archive root per RFC 0035 rule 9, `InstallInfo` gains the stamped `Target` anchor and `Path`, and one containment helper now guards both paths, gaining the leading `~` case and rejecting a backslash the way the index does when it stamps.

Two commits, one per concern. `Borea.Storage` carries one nullability warning until the storage half lands
