### PR TITLE
Persist the install target and path

### DIFF
--- a/src/Borea.Storage/Mods/InstallInfoDto.cs
+++ b/src/Borea.Storage/Mods/InstallInfoDto.cs
@@ -5,6 +5,14 @@
 /// </summary>
 public sealed class InstallInfoDto
 {
-    public string Root { get; set; } = string.Empty;
+    /// <summary>Null means the archive root.</summary>
+    public string? Root { get; set; }
+
     public bool Derived { get; set; }
+
+    /// <summary>The anchor, lowercase. Null means the type default.</summary>
+    public string? Target { get; set; }
+
+    /// <summary>Null means the anchor itself.</summary>
+    public string? Path { get; set; }
 }

--- a/src/Borea.Storage/Mods/InstallInfoMapper.cs
+++ b/src/Borea.Storage/Mods/InstallInfoMapper.cs
@@ -8,7 +8,13 @@ public static class InstallInfoMapper
     {
         Root = install.Root,
         Derived = install.Derived,
+        Target = install.Target is { } target ? MetadataEnumMapper.ToDto(target) : null,
+        Path = install.Path,
     };
 
-    public static InstallInfo FromDto(InstallInfoDto dto) => new(dto.Root, dto.Derived);
+    public static InstallInfo FromDto(InstallInfoDto dto) => new(
+        dto.Root,
+        dto.Derived,
+        dto.Target is null ? null : MetadataEnumMapper.ParseAnchor(dto.Target),
+        dto.Path);
 }

--- a/src/Borea.Storage/Mods/MetadataEnumMapper.cs
+++ b/src/Borea.Storage/Mods/MetadataEnumMapper.cs
@@ -78,6 +78,24 @@ public static class MetadataEnumMapper
         _ => Core.Dependencies.ModDependencyKind.Unknown,
     };
 
+    public static string ToDto(InstallAnchor anchor) => anchor switch
+    {
+        InstallAnchor.Mods => "mods",
+        InstallAnchor.UserData => "user-data",
+        InstallAnchor.GameRoot => "game-root",
+        InstallAnchor.Standalone => "standalone",
+        _ => "unknown",
+    };
+
+    public static InstallAnchor ParseAnchor(string value) => value.ToLowerInvariant() switch
+    {
+        "mods" => InstallAnchor.Mods,
+        "user-data" => InstallAnchor.UserData,
+        "game-root" => InstallAnchor.GameRoot,
+        "standalone" => InstallAnchor.Standalone,
+        _ => InstallAnchor.Unknown,
+    };
+
     public static string? ToDto(MetadataSource? source) => source switch
     {
         null => null,

--- a/tests/Borea.Storage.Tests/Mods/MetadataEnumMapperTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/MetadataEnumMapperTests.cs
@@ -52,6 +52,24 @@ public sealed class MetadataEnumMapperTests
     }
 
     [Theory]
+    [InlineData(InstallAnchor.Mods, "mods")]
+    [InlineData(InstallAnchor.UserData, "user-data")]
+    [InlineData(InstallAnchor.GameRoot, "game-root")]
+    [InlineData(InstallAnchor.Standalone, "standalone")]
+    [InlineData(InstallAnchor.Unknown, "unknown")]
+    public void InstallAnchor_WritesTheFormatSpelling(InstallAnchor anchor, string expected)
+    {
+        Assert.Equal(expected, MetadataEnumMapper.ToDto(anchor));
+        Assert.Equal(anchor, MetadataEnumMapper.ParseAnchor(expected));
+    }
+
+    [Fact]
+    public void InstallAnchor_AnchorAFutureRfcAddsParsesToUnknown()
+    {
+        Assert.Equal(InstallAnchor.Unknown, MetadataEnumMapper.ParseAnchor("cache-dir"));
+    }
+
+    [Theory]
     [InlineData(MetadataSource.Authored, "authored")]
     [InlineData(MetadataSource.Derived, "derived")]
     [InlineData(MetadataSource.Unknown, "unknown")]

--- a/tests/Borea.Storage.Tests/Mods/ModVersionMetadataMapperTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/ModVersionMetadataMapperTests.cs
@@ -157,6 +157,72 @@ public sealed class ModVersionMetadataMapperTests : IDisposable
     }
 
     [Fact]
+    public async Task RoundTrip_ModInstallShape_KeepsTheDerivedRootAndNoTarget()
+    {
+        // releases/AdvancedFlightComputer/0.7.2.json, as the index stamps it.
+        var original = new ModVersionMetadata(
+            specVersion: 1,
+            modId: "AdvancedFlightComputer",
+            version: ModVersion.Parse("0.7.2"),
+            releaseStatus: ReleaseStatus.Stable,
+            releaseDate: MetadataFixtures.SampleTimestamp(),
+            gameMin: "2026.8.3.5117",
+            gameMinRevision: 5117,
+            download: MetadataFixtures.SampleDownload(),
+            installSizeBytes: 326889,
+            dependencies: Array.Empty<ModDependency>(),
+            install: new InstallInfo("AdvancedFlightComputer", derived: true));
+
+        var (reloaded, _, tomlText) = await RoundTripAsync(original);
+
+        Assert.Equal("AdvancedFlightComputer", reloaded.Install!.Root);
+        Assert.True(reloaded.Install.Derived);
+        Assert.Null(reloaded.Install.Target);
+        Assert.Null(reloaded.Install.Path);
+        Assert.DoesNotContain("Target", tomlText);
+    }
+
+    [Fact]
+    public async Task RoundTrip_LoaderInstallShape_KeepsTheStandaloneTargetWithoutARoot()
+    {
+        // releases/StarMap/0.4.6.json, as the index stamps it.
+        var original = new ModVersionMetadata(
+            specVersion: 1,
+            modId: "StarMap",
+            version: ModVersion.Parse("0.4.6"),
+            releaseStatus: ReleaseStatus.Stable,
+            releaseDate: MetadataFixtures.SampleTimestamp(),
+            gameMin: "2026.8.3.5117",
+            gameMinRevision: 5117,
+            download: MetadataFixtures.SampleDownload(),
+            installSizeBytes: 2549644,
+            dependencies: Array.Empty<ModDependency>(),
+            type: ContentType.ModLoader,
+            install: new InstallInfo(null, derived: true, InstallAnchor.Standalone));
+
+        var (reloaded, reloadedDto, tomlText) = await RoundTripAsync(original);
+
+        Assert.Equal(ContentType.ModLoader, reloaded.Type);
+        Assert.Null(reloaded.Install!.Root);
+        Assert.True(reloaded.Install.Derived);
+        Assert.Equal(InstallAnchor.Standalone, reloaded.Install.Target);
+        Assert.Null(reloadedDto.Install!.Root);
+        Assert.Contains("Target = \"standalone\"", tomlText);
+        Assert.DoesNotContain("Root", tomlText);
+    }
+
+    [Fact]
+    public void FromDto_AnchorThisBuildDoesNotKnow_ParsesToUnknown()
+    {
+        var dto = ModVersionMetadataMapper.ToDto(MetadataFixtures.FullRelease());
+        dto.Install!.Target = "cache-dir";
+
+        var reloaded = ModVersionMetadataMapper.FromDto(dto);
+
+        Assert.Equal(InstallAnchor.Unknown, reloaded.Install!.Target);
+    }
+
+    [Fact]
     public async Task RoundTrip_UnknownChecksumAndSizes_StayAbsent()
     {
         // Facts a source cannot provide persist as absent, never as zero.


### PR DESCRIPTION
Closes #41. Stacked on #45, review that one first.

The storage half: the DTO and the mapper carry `Target` and `Path`, `Root` is nullable there too, and the anchor maps through `MetadataEnumMapper` like the five enums already there, so a token this build does not know parses to `Unknown` instead of throwing.
