### PR TITLE
Name the highest spec version Borea implements

### DIFF
--- a/src/Borea.Core/Mods/SpecVersions.cs
+++ b/src/Borea.Core/Mods/SpecVersions.cs
@@ -1,0 +1,15 @@
+namespace Borea.Core.Mods;
+
+public static class SpecVersions
+{
+    /// <summary>
+    /// The highest spec version this build reads, and the one it stamps on
+    /// documents it synthesizes itself.
+    /// </summary>
+    public const int Highest = 1;
+
+    /// <summary>
+    /// Whether the document is from a newer format than this build implements.
+    /// </summary>
+    public static bool IsAboveHighest(int specVersion) => specVersion > Highest;
+}

--- a/src/Borea.Network/SpaceDock/SpaceDockModRepository .cs
+++ b/src/Borea.Network/SpaceDock/SpaceDockModRepository .cs
@@ -181,7 +181,7 @@ public sealed class SpaceDockModRepository : IModRepository
                 : "unknown");
 
         return new ModMetadata(
-            specVersion: 1,
+            specVersion: SpecVersions.Highest,
             modId: modId,
             source: SourceName,
             name: string.IsNullOrWhiteSpace(dto.Name) ? $"SpaceDock mod {dto.Id}" : dto.Name,
@@ -235,7 +235,7 @@ public sealed class SpaceDockModRepository : IModRepository
             contentType: "application/zip");
 
         release = new ModVersionMetadata(
-            specVersion: 1,
+            specVersion: SpecVersions.Highest,
             modId: dto.Id.ToString(CultureInfo.InvariantCulture),
             version: modVersion,
             releaseStatus: modVersion.PreRelease is null ? ReleaseStatus.Stable : ReleaseStatus.Testing,

--- a/src/Borea.Storage/Mods/ModMetadataMapper.cs
+++ b/src/Borea.Storage/Mods/ModMetadataMapper.cs
@@ -30,8 +30,10 @@ public static class ModMetadataMapper
 
     public static ModMetadata FromDto(ModMetadataDto dto)
     {
-        if (dto.SpecVersion == 0)
-            throw new FormatException("The metadata file predates the metadata model (no spec version).");
+        if (dto.SpecVersion < 1)
+            throw new FormatException(dto.SpecVersion == 0
+                ? "The metadata file predates the metadata model (no spec version)."
+                : $"The metadata file carries an invalid spec version ({dto.SpecVersion}).");
 
         return new ModMetadata(
         specVersion: dto.SpecVersion,

--- a/src/Borea.Storage/Mods/ModVersionMetadataMapper.cs
+++ b/src/Borea.Storage/Mods/ModVersionMetadataMapper.cs
@@ -32,8 +32,10 @@ public static class ModVersionMetadataMapper
 
     public static ModVersionMetadata FromDto(ModVersionMetadataDto dto)
     {
-        if (dto.SpecVersion == 0)
-            throw new FormatException("The release file predates the metadata model (no spec version).");
+        if (dto.SpecVersion < 1)
+            throw new FormatException(dto.SpecVersion == 0
+                ? "The release file predates the metadata model (no spec version)."
+                : $"The release file carries an invalid spec version ({dto.SpecVersion}).");
 
         return new ModVersionMetadata(
         specVersion: dto.SpecVersion,

--- a/tests/Borea.Core.Tests/Mods/ModMetadataTests.cs
+++ b/tests/Borea.Core.Tests/Mods/ModMetadataTests.cs
@@ -14,9 +14,10 @@ public sealed class ModMetadataTests
         IReadOnlyDictionary<string, string>? links = null,
         ContentType type = ContentType.Mod,
         LoaderRequirement? loader = null,
-        string? supersededBy = null) =>
+        string? supersededBy = null,
+        int specVersion = SpecVersions.Highest) =>
         new(
-            specVersion: 1,
+            specVersion: specVersion,
             modId: modId,
             source: source,
             name: name,
@@ -110,5 +111,21 @@ public sealed class ModMetadataTests
     public void Constructor_InvalidSupersededBy_ThrowsArgumentException()
     {
         Assert.Throws<ArgumentException>(() => Build(supersededBy: "not a valid id"));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_SpecVersionBelowOne_ThrowsArgumentOutOfRangeException(int specVersion)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Build(specVersion: specVersion));
+    }
+
+    [Fact]
+    public void Constructor_SpecVersionAboveHighest_IsAccepted()
+    {
+        var metadata = Build(specVersion: SpecVersions.Highest + 1);
+
+        Assert.True(SpecVersions.IsAboveHighest(metadata.SpecVersion));
     }
 }

--- a/tests/Borea.Core.Tests/Mods/ModVersionMetadataTests.cs
+++ b/tests/Borea.Core.Tests/Mods/ModVersionMetadataTests.cs
@@ -14,9 +14,10 @@ public sealed class ModVersionMetadataTests
         ContentType type = ContentType.Mod,
         InstallInfo? install = null,
         LoaderRequirement? loader = null,
-        IReadOnlyList<ModDependency>? dependencies = null) =>
+        IReadOnlyList<ModDependency>? dependencies = null,
+        int specVersion = SpecVersions.Highest) =>
         new(
-            specVersion: 1,
+            specVersion: specVersion,
             modId: "test-mod",
             version: ModVersion.Parse("1.0.0"),
             releaseStatus: ReleaseStatus.Stable,
@@ -109,5 +110,21 @@ public sealed class ModVersionMetadataTests
         var loader = new LoaderRequirement("StarMap", ModVersion.Parse("0.4.5"));
 
         Assert.Throws<ArgumentException>(() => Build(type: ContentType.ModLoader, loader: loader));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_SpecVersionBelowOne_ThrowsArgumentOutOfRangeException(int specVersion)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Build(specVersion: specVersion));
+    }
+
+    [Fact]
+    public void Constructor_SpecVersionAboveHighest_IsAccepted()
+    {
+        var release = Build(specVersion: SpecVersions.Highest + 1);
+
+        Assert.True(SpecVersions.IsAboveHighest(release.SpecVersion));
     }
 }

--- a/tests/Borea.Core.Tests/Mods/SpecVersionsTests.cs
+++ b/tests/Borea.Core.Tests/Mods/SpecVersionsTests.cs
@@ -1,0 +1,36 @@
+using Borea.Core.Mods;
+
+namespace Borea.Core.Tests.Mods;
+
+public sealed class SpecVersionsTests
+{
+    [Fact]
+    public void Highest_IsTheOneVersionTheFormatDefines()
+    {
+        Assert.Equal(1, SpecVersions.Highest);
+    }
+
+    [Fact]
+    public void IsAboveHighest_AtHighest_ReturnsFalse()
+    {
+        Assert.False(SpecVersions.IsAboveHighest(SpecVersions.Highest));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void IsAboveHighest_NonPositive_ReturnsFalse(int specVersion)
+    {
+        Assert.False(SpecVersions.IsAboveHighest(specVersion));
+    }
+
+    [Theory]
+    [InlineData(SpecVersions.Highest + 1)]
+    [InlineData(SpecVersions.Highest + 6)]
+    [InlineData(int.MaxValue)]
+    public void IsAboveHighest_AboveHighest_ReturnsTrue(int specVersion)
+    {
+        Assert.True(SpecVersions.IsAboveHighest(specVersion));
+    }
+}

--- a/tests/Borea.Storage.Tests/Mods/ModMetadataMapperTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/ModMetadataMapperTests.cs
@@ -156,6 +156,17 @@ public sealed class ModMetadataMapperTests : IDisposable
         Assert.Contains("spec version", exception.Message);
     }
 
+    [Fact]
+    public void FromDto_SpecVersionAboveHighest_StillMaps()
+    {
+        var dto = ModMetadataMapper.ToDto(MetadataFixtures.MinimalMetadata());
+        dto.SpecVersion = SpecVersions.Highest + 1;
+
+        var mapped = ModMetadataMapper.FromDto(dto);
+
+        Assert.Equal(SpecVersions.Highest + 1, mapped.SpecVersion);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempRoot))

--- a/tests/Borea.Storage.Tests/Mods/ModMetadataMapperTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/ModMetadataMapperTests.cs
@@ -157,6 +157,16 @@ public sealed class ModMetadataMapperTests : IDisposable
     }
 
     [Fact]
+    public void FromDto_NegativeSpecVersion_IsAMalformedFile()
+    {
+        var dto = ModMetadataMapper.ToDto(MetadataFixtures.MinimalMetadata());
+        dto.SpecVersion = -3;
+
+        var exception = Assert.Throws<FormatException>(() => ModMetadataMapper.FromDto(dto));
+        Assert.Contains("spec version", exception.Message);
+    }
+
+    [Fact]
     public void FromDto_SpecVersionAboveHighest_StillMaps()
     {
         var dto = ModMetadataMapper.ToDto(MetadataFixtures.MinimalMetadata());

--- a/tests/Borea.Storage.Tests/Mods/ModVersionMetadataMapperTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/ModVersionMetadataMapperTests.cs
@@ -279,6 +279,16 @@ public sealed class ModVersionMetadataMapperTests : IDisposable
     }
 
     [Fact]
+    public void FromDto_NegativeSpecVersion_IsAMalformedFile()
+    {
+        var dto = ModVersionMetadataMapper.ToDto(MetadataFixtures.MinimalRelease());
+        dto.SpecVersion = -3;
+
+        var exception = Assert.Throws<FormatException>(() => ModVersionMetadataMapper.FromDto(dto));
+        Assert.Contains("spec version", exception.Message);
+    }
+
+    [Fact]
     public void FromDto_SpecVersionAboveHighest_StillMaps()
     {
         var dto = ModVersionMetadataMapper.ToDto(MetadataFixtures.MinimalRelease());

--- a/tests/Borea.Storage.Tests/Mods/ModVersionMetadataMapperTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/ModVersionMetadataMapperTests.cs
@@ -278,6 +278,17 @@ public sealed class ModVersionMetadataMapperTests : IDisposable
         Assert.Contains("spec version", exception.Message);
     }
 
+    [Fact]
+    public void FromDto_SpecVersionAboveHighest_StillMaps()
+    {
+        var dto = ModVersionMetadataMapper.ToDto(MetadataFixtures.MinimalRelease());
+        dto.SpecVersion = SpecVersions.Highest + 1;
+
+        var mapped = ModVersionMetadataMapper.FromDto(dto);
+
+        Assert.Equal(SpecVersions.Highest + 1, mapped.SpecVersion);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempRoot))


### PR DESCRIPTION
Closes #40.

Nothing compared `spec_version` against a ceiling, so a document stamped version 7 constructed cleanly and flowed through search, storage and `CompositeModRepository` as if fully understood even tho the current spec is just version 1.

`SpecVersions.Highest` names the version this build implements, and `IsAboveHighest` answers the comparison.

The two `specVersion: 1` literals in `SpaceDockModRepository` read the constant now.

No caller acts on the predicate yet. The first one is the index reader (#44).
