### PR TITLE
Evaluate a release against the installed game and the target platform

### DIFF
--- a/src/Borea.Core/Game/Compatibility.cs
+++ b/src/Borea.Core/Game/Compatibility.cs
@@ -1,0 +1,37 @@
+﻿using Borea.Core.Mods;
+
+namespace Borea.Core.Game;
+
+/// <summary>
+/// Classifies content against the installed game.
+/// </summary>
+public static class Compatibility
+{
+    /// <summary>
+    /// The state the revision bounds put the installed game in (RFC 0017).
+    /// </summary>
+    public static GameCompatibility Evaluate(int? minRevision, int? maxRevision, GameVersion? installed)
+    {
+        if (installed is not { } version || minRevision is not { } min)
+            return GameCompatibility.Unknown;
+
+        if (version.Revision < min)
+            return GameCompatibility.Incompatible;
+
+        return maxRevision is { } max && version.Revision > max
+            ? GameCompatibility.Untested
+            : GameCompatibility.Compatible;
+    }
+
+    /// <summary>
+    /// The state the bounds of a stamped release put the installed game in.
+    /// A release always carries a lower bound.
+    /// </summary>
+    public static GameCompatibility Evaluate(ModVersionMetadata release, GameVersion? installed)
+    {
+        if (release is null)
+            throw new ArgumentNullException(nameof(release));
+
+        return Evaluate(release.GameMinRevision, release.GameMaxRevision, installed);
+    }
+}

--- a/src/Borea.Core/Game/Compatibility.cs
+++ b/src/Borea.Core/Game/Compatibility.cs
@@ -1,9 +1,9 @@
-﻿using Borea.Core.Mods;
+using Borea.Core.Mods;
 
 namespace Borea.Core.Game;
 
 /// <summary>
-/// Classifies content against the installed game.
+/// Classifies content against the installed game and the target platform.
 /// </summary>
 public static class Compatibility
 {
@@ -34,4 +34,35 @@ public static class Compatibility
 
         return Evaluate(release.GameMinRevision, release.GameMaxRevision, installed);
     }
+
+    /// <summary>
+    /// What the os list says about the target platform.
+    /// </summary>
+    public static OsSupport EvaluateOs(IReadOnlyList<string>? os, OsPlatform target)
+    {
+        if (os is null || os.Count == 0)
+            return new OsSupport(isSupported: true);
+
+        var unrecognized = new List<string>();
+        var supported = false;
+
+        foreach (var entry in os)
+        {
+            var platform = Parse(entry);
+            if (platform is null)
+                unrecognized.Add(entry);
+            else if (platform == target)
+                supported = true;
+        }
+
+        return new OsSupport(supported, unrecognized);
+    }
+
+    private static OsPlatform? Parse(string value) => value.ToLowerInvariant() switch
+    {
+        "windows" => OsPlatform.Windows,
+        "linux" => OsPlatform.Linux,
+        "macos" => OsPlatform.MacOs,
+        _ => null,
+    };
 }

--- a/src/Borea.Core/Game/GameCompatibility.cs
+++ b/src/Borea.Core/Game/GameCompatibility.cs
@@ -1,0 +1,27 @@
+namespace Borea.Core.Game;
+
+/// <summary>
+/// How a release fits the installed game (RFC 0017).
+/// </summary>
+public enum GameCompatibility
+{
+    /// <summary>
+    /// The installed revision is inside the stated range.
+    /// </summary>
+    Compatible = 0,
+
+    /// <summary>
+    /// The installed revision is above the stated upper bound.
+    /// </summary>
+    Untested = 1,
+
+    /// <summary>
+    /// The installed revision is below the lower bound.
+    /// </summary>
+    Incompatible = 2,
+
+    /// <summary>
+    /// No usable compatibility data.
+    /// </summary>
+    Unknown = 3,
+}

--- a/src/Borea.Core/Game/OsPlatform.cs
+++ b/src/Borea.Core/Game/OsPlatform.cs
@@ -1,0 +1,8 @@
+namespace Borea.Core.Game;
+
+public enum OsPlatform
+{
+    Windows = 0,
+    Linux = 1,
+    MacOs = 2,
+}

--- a/src/Borea.Core/Game/OsSupport.cs
+++ b/src/Borea.Core/Game/OsSupport.cs
@@ -1,0 +1,18 @@
+using System.Collections.ObjectModel;
+
+namespace Borea.Core.Game;
+
+public sealed class OsSupport
+{
+    public bool IsSupported { get; }
+
+    public IReadOnlyList<string> Unrecognized { get; }
+
+    public OsSupport(bool isSupported, IReadOnlyList<string>? unrecognized = null)
+    {
+        IsSupported = isSupported;
+        Unrecognized = unrecognized is null
+            ? Array.Empty<string>()
+            : new ReadOnlyCollection<string>(unrecognized.ToArray());
+    }
+}

--- a/tests/Borea.Core.Tests/Game/CompatibilityTests.cs
+++ b/tests/Borea.Core.Tests/Game/CompatibilityTests.cs
@@ -13,7 +13,8 @@ public sealed class CompatibilityTests
         string gameMin = "2026.7.4.2131",
         int gameMinRevision = 2131,
         string? gameMax = null,
-        int? gameMaxRevision = null) =>
+        int? gameMaxRevision = null,
+        IReadOnlyList<string>? os = null) =>
         new(
             specVersion: SpecVersions.Highest,
             modId: "test-mod",
@@ -26,7 +27,8 @@ public sealed class CompatibilityTests
             installSizeBytes: 2048,
             dependencies: Array.Empty<ModDependency>(),
             gameMax: gameMax,
-            gameMaxRevision: gameMaxRevision);
+            gameMaxRevision: gameMaxRevision,
+            os: os);
 
     [Fact]
     public void Evaluate_NoLowerBound_IsUnknown()
@@ -115,5 +117,77 @@ public sealed class CompatibilityTests
     public void Evaluate_NullRelease_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() => Compatibility.Evaluate(null!, Installed(5117)));
+    }
+
+    [Fact]
+    public void EvaluateOs_AbsentList_SupportsEveryPlatform()
+    {
+        var support = Compatibility.EvaluateOs(null, OsPlatform.Linux);
+
+        Assert.True(support.IsSupported);
+        Assert.Empty(support.Unrecognized);
+    }
+
+    [Fact]
+    public void EvaluateOs_EmptyList_ReadsLikeAnAbsentOne()
+    {
+        var support = Compatibility.EvaluateOs(Array.Empty<string>(), OsPlatform.Linux);
+
+        Assert.True(support.IsSupported);
+        Assert.Empty(support.Unrecognized);
+    }
+
+    [Theory]
+    [InlineData("windows", OsPlatform.Windows)]
+    [InlineData("linux", OsPlatform.Linux)]
+    [InlineData("macos", OsPlatform.MacOs)]
+    public void EvaluateOs_ListNamingTheTarget_IsSupported(string entry, OsPlatform target)
+    {
+        Assert.True(Compatibility.EvaluateOs(new[] { entry }, target).IsSupported);
+    }
+
+    [Theory]
+    [InlineData("Windows")]
+    [InlineData("WINDOWS")]
+    [InlineData("WiNdOwS")]
+    public void EvaluateOs_ComparesCaseInsensitively(string entry)
+    {
+        Assert.True(Compatibility.EvaluateOs(new[] { entry }, OsPlatform.Windows).IsSupported);
+    }
+
+    [Fact]
+    public void EvaluateOs_ListWithoutTheTarget_IsNotSupported()
+    {
+        var support = Compatibility.EvaluateOs(new[] { "windows", "macos" }, OsPlatform.Linux);
+
+        Assert.False(support.IsSupported);
+        Assert.Empty(support.Unrecognized);
+    }
+
+    [Fact]
+    public void EvaluateOs_UnrecognizedEntry_DoesNotStopTheRecognizedOnes()
+    {
+        var support = Compatibility.EvaluateOs(new[] { "freebsd", "linux" }, OsPlatform.Linux);
+
+        Assert.True(support.IsSupported);
+        Assert.Equal(new[] { "freebsd" }, support.Unrecognized);
+    }
+
+    [Fact]
+    public void EvaluateOs_OnlyUnrecognizedEntries_IsNotSupportedAndReportsThem()
+    {
+        var support = Compatibility.EvaluateOs(new[] { "FreeBSD", "haiku" }, OsPlatform.Windows);
+
+        Assert.False(support.IsSupported);
+        Assert.Equal(new[] { "FreeBSD", "haiku" }, support.Unrecognized);
+    }
+
+    [Fact]
+    public void EvaluateOs_TheReleaseList_IsReadTheSameWay()
+    {
+        var release = Release(os: new[] { "windows" });
+
+        Assert.True(Compatibility.EvaluateOs(release.Os, OsPlatform.Windows).IsSupported);
+        Assert.False(Compatibility.EvaluateOs(release.Os, OsPlatform.MacOs).IsSupported);
     }
 }

--- a/tests/Borea.Core.Tests/Game/CompatibilityTests.cs
+++ b/tests/Borea.Core.Tests/Game/CompatibilityTests.cs
@@ -1,0 +1,119 @@
+﻿using Borea.Core.Dependencies;
+using Borea.Core.Game;
+using Borea.Core.Mods;
+using Borea.Core.Tests.Mods;
+
+namespace Borea.Core.Tests.Game;
+
+public sealed class CompatibilityTests
+{
+    private static GameVersion Installed(int revision) => new(2026, 8, 3, revision);
+
+    private static ModVersionMetadata Release(
+        string gameMin = "2026.7.4.2131",
+        int gameMinRevision = 2131,
+        string? gameMax = null,
+        int? gameMaxRevision = null) =>
+        new(
+            specVersion: SpecVersions.Highest,
+            modId: "test-mod",
+            version: ModVersion.Parse("1.0.0"),
+            releaseStatus: ReleaseStatus.Stable,
+            releaseDate: DateTimeOffset.UtcNow,
+            gameMin: gameMin,
+            gameMinRevision: gameMinRevision,
+            download: TestFixtures.SampleDownload(),
+            installSizeBytes: 2048,
+            dependencies: Array.Empty<ModDependency>(),
+            gameMax: gameMax,
+            gameMaxRevision: gameMaxRevision);
+
+    [Fact]
+    public void Evaluate_NoLowerBound_IsUnknown()
+    {
+        Assert.Equal(GameCompatibility.Unknown, Compatibility.Evaluate(null, null, Installed(5117)));
+    }
+
+    [Fact]
+    public void Evaluate_NoLowerBoundButAnUpperOne_IsStillUnknown()
+    {
+        Assert.Equal(GameCompatibility.Unknown, Compatibility.Evaluate(null, 5117, Installed(2131)));
+    }
+
+    [Fact]
+    public void Evaluate_UnknownInstalledVersion_IsUnknown()
+    {
+        Assert.Equal(GameCompatibility.Unknown, Compatibility.Evaluate(2131, null, null));
+        Assert.Equal(GameCompatibility.Unknown, Compatibility.Evaluate(Release(), null));
+    }
+
+    [Fact]
+    public void Evaluate_BelowTheLowerBound_IsIncompatible()
+    {
+        Assert.Equal(GameCompatibility.Incompatible, Compatibility.Evaluate(5117, null, Installed(5116)));
+    }
+
+    [Fact]
+    public void Evaluate_AtTheLowerBound_IsCompatible()
+    {
+        Assert.Equal(GameCompatibility.Compatible, Compatibility.Evaluate(5117, null, Installed(5117)));
+    }
+
+    [Fact]
+    public void Evaluate_AboveAnOpenLowerBound_IsCompatible()
+    {
+        Assert.Equal(GameCompatibility.Compatible, Compatibility.Evaluate(2131, null, Installed(5348)));
+    }
+
+    [Fact]
+    public void Evaluate_AtTheUpperBound_IsCompatible()
+    {
+        Assert.Equal(GameCompatibility.Compatible, Compatibility.Evaluate(2131, 5117, Installed(5117)));
+    }
+
+    [Fact]
+    public void Evaluate_AboveTheUpperBound_IsUntested()
+    {
+        Assert.Equal(GameCompatibility.Untested, Compatibility.Evaluate(2131, 5117, Installed(5118)));
+    }
+
+    [Fact]
+    public void Evaluate_BoundsNamingOneRevision_AcceptOnlyThatRevision()
+    {
+        Assert.Equal(GameCompatibility.Compatible, Compatibility.Evaluate(5117, 5117, Installed(5117)));
+        Assert.Equal(GameCompatibility.Incompatible, Compatibility.Evaluate(5117, 5117, Installed(5116)));
+        Assert.Equal(GameCompatibility.Untested, Compatibility.Evaluate(5117, 5117, Installed(5118)));
+    }
+
+    [Fact]
+    public void Evaluate_IgnoresEveryComponentButTheRevision()
+    {
+        var installed = new GameVersion(2030, 12, 99, 2130);
+
+        Assert.Equal(GameCompatibility.Incompatible, Compatibility.Evaluate(2131, null, installed));
+    }
+
+    [Fact]
+    public void Evaluate_Release_ReadsItsStampedBounds()
+    {
+        var release = Release(gameMax: "2026.8.3.5117", gameMaxRevision: 5117);
+
+        Assert.Equal(GameCompatibility.Incompatible, Compatibility.Evaluate(release, Installed(2130)));
+        Assert.Equal(GameCompatibility.Compatible, Compatibility.Evaluate(release, Installed(2131)));
+        Assert.Equal(GameCompatibility.Untested, Compatibility.Evaluate(release, Installed(5118)));
+    }
+
+    [Fact]
+    public void Evaluate_Release_WithAKnownInstalledVersion_NeverAnswersUnknown()
+    {
+        // A release always carries a lower bound.
+        Assert.NotEqual(GameCompatibility.Unknown, Compatibility.Evaluate(Release(), Installed(1)));
+        Assert.NotEqual(GameCompatibility.Unknown, Compatibility.Evaluate(Release(), Installed(int.MaxValue)));
+    }
+
+    [Fact]
+    public void Evaluate_NullRelease_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => Compatibility.Evaluate(null!, Installed(5117)));
+    }
+}


### PR DESCRIPTION
Closes #39.

`Compatibility.Evaluate` answers the four states of RFC 0017, ordered by the revision alone, and `EvaluateOs` answers the os list of RFC 0031.

The installed version is nullable, so a caller that could not detect or parse it answers Unknown. That is the shape #38 hands back.

No caller acts on either yet.
