### PR TITLE
Align the pack document with RFC 0031

### DIFF
--- a/src/Borea.Core/Comparison/ModListComparer.cs
+++ b/src/Borea.Core/Comparison/ModListComparer.cs
@@ -19,7 +19,7 @@ public sealed class ModListComparer
         if (targetMods is null) throw new ArgumentNullException(nameof(targetMods));
 
         var currentById = currentMods.ToDictionary(m => m.ModId, ModIds.Comparer);
-        var targetIds = new HashSet<string>(targetMods.Select(m => m.ModId), ModIds.Comparer);
+        var targetIds = new HashSet<string>(targetMods.Select(m => m.ContentId), ModIds.Comparer);
 
         var toAdd = new List<ModPackEntry>();
         var toUpdate = new List<ModVersionChange>();
@@ -27,12 +27,12 @@ public sealed class ModListComparer
 
         foreach (var target in targetMods)
         {
-            if (currentById.TryGetValue(target.ModId, out var current))
+            if (currentById.TryGetValue(target.ContentId, out var current))
             {
                 if (current.Version.Equals(target.Version))
-                    unchanged.Add(target.ModId);
+                    unchanged.Add(target.ContentId);
                 else
-                    toUpdate.Add(new ModVersionChange(target.ModId, current.Version, target.Version));
+                    toUpdate.Add(new ModVersionChange(target.ContentId, current.Version, target.Version));
             }
             else
             {

--- a/src/Borea.Core/Comparison/ModListComparer.cs
+++ b/src/Borea.Core/Comparison/ModListComparer.cs
@@ -4,14 +4,18 @@ using Borea.Core.Mods;
 namespace Borea.Core.Comparison;
 
 /// <summary>
-/// Compares a set of currently installed mods against a target mod list.
+/// Compares the mods installed in an instance against the mods a pack pins.
 /// </summary>
 public sealed class ModListComparer
 {
-
     /// <summary>
-    /// Compares a list of InstalledMods against a list of ModPackEntries,
-    /// returning a ModListDiff that describes the differences.
+    /// Compares the installed mods against the pinned mods and returns the
+    /// <see cref="ModListDiff"/> between them.
+    /// <paramref name="targetMods"/> is the mods section of a pack document, so
+    /// <see cref="ModPackMetadata.Mods"/> and never its vehicles or saves. A pin carries
+    /// no content type, the section it sits in does, and an installed mod is the only
+    /// thing this comparison matches a pin against, so an entry from another section
+    /// would come back as a mod to add.
     /// </summary>
     public ModListDiff Compare(IReadOnlyList<InstalledMod> currentMods, IReadOnlyList<ModPackEntry> targetMods)
     {

--- a/src/Borea.Core/ModPacks/ModPackEntry.cs
+++ b/src/Borea.Core/ModPacks/ModPackEntry.cs
@@ -2,10 +2,20 @@ using Borea.Core.Mods;
 
 namespace Borea.Core.ModPacks;
 
+/// <summary>
+/// One exact pin in a pack document: a content id and the version the pack was curated with.
+/// The mods, vehicles and saves sections share this shape, and the section an entry sits in
+/// says what kind of content the id names, so the entry carries no content type of its own.
+/// </summary>
 public readonly record struct ModPackEntry
 {
     public string ContentId { get; }
 
+    /// <summary>
+    /// Valid by construction: <see cref="ModVersion"/> rejects a negative component and a
+    /// malformed pre-release label when it is built or parsed, and its default value is the
+    /// legal version 0.0.0.
+    /// </summary>
     public ModVersion Version { get; }
 
     public ModPackEntry(string contentId, ModVersion version)

--- a/src/Borea.Core/ModPacks/ModPackEntry.cs
+++ b/src/Borea.Core/ModPacks/ModPackEntry.cs
@@ -1,0 +1,25 @@
+using Borea.Core.Mods;
+
+namespace Borea.Core.ModPacks;
+
+public readonly record struct ModPackEntry
+{
+    public string ContentId { get; }
+
+    public ModVersion Version { get; }
+
+    public ModPackEntry(string contentId, ModVersion version)
+    {
+        ModIds.Validate(contentId, nameof(contentId));
+
+        ContentId = contentId;
+        Version = version;
+    }
+
+    public bool Equals(ModPackEntry other) =>
+        ModIds.Equals(ContentId, other.ContentId) && Version.Equals(other.Version);
+
+    public override int GetHashCode() => HashCode.Combine(
+        ContentId is null ? 0 : ModIds.Comparer.GetHashCode(ContentId),
+        Version);
+}

--- a/src/Borea.Core/ModPacks/ModPackMetadata.cs
+++ b/src/Borea.Core/ModPacks/ModPackMetadata.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 namespace Borea.Core.ModPacks;
 
 /// <summary>
-/// One version of a mod pack: the shared authored core plus the pack extension.
+/// One version of a mod pack (RFC 0031): the shared authored core plus the pack extension.
 /// Pure reference metadata, so no releases, no loader, and no install data.
 /// </summary>
 public sealed class ModPackMetadata
@@ -16,12 +16,16 @@ public sealed class ModPackMetadata
 
     public ContentType Type => ContentType.ModPack;
 
+    /// <summary>Which source this metadata came from. Borea-internal, not a format field.</summary>
     public string Source { get; }
 
+    /// <summary>The display name.</summary>
     public string Name { get; }
 
+    /// <summary>Display names of the authors.</summary>
     public IReadOnlyList<string> Authors { get; }
 
+    /// <summary>One or two sentences for list and search views.</summary>
     public string Abstract { get; }
 
     /// <summary>Longer CommonMark text on top of the abstract.</summary>
@@ -30,8 +34,10 @@ public sealed class ModPackMetadata
     /// <summary>SPDX expression. It covers the pack's own text, never a member's files.</summary>
     public string License { get; }
 
+    /// <summary>Free-form lowercase tags.</summary>
     public IReadOnlyList<string> Tags { get; }
 
+    /// <summary>The author's declaration about the pack.</summary>
     public ModStatus Status { get; }
 
     /// <summary>Only meaningful together with a deprecated status.</summary>
@@ -40,6 +46,7 @@ public sealed class ModPackMetadata
     /// <summary>Keys compare case-insensitively; "forums" is required.</summary>
     public IReadOnlyDictionary<string, string> Links { get; }
 
+    /// <summary>The required KSA forums thread for this pack.</summary>
     public string ForumUrl => Links["forums"];
 
     /// <summary>Oldest game version known to work.</summary>
@@ -56,12 +63,16 @@ public sealed class ModPackMetadata
 
     public DateTimeOffset ReleasedAt { get; }
 
+    /// <summary>URL or free text for this pack version.</summary>
     public string? Changelog { get; }
 
+    /// <summary>The curated mods, each an exact pin. At least one.</summary>
     public IReadOnlyList<ModPackEntry> Mods { get; }
 
+    /// <summary>Pinned vehicles, the same entry shape as the mods. Empty when none.</summary>
     public IReadOnlyList<ModPackEntry> Vehicles { get; }
 
+    /// <summary>Pinned saves, the same entry shape as the mods. Empty when none.</summary>
     public IReadOnlyList<ModPackEntry> Saves { get; }
 
     public ModPackMetadata(
@@ -123,6 +134,11 @@ public sealed class ModPackMetadata
         if (mods is null || mods.Count == 0)
             throw new ArgumentException("A mod pack must contain at least one mod.", nameof(mods));
 
+        RejectRepeatedPins(
+            (mods, nameof(mods)),
+            (vehicles ?? Array.Empty<ModPackEntry>(), nameof(vehicles)),
+            (saves ?? Array.Empty<ModPackEntry>(), nameof(saves)));
+
         SpecVersion = specVersion;
         ModPackId = modPackId;
         Source = source;
@@ -144,31 +160,24 @@ public sealed class ModPackMetadata
         Mods = new ReadOnlyCollection<ModPackEntry>(mods.ToArray());
         Vehicles = vehicles is null ? Array.Empty<ModPackEntry>() : new ReadOnlyCollection<ModPackEntry>(vehicles.ToArray());
         Saves = saves is null ? Array.Empty<ModPackEntry>() : new ReadOnlyCollection<ModPackEntry>(saves.ToArray());
-
-        RejectRepeatedPins();
     }
 
     /// <summary>
     /// One id is pinned once across the whole document, since the namespace is global.
+    /// The exception names the constructor parameter of the section the repeated pin is in.
     /// </summary>
-    private void RejectRepeatedPins()
+    private static void RejectRepeatedPins(params (IReadOnlyList<ModPackEntry> Entries, string ParamName)[] sections)
     {
         var seen = new HashSet<string>(ModIds.Comparer);
-        var sections = new (IReadOnlyList<ModPackEntry> Entries, string Name)[]
-        {
-            (Mods, nameof(Mods)),
-            (Vehicles, nameof(Vehicles)),
-            (Saves, nameof(Saves)),
-        };
 
-        foreach (var (entries, name) in sections)
+        foreach (var (entries, paramName) in sections)
         {
             foreach (var entry in entries)
             {
-                ModIds.Validate(entry.ContentId, name);
+                ModIds.Validate(entry.ContentId, paramName);
 
                 if (!seen.Add(entry.ContentId))
-                    throw new ArgumentException($"'{entry.ContentId}' is pinned more than once.", name);
+                    throw new ArgumentException($"'{entry.ContentId}' is pinned more than once.", paramName);
             }
         }
     }

--- a/src/Borea.Core/ModPacks/ModPackMetadata.cs
+++ b/src/Borea.Core/ModPacks/ModPackMetadata.cs
@@ -63,8 +63,3 @@ public sealed class ModPackMetadata
         HomepageUrl = homepageUrl;
     }
 }
-
-/// <summary>
-/// A single mod+version entry within a mod pack.
-/// </summary>
-public readonly record struct ModPackEntry(string ModId, Mods.ModVersion Version);

--- a/src/Borea.Core/ModPacks/ModPackMetadata.cs
+++ b/src/Borea.Core/ModPacks/ModPackMetadata.cs
@@ -1,40 +1,96 @@
-﻿using Borea.Core.Mods;
-using Borea.Core.Game;
+using Borea.Core.Mods;
 using System.Collections.ObjectModel;
 
 namespace Borea.Core.ModPacks;
 
 /// <summary>
-/// Describes a named collection of specific mod versions intended to be
-/// installed/activated together. Immutable once constructed.
+/// One version of a mod pack: the shared authored core plus the pack extension.
+/// Pure reference metadata, so no releases, no loader, and no install data.
 /// </summary>
 public sealed class ModPackMetadata
 {
+    public int SpecVersion { get; }
+
+    /// <summary>Ids compare case-insensitively and share one namespace with every content type.</summary>
     public string ModPackId { get; }
+
+    public ContentType Type => ContentType.ModPack;
+
     public string Source { get; }
+
     public string Name { get; }
-    public string Author { get; }
+
+    public IReadOnlyList<string> Authors { get; }
+
+    public string Abstract { get; }
+
+    /// <summary>Longer CommonMark text on top of the abstract.</summary>
+    public string? Description { get; }
+
+    /// <summary>SPDX expression. It covers the pack's own text, never a member's files.</summary>
+    public string License { get; }
+
+    public IReadOnlyList<string> Tags { get; }
+
+    public ModStatus Status { get; }
+
+    /// <summary>Only meaningful together with a deprecated status.</summary>
+    public string? SupersededBy { get; }
+
+    /// <summary>Keys compare case-insensitively; "forums" is required.</summary>
+    public IReadOnlyDictionary<string, string> Links { get; }
+
+    public string ForumUrl => Links["forums"];
+
+    /// <summary>Oldest game version known to work.</summary>
+    public string GameMin { get; }
+
+    /// <summary>Null means no known upper limit.</summary>
+    public string? GameMax { get; }
+
+    /// <summary>Null means no known platform restriction.</summary>
+    public IReadOnlyList<string>? Os { get; }
+
+    /// <summary>The document is the release, so the version is authored.</summary>
     public ModVersion Version { get; }
-    public GameVersion BuiltForGameVersion { get; }
-    public string Description { get; }
-    public string? HomepageUrl { get; }
+
     public DateTimeOffset ReleasedAt { get; }
+
+    public string? Changelog { get; }
+
     public IReadOnlyList<ModPackEntry> Mods { get; }
 
+    public IReadOnlyList<ModPackEntry> Vehicles { get; }
+
+    public IReadOnlyList<ModPackEntry> Saves { get; }
+
     public ModPackMetadata(
+        int specVersion,
         string modPackId,
         string source,
         string name,
-        string author,
+        IReadOnlyList<string> authors,
+        string abstractText,
+        string license,
+        IReadOnlyDictionary<string, string> links,
+        string gameMin,
         ModVersion version,
-        GameVersion builtForGameVersion,
-        string description,
         DateTimeOffset releasedAt,
         IReadOnlyList<ModPackEntry> mods,
-        string? homepageUrl = null)
+        IReadOnlyList<string>? tags = null,
+        string? description = null,
+        ModStatus status = ModStatus.Active,
+        string? supersededBy = null,
+        string? gameMax = null,
+        IReadOnlyList<string>? os = null,
+        string? changelog = null,
+        IReadOnlyList<ModPackEntry>? vehicles = null,
+        IReadOnlyList<ModPackEntry>? saves = null)
     {
-        if (string.IsNullOrWhiteSpace(modPackId))
-            throw new ArgumentException("Mod pack ID cannot be null or whitespace.", nameof(modPackId));
+        if (specVersion < 1)
+            throw new ArgumentOutOfRangeException(nameof(specVersion), "Spec version must be a positive integer.");
+
+        ModIds.Validate(modPackId, nameof(modPackId));
 
         if (string.IsNullOrWhiteSpace(source))
             throw new ArgumentException("Source cannot be null or whitespace.", nameof(source));
@@ -42,24 +98,78 @@ public sealed class ModPackMetadata
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException("Name cannot be null or whitespace.", nameof(name));
 
-        if (string.IsNullOrWhiteSpace(author))
-            throw new ArgumentException("Author cannot be null or whitespace.", nameof(author));
+        if (authors is null || authors.Count == 0)
+            throw new ArgumentException("At least one author is required.", nameof(authors));
 
-        if (description is null)
-            throw new ArgumentNullException(nameof(description));
+        if (abstractText is null)
+            throw new ArgumentNullException(nameof(abstractText));
+
+        if (string.IsNullOrWhiteSpace(license))
+            throw new ArgumentException("License cannot be null or whitespace.", nameof(license));
+
+        if (links is null || !links.Any(p => string.Equals(p.Key, "forums", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(p.Value)))
+            throw new ArgumentException("The links must contain a forums entry.", nameof(links));
+
+        var duplicateKey = links.Keys.GroupBy(k => k, StringComparer.OrdinalIgnoreCase).FirstOrDefault(g => g.Count() > 1)?.Key;
+        if (duplicateKey is not null)
+            throw new ArgumentException($"Link key '{duplicateKey}' appears more than once when compared case-insensitively.", nameof(links));
+
+        if (string.IsNullOrWhiteSpace(gameMin))
+            throw new ArgumentException("The minimum game version is required.", nameof(gameMin));
+
+        if (supersededBy is not null)
+            ModIds.Validate(supersededBy, nameof(supersededBy));
 
         if (mods is null || mods.Count == 0)
             throw new ArgumentException("A mod pack must contain at least one mod.", nameof(mods));
 
+        SpecVersion = specVersion;
         ModPackId = modPackId;
         Source = source;
         Name = name;
-        Author = author;
-        Version = version;
-        BuiltForGameVersion = builtForGameVersion;
+        Authors = new ReadOnlyCollection<string>(authors.ToArray());
+        Abstract = abstractText;
         Description = description;
+        License = license;
+        Tags = tags is null ? Array.Empty<string>() : new ReadOnlyCollection<string>(tags.ToArray());
+        Status = status;
+        SupersededBy = supersededBy;
+        Links = new Dictionary<string, string>(links, StringComparer.OrdinalIgnoreCase);
+        GameMin = gameMin;
+        GameMax = gameMax;
+        Os = os is null ? null : new ReadOnlyCollection<string>(os.ToArray());
+        Version = version;
         ReleasedAt = releasedAt;
+        Changelog = changelog;
         Mods = new ReadOnlyCollection<ModPackEntry>(mods.ToArray());
-        HomepageUrl = homepageUrl;
+        Vehicles = vehicles is null ? Array.Empty<ModPackEntry>() : new ReadOnlyCollection<ModPackEntry>(vehicles.ToArray());
+        Saves = saves is null ? Array.Empty<ModPackEntry>() : new ReadOnlyCollection<ModPackEntry>(saves.ToArray());
+
+        RejectRepeatedPins();
+    }
+
+    /// <summary>
+    /// One id is pinned once across the whole document, since the namespace is global.
+    /// </summary>
+    private void RejectRepeatedPins()
+    {
+        var seen = new HashSet<string>(ModIds.Comparer);
+        var sections = new (IReadOnlyList<ModPackEntry> Entries, string Name)[]
+        {
+            (Mods, nameof(Mods)),
+            (Vehicles, nameof(Vehicles)),
+            (Saves, nameof(Saves)),
+        };
+
+        foreach (var (entries, name) in sections)
+        {
+            foreach (var entry in entries)
+            {
+                ModIds.Validate(entry.ContentId, name);
+
+                if (!seen.Add(entry.ContentId))
+                    throw new ArgumentException($"'{entry.ContentId}' is pinned more than once.", name);
+            }
+        }
     }
 }

--- a/src/Borea.Storage/ModPacks/ModPackEntryDto.cs
+++ b/src/Borea.Storage/ModPacks/ModPackEntryDto.cs
@@ -2,6 +2,6 @@
 
 public sealed class ModPackEntryDto
 {
-    public string ModId { get; set; } = string.Empty;
+    public string ContentId { get; set; } = string.Empty;
     public string Version { get; set; } = string.Empty;
 }

--- a/src/Borea.Storage/ModPacks/ModPackMetadataDto.cs
+++ b/src/Borea.Storage/ModPacks/ModPackMetadataDto.cs
@@ -1,15 +1,39 @@
 ﻿namespace Borea.Storage.ModPacks;
 
+/// <summary>
+/// TOML form of a pack version document.
+/// </summary>
 public sealed class ModPackMetadataDto
 {
+    public int SpecVersion { get; set; }
     public string ModPackId { get; set; } = string.Empty;
+
+    public string Type { get; set; } = string.Empty;
+
     public string Source { get; set; } = string.Empty;
+
     public string Name { get; set; } = string.Empty;
-    public string Author { get; set; } = string.Empty;
+    public List<string> Authors { get; set; } = new();
+    public string Abstract { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string License { get; set; } = string.Empty;
+    public List<string> Tags { get; set; } = new();
+
+    /// <summary>Absent means active.</summary>
+    public string? Status { get; set; }
+
+    public string? SupersededBy { get; set; }
+    public Dictionary<string, string> Links { get; set; } = new();
+    public string GameMin { get; set; } = string.Empty;
+    public string? GameMax { get; set; }
+
+    public List<string>? Os { get; set; }
+
     public string Version { get; set; } = string.Empty;
-    public string BuiltForGameVersion { get; set; } = string.Empty;
-    public string Description { get; set; } = string.Empty;
-    public string? HomepageUrl { get; set; }
-    public System.DateTimeOffset ReleasedAt { get; set; }
+    public DateTimeOffset ReleasedAt { get; set; }
+    public string? Changelog { get; set; }
+
     public List<ModPackEntryDto> Mods { get; set; } = new();
+    public List<ModPackEntryDto> Vehicles { get; set; } = new();
+    public List<ModPackEntryDto> Saves { get; set; } = new();
 }

--- a/src/Borea.Storage/ModPacks/ModPackMetadataDto.cs
+++ b/src/Borea.Storage/ModPacks/ModPackMetadataDto.cs
@@ -1,7 +1,7 @@
 ﻿namespace Borea.Storage.ModPacks;
 
 /// <summary>
-/// TOML form of a pack version document.
+/// TOML-serializable representation of one ModPackMetadata version.
 /// </summary>
 public sealed class ModPackMetadataDto
 {

--- a/src/Borea.Storage/ModPacks/ModPackMetadataMapper.cs
+++ b/src/Borea.Storage/ModPacks/ModPackMetadataMapper.cs
@@ -1,6 +1,6 @@
-﻿using Borea.Core.Game;
-using Borea.Core.ModPacks;
+﻿using Borea.Core.ModPacks;
 using Borea.Core.Mods;
+using Borea.Storage.Mods;
 
 namespace Borea.Storage.ModPacks;
 
@@ -8,29 +8,64 @@ public static class ModPackMetadataMapper
 {
     public static ModPackMetadataDto ToDto(ModPackMetadata modPack) => new()
     {
+        SpecVersion = modPack.SpecVersion,
         ModPackId = modPack.ModPackId,
+        Type = MetadataEnumMapper.ToDto(modPack.Type),
         Source = modPack.Source,
         Name = modPack.Name,
-        Author = modPack.Author,
-        Version = modPack.Version.ToString(),
-        BuiltForGameVersion = modPack.BuiltForGameVersion.ToString(),
+        Authors = modPack.Authors.ToList(),
+        Abstract = modPack.Abstract,
         Description = modPack.Description,
-        HomepageUrl = modPack.HomepageUrl,
+        License = modPack.License,
+        Tags = modPack.Tags.ToList(),
+        Status = MetadataEnumMapper.ToDto(modPack.Status),
+        SupersededBy = modPack.SupersededBy,
+        Links = modPack.Links.ToDictionary(p => p.Key, p => p.Value),
+        GameMin = modPack.GameMin,
+        GameMax = modPack.GameMax,
+        Os = modPack.Os?.ToList(),
+        Version = modPack.Version.ToString(),
         ReleasedAt = modPack.ReleasedAt,
+        Changelog = modPack.Changelog,
         Mods = modPack.Mods.Select(ToDto).ToList(),
+        Vehicles = modPack.Vehicles.Select(ToDto).ToList(),
+        Saves = modPack.Saves.Select(ToDto).ToList(),
     };
 
-    public static ModPackMetadata FromDto(ModPackMetadataDto dto) => new(
-        dto.ModPackId,
-        dto.Source,
-        dto.Name,
-        dto.Author,
-        ModVersion.Parse(dto.Version),
-        GameVersion.Parse(dto.BuiltForGameVersion),
-        dto.Description,
-        dto.ReleasedAt,
-        dto.Mods.Select(FromDto).ToList(),
-        dto.HomepageUrl);
+    public static ModPackMetadata FromDto(ModPackMetadataDto dto)
+    {
+        if (dto.SpecVersion < 1)
+            throw new FormatException(dto.SpecVersion == 0
+                ? "The pack file predates the metadata model (no spec version)."
+                : $"The pack file carries an invalid spec version ({dto.SpecVersion}).");
+
+        var type = MetadataEnumMapper.ParseContentType(dto.Type);
+        if (type != ContentType.ModPack)
+            throw new FormatException($"The pack file declares type '{dto.Type}' and not a pack.");
+
+        return new ModPackMetadata(
+            specVersion: dto.SpecVersion,
+            modPackId: dto.ModPackId,
+            source: dto.Source,
+            name: dto.Name,
+            authors: dto.Authors,
+            abstractText: dto.Abstract,
+            license: dto.License,
+            links: dto.Links,
+            gameMin: dto.GameMin,
+            version: ModVersion.Parse(dto.Version),
+            releasedAt: dto.ReleasedAt,
+            mods: dto.Mods.Select(FromDto).ToList(),
+            tags: dto.Tags,
+            description: dto.Description,
+            status: dto.Status is null ? ModStatus.Active : MetadataEnumMapper.ParseModStatus(dto.Status),
+            supersededBy: dto.SupersededBy,
+            gameMax: dto.GameMax,
+            os: dto.Os,
+            changelog: dto.Changelog,
+            vehicles: dto.Vehicles.Select(FromDto).ToList(),
+            saves: dto.Saves.Select(FromDto).ToList());
+    }
 
     private static ModPackEntryDto ToDto(ModPackEntry entry) => new()
     {

--- a/src/Borea.Storage/ModPacks/ModPackMetadataMapper.cs
+++ b/src/Borea.Storage/ModPacks/ModPackMetadataMapper.cs
@@ -34,11 +34,11 @@ public static class ModPackMetadataMapper
 
     private static ModPackEntryDto ToDto(ModPackEntry entry) => new()
     {
-        ModId = entry.ModId,
+        ContentId = entry.ContentId,
         Version = entry.Version.ToString(),
     };
 
     private static ModPackEntry FromDto(ModPackEntryDto dto) => new(
-        dto.ModId,
+        dto.ContentId,
         ModVersion.Parse(dto.Version));
 }

--- a/tests/Borea.Core.Tests/Comparison/ModListComparerTests.cs
+++ b/tests/Borea.Core.Tests/Comparison/ModListComparerTests.cs
@@ -27,7 +27,7 @@ public sealed class ModListComparerTests
         var diff = _comparer.Compare(Array.Empty<InstalledMod>(), new[] { new ModPackEntry("new-mod", ModVersion.Parse("1.0.0")) });
 
         Assert.Single(diff.ToAdd);
-        Assert.Equal("new-mod", diff.ToAdd[0].ModId);
+        Assert.Equal("new-mod", diff.ToAdd[0].ContentId);
     }
 
     [Fact]

--- a/tests/Borea.Core.Tests/ModPacks/ModPackEntryTests.cs
+++ b/tests/Borea.Core.Tests/ModPacks/ModPackEntryTests.cs
@@ -1,0 +1,41 @@
+using Borea.Core.ModPacks;
+using Borea.Core.Mods;
+
+namespace Borea.Core.Tests.ModPacks;
+
+public sealed class ModPackEntryTests
+{
+    private static ModPackEntry Entry(string contentId, string version = "1.0.0") =>
+        new(contentId, ModVersion.Parse(version));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not a valid id")]
+    public void Constructor_InvalidContentId_ThrowsArgumentException(string? contentId)
+    {
+        Assert.Throws<ArgumentException>(() => new ModPackEntry(contentId!, ModVersion.Parse("1.0.0")));
+    }
+
+    [Fact]
+    public void Constructor_DefaultVersion_IsTheZeroVersion()
+    {
+        var entry = new ModPackEntry("some-mod", default);
+
+        Assert.Equal(ModVersion.Parse("0.0.0"), entry.Version);
+    }
+
+    [Fact]
+    public void Equals_IdsDifferingOnlyByCase_AreEqual()
+    {
+        Assert.Equal(Entry("SomeMod"), Entry("somemod"));
+        Assert.Equal(Entry("SomeMod").GetHashCode(), Entry("somemod").GetHashCode());
+    }
+
+    [Fact]
+    public void Equals_SameIdDifferentVersion_AreNotEqual()
+    {
+        Assert.NotEqual(Entry("some-mod", "1.0.0"), Entry("some-mod", "2.0.0"));
+    }
+}

--- a/tests/Borea.Core.Tests/ModPacks/ModPackMetadataTests.cs
+++ b/tests/Borea.Core.Tests/ModPacks/ModPackMetadataTests.cs
@@ -1,50 +1,127 @@
-﻿using Borea.Core.Game;
-using Borea.Core.ModPacks;
+﻿using Borea.Core.ModPacks;
 using Borea.Core.Mods;
 
 namespace Borea.Core.Tests.ModPacks;
 
 public sealed class ModPackMetadataTests
 {
-    private static readonly ModPackEntry[] OneMod =
-        { new("some-mod", ModVersion.Parse("1.0.0")) };
+    private static ModPackEntry Entry(string contentId, string version = "1.0.0") =>
+        new(contentId, ModVersion.Parse(version));
+
+    private static IReadOnlyDictionary<string, string> SampleLinks() =>
+        new Dictionary<string, string> { ["forums"] = "https://forums.example/thread/1" };
 
     private static ModPackMetadata Build(
         string modPackId = "test-pack",
         string source = "TestSource",
         string name = "Test Pack",
-        string author = "Author",
-        ModPackEntry[]? mods = null) =>
+        IReadOnlyList<string>? authors = null,
+        string license = "CC0-1.0",
+        IReadOnlyDictionary<string, string>? links = null,
+        string gameMin = "2026.7",
+        string? supersededBy = null,
+        IReadOnlyList<ModPackEntry>? mods = null,
+        IReadOnlyList<ModPackEntry>? vehicles = null,
+        IReadOnlyList<ModPackEntry>? saves = null,
+        int specVersion = SpecVersions.Highest) =>
         new(
-            modPackId,
-            source,
-            name,
-            author,
-            ModVersion.Parse("1.0.0"),
-            GameVersion.Parse("2026.7.4.2131"),
-            "Description",
-            DateTimeOffset.UtcNow,
-            mods!);
+            specVersion: specVersion,
+            modPackId: modPackId,
+            source: source,
+            name: name,
+            authors: authors ?? new[] { "Author" },
+            abstractText: "Abstract.",
+            license: license,
+            links: links ?? SampleLinks(),
+            gameMin: gameMin,
+            version: ModVersion.Parse("1.0.0"),
+            releasedAt: DateTimeOffset.UtcNow,
+            mods: mods ?? new[] { Entry("some-mod") },
+            supersededBy: supersededBy,
+            vehicles: vehicles,
+            saves: saves);
 
     [Fact]
     public void Constructor_ValidInput_SetsAllProperties()
     {
-        var pack = Build(mods: OneMod);
+        var pack = Build();
 
         Assert.Equal("test-pack", pack.ModPackId);
+        Assert.Equal(ContentType.ModPack, pack.Type);
         Assert.Equal("TestSource", pack.Source);
-        Assert.Equal("Test Pack", pack.Name);
-        Assert.Equal("Author", pack.Author);
+        Assert.Equal("https://forums.example/thread/1", pack.ForumUrl);
+        Assert.Equal(ModStatus.Active, pack.Status);
         Assert.Single(pack.Mods);
+        Assert.Null(pack.Description);
+        Assert.Null(pack.GameMax);
+        Assert.Null(pack.Os);
+        Assert.Null(pack.Changelog);
+        Assert.Empty(pack.Tags);
+        Assert.Empty(pack.Vehicles);
+        Assert.Empty(pack.Saves);
+    }
+
+    [Fact]
+    public void Constructor_MonthFormGameMin_IsAccepted()
+    {
+        Assert.Equal("2026.7", Build(gameMin: "2026.7").GameMin);
+    }
+
+    [Fact]
+    public void Constructor_VehiclesAndSaves_UseTheSameEntryShape()
+    {
+        var pack = Build(
+            vehicles: new[] { Entry("ReusableBoosterDemo", "1.2.0") },
+            saves: new[] { Entry("ApolloRecreation") });
+
+        Assert.Equal("ReusableBoosterDemo", pack.Vehicles[0].ContentId);
+        Assert.Equal(ModVersion.Parse("1.2.0"), pack.Vehicles[0].Version);
+        Assert.Equal("ApolloRecreation", pack.Saves[0].ContentId);
     }
 
     [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
+    [InlineData("CON")]
+    [InlineData(".hidden")]
+    [InlineData("not a valid id")]
     public void Constructor_InvalidModPackId_ThrowsArgumentException(string? modPackId)
     {
+        // A pack id follows the same rules a mod id does.
         Assert.Throws<ArgumentException>(() => Build(modPackId: modPackId!));
+    }
+
+    [Fact]
+    public void Constructor_MissingForumsLink_ThrowsArgumentException()
+    {
+        var links = new Dictionary<string, string> { ["homepage"] = "https://example.com" };
+
+        Assert.Throws<ArgumentException>(() => Build(links: links));
+    }
+
+    [Fact]
+    public void Constructor_LinkKeysCollidingByCase_ThrowsArgumentException()
+    {
+        var links = new Dictionary<string, string>
+        {
+            ["forums"] = "https://forums.example/thread/1",
+            ["Forums"] = "https://forums.example/thread/2",
+        };
+
+        Assert.Throws<ArgumentException>(() => Build(links: links));
+    }
+
+    [Fact]
+    public void Constructor_EmptyAuthors_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => Build(authors: Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Constructor_InvalidSupersededBy_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => Build(supersededBy: "not a valid id"));
     }
 
     [Fact]
@@ -56,6 +133,78 @@ public sealed class ModPackMetadataTests
     [Fact]
     public void Constructor_NullModsList_ThrowsArgumentException()
     {
-        Assert.Throws<ArgumentException>(() => Build(mods: null));
+        Assert.Throws<ArgumentException>(() => new ModPackMetadata(
+            SpecVersions.Highest, "test-pack", "TestSource", "Test Pack", new[] { "Author" },
+            "Abstract.", "CC0-1.0", SampleLinks(), "2026.7", ModVersion.Parse("1.0.0"),
+            DateTimeOffset.UtcNow, null!));
+    }
+
+    [Fact]
+    public void Constructor_SameContentPinnedTwice_ThrowsArgumentException()
+    {
+        var mods = new[] { Entry("some-mod", "1.0.0"), Entry("SOME-MOD", "2.0.0") };
+
+        Assert.Throws<ArgumentException>(() => Build(mods: mods));
+    }
+
+    [Fact]
+    public void Constructor_SameContentPinnedAcrossTwoSections_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            Build(mods: new[] { Entry("shared-id") }, saves: new[] { Entry("shared-id") }));
+    }
+
+    [Fact]
+    public void Constructor_DefaultEntry_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => Build(mods: new ModPackEntry[1]));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_SpecVersionBelowOne_ThrowsArgumentOutOfRangeException(int specVersion)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Build(specVersion: specVersion));
+    }
+
+    [Fact]
+    public void Constructor_SpecVersionAboveHighest_IsAccepted()
+    {
+        var pack = Build(specVersion: SpecVersions.Highest + 1);
+
+        Assert.True(SpecVersions.IsAboveHighest(pack.SpecVersion));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not a valid id")]
+    public void Entry_InvalidContentId_ThrowsArgumentException(string? contentId)
+    {
+        Assert.Throws<ArgumentException>(() => new ModPackEntry(contentId!, ModVersion.Parse("1.0.0")));
+    }
+
+    [Fact]
+    public void Entry_IdsDifferingOnlyByCase_AreEqual()
+    {
+        Assert.Equal(Entry("SomeMod"), Entry("somemod"));
+        Assert.Equal(Entry("SomeMod").GetHashCode(), Entry("somemod").GetHashCode());
+    }
+
+    [Fact]
+    public void Entry_SameIdDifferentVersion_AreNotEqual()
+    {
+        Assert.NotEqual(Entry("some-mod", "1.0.0"), Entry("some-mod", "2.0.0"));
+    }
+
+    [Fact]
+    public void RepeatedPin_NamesTheSectionItIsIn()
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            Build(mods: new[] { Entry("shared-id") }, saves: new[] { Entry("shared-id") }));
+
+        Assert.Equal("Saves", exception.ParamName);
     }
 }

--- a/tests/Borea.Core.Tests/ModPacks/ModPackMetadataTests.cs
+++ b/tests/Borea.Core.Tests/ModPacks/ModPackMetadataTests.cs
@@ -47,9 +47,14 @@ public sealed class ModPackMetadataTests
         var pack = Build();
 
         Assert.Equal("test-pack", pack.ModPackId);
-        Assert.Equal(ContentType.ModPack, pack.Type);
         Assert.Equal("TestSource", pack.Source);
+        Assert.Equal("Test Pack", pack.Name);
+        Assert.Equal(new[] { "Author" }, pack.Authors);
+        Assert.Equal("Abstract.", pack.Abstract);
+        Assert.Equal("CC0-1.0", pack.License);
         Assert.Equal("https://forums.example/thread/1", pack.ForumUrl);
+        Assert.Equal("2026.7", pack.GameMin);
+        Assert.Equal(ModVersion.Parse("1.0.0"), pack.Version);
         Assert.Equal(ModStatus.Active, pack.Status);
         Assert.Single(pack.Mods);
         Assert.Null(pack.Description);
@@ -98,6 +103,16 @@ public sealed class ModPackMetadataTests
         var links = new Dictionary<string, string> { ["homepage"] = "https://example.com" };
 
         Assert.Throws<ArgumentException>(() => Build(links: links));
+    }
+
+    [Fact]
+    public void Constructor_ForumsLinkWithAuthoredCasing_IsAccepted()
+    {
+        var links = new Dictionary<string, string> { ["Forums"] = "https://forums.example/thread/2" };
+
+        var pack = Build(links: links);
+
+        Assert.Equal("https://forums.example/thread/2", pack.ForumUrl);
     }
 
     [Fact]
@@ -155,6 +170,15 @@ public sealed class ModPackMetadataTests
     }
 
     [Fact]
+    public void Constructor_SameContentPinnedInModsAndVehicles_ThrowsArgumentException()
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            Build(mods: new[] { Entry("shared-id") }, vehicles: new[] { Entry("SHARED-ID") }));
+
+        Assert.Equal("vehicles", exception.ParamName);
+    }
+
+    [Fact]
     public void Constructor_DefaultEntry_ThrowsArgumentException()
     {
         Assert.Throws<ArgumentException>(() => Build(mods: new ModPackEntry[1]));
@@ -176,35 +200,12 @@ public sealed class ModPackMetadataTests
         Assert.True(SpecVersions.IsAboveHighest(pack.SpecVersion));
     }
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
-    [InlineData("not a valid id")]
-    public void Entry_InvalidContentId_ThrowsArgumentException(string? contentId)
-    {
-        Assert.Throws<ArgumentException>(() => new ModPackEntry(contentId!, ModVersion.Parse("1.0.0")));
-    }
-
-    [Fact]
-    public void Entry_IdsDifferingOnlyByCase_AreEqual()
-    {
-        Assert.Equal(Entry("SomeMod"), Entry("somemod"));
-        Assert.Equal(Entry("SomeMod").GetHashCode(), Entry("somemod").GetHashCode());
-    }
-
-    [Fact]
-    public void Entry_SameIdDifferentVersion_AreNotEqual()
-    {
-        Assert.NotEqual(Entry("some-mod", "1.0.0"), Entry("some-mod", "2.0.0"));
-    }
-
     [Fact]
     public void RepeatedPin_NamesTheSectionItIsIn()
     {
         var exception = Assert.Throws<ArgumentException>(() =>
             Build(mods: new[] { Entry("shared-id") }, saves: new[] { Entry("shared-id") }));
 
-        Assert.Equal("Saves", exception.ParamName);
+        Assert.Equal("saves", exception.ParamName);
     }
 }

--- a/tests/Borea.Storage.Tests/ModPacks/ModPackMetadataMapperTests.cs
+++ b/tests/Borea.Storage.Tests/ModPacks/ModPackMetadataMapperTests.cs
@@ -1,0 +1,212 @@
+﻿using Borea.Core.ModPacks;
+using Borea.Core.Mods;
+using Borea.Storage.ModPacks;
+using Borea.Storage.Toml;
+
+namespace Borea.Storage.Tests.ModPacks;
+
+public sealed class ModPackMetadataMapperTests : IDisposable
+{
+    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+
+    private static DateTimeOffset SampleTimestamp() =>
+        new DateTimeOffset(2026, 8, 8, 12, 0, 0, TimeSpan.Zero).AddTicks(1234567);
+
+    private static ModPackEntry Entry(string contentId, string version = "1.0.0") =>
+        new(contentId, ModVersion.Parse(version));
+
+    private static ModPackMetadata MinimalPack() => new(
+        specVersion: SpecVersions.Highest,
+        modPackId: "NavigationStarterPack",
+        source: "TestSource",
+        name: "Navigation Starter Pack",
+        authors: new[] { "Maxi" },
+        abstractText: "Abstract.",
+        license: "CC0-1.0",
+        links: new Dictionary<string, string> { ["forums"] = "https://forums.example/thread/1" },
+        gameMin: "2026.7",
+        version: ModVersion.Parse("1.0.0"),
+        releasedAt: SampleTimestamp(),
+        mods: new[] { Entry("AdvancedFlightComputer", "0.7.0") });
+
+    private static ModPackMetadata FullPack() => new(
+        specVersion: SpecVersions.Highest,
+        modPackId: "NavigationStarterPack",
+        source: "TestSource",
+        name: "Navigation Starter Pack",
+        authors: new[] { "Maxi", "Author B" },
+        abstractText: "Everything you need for maneuver planning, tested together.",
+        license: "CC0-1.0",
+        links: new Dictionary<string, string>
+        {
+            ["forums"] = "https://forums.example/thread/1",
+            ["homepage"] = "https://example.com/pack",
+        },
+        gameMin: "2026.8.3.5117",
+        version: ModVersion.Parse("1.2.0-beta.2"),
+        releasedAt: SampleTimestamp(),
+        mods: new[] { Entry("AdvancedFlightComputer", "0.7.0"), Entry("KittenExtensions", "0.4.0") },
+        tags: new[] { "navigation" },
+        description: "A longer description.",
+        status: ModStatus.Deprecated,
+        supersededBy: "NavigationStarterPackNG",
+        gameMax: "2026.8.22.5348",
+        os: new[] { "windows" },
+        changelog: "https://example.com/pack/changelog",
+        vehicles: new[] { Entry("ReusableBoosterDemo", "1.2.0") },
+        saves: new[] { Entry("ApolloRecreation") });
+
+    private async Task<(ModPackMetadata Reloaded, ModPackMetadataDto ReloadedDto, string TomlText)> RoundTripAsync(ModPackMetadata original)
+    {
+        var path = Path.Combine(_tempRoot, "pack.toml");
+        await TomlFileStore.WriteAsync(path, ModPackMetadataMapper.ToDto(original));
+        var reloadedDto = await TomlFileStore.ReadAsync<ModPackMetadataDto>(path);
+        return (ModPackMetadataMapper.FromDto(reloadedDto!), reloadedDto!, await File.ReadAllTextAsync(path));
+    }
+
+    [Fact]
+    public async Task RoundTrip_FullShape_PreservesEveryField()
+    {
+        var original = FullPack();
+
+        var (reloaded, _, tomlText) = await RoundTripAsync(original);
+
+        Assert.Equal(original.SpecVersion, reloaded.SpecVersion);
+        Assert.Equal(original.ModPackId, reloaded.ModPackId);
+        Assert.Equal(ContentType.ModPack, reloaded.Type);
+        Assert.Equal(original.Source, reloaded.Source);
+        Assert.Equal(original.Name, reloaded.Name);
+        Assert.Equal(original.Authors, reloaded.Authors);
+        Assert.Equal(original.Abstract, reloaded.Abstract);
+        Assert.Equal(original.Description, reloaded.Description);
+        Assert.Equal(original.License, reloaded.License);
+        Assert.Equal(original.Tags, reloaded.Tags);
+        Assert.Equal(ModStatus.Deprecated, reloaded.Status);
+        Assert.Equal(original.SupersededBy, reloaded.SupersededBy);
+        Assert.Equal(original.ForumUrl, reloaded.ForumUrl);
+        Assert.Equal(original.Links["homepage"], reloaded.Links["homepage"]);
+        Assert.Equal(original.GameMin, reloaded.GameMin);
+        Assert.Equal(original.GameMax, reloaded.GameMax);
+        Assert.Equal(original.Os, reloaded.Os);
+        Assert.Equal(original.Version, reloaded.Version);
+        Assert.Equal(original.ReleasedAt, reloaded.ReleasedAt);
+        Assert.Equal(original.Changelog, reloaded.Changelog);
+
+        Assert.Equal(2, reloaded.Mods.Count);
+        Assert.Equal("AdvancedFlightComputer", reloaded.Mods[0].ContentId);
+        Assert.Equal(ModVersion.Parse("0.7.0"), reloaded.Mods[0].Version);
+        Assert.Equal("ReusableBoosterDemo", reloaded.Vehicles[0].ContentId);
+        Assert.Equal("ApolloRecreation", reloaded.Saves[0].ContentId);
+
+        Assert.Contains("Description", tomlText);
+        Assert.Contains("SupersededBy", tomlText);
+        Assert.Contains("GameMax", tomlText);
+        Assert.Contains("Os = ", tomlText);
+        Assert.Contains("Changelog", tomlText);
+
+        Assert.Contains("Type = \"modpack\"", tomlText);
+        Assert.Contains("Status = \"deprecated\"", tomlText);
+    }
+
+    [Fact]
+    public async Task RoundTrip_MinimalShape_AbsentOptionalsStayAbsent()
+    {
+        var original = MinimalPack();
+
+        var (reloaded, reloadedDto, tomlText) = await RoundTripAsync(original);
+
+        Assert.Null(reloadedDto.Description);
+        Assert.Null(reloadedDto.SupersededBy);
+        Assert.Null(reloadedDto.GameMax);
+        Assert.Null(reloadedDto.Os);
+        Assert.Null(reloadedDto.Changelog);
+
+        Assert.Null(reloaded.Description);
+        Assert.Null(reloaded.GameMax);
+        Assert.Null(reloaded.Os);
+        Assert.Null(reloaded.Changelog);
+        Assert.Equal(ModStatus.Active, reloaded.Status);
+        Assert.Empty(reloaded.Tags);
+        Assert.Empty(reloaded.Vehicles);
+        Assert.Empty(reloaded.Saves);
+
+        Assert.DoesNotContain("Description", tomlText);
+        Assert.DoesNotContain("SupersededBy", tomlText);
+        Assert.DoesNotContain("GameMax", tomlText);
+        Assert.DoesNotContain("Os = ", tomlText);
+        Assert.DoesNotContain("Changelog", tomlText);
+    }
+
+    [Fact]
+    public async Task RoundTrip_TimestampKeepsSubSecondPrecision()
+    {
+        var (reloaded, _, _) = await RoundTripAsync(MinimalPack());
+
+        Assert.Equal(SampleTimestamp().Ticks, reloaded.ReleasedAt.Ticks);
+    }
+
+    [Fact]
+    public async Task RoundTrip_MonthFormGameMin_StaysAsAuthored()
+    {
+        var (reloaded, _, _) = await RoundTripAsync(MinimalPack());
+
+        Assert.Equal("2026.7", reloaded.GameMin);
+    }
+
+    [Fact]
+    public void FromDto_AbsentStatus_IsActive()
+    {
+        var dto = ModPackMetadataMapper.ToDto(MinimalPack());
+        dto.Status = null;
+
+        Assert.Equal(ModStatus.Active, ModPackMetadataMapper.FromDto(dto).Status);
+    }
+
+    [Fact]
+    public void FromDto_MissingSpecVersion_NamesThePreModelShape()
+    {
+        var dto = ModPackMetadataMapper.ToDto(MinimalPack());
+        dto.SpecVersion = 0;
+
+        var exception = Assert.Throws<FormatException>(() => ModPackMetadataMapper.FromDto(dto));
+        Assert.Contains("spec version", exception.Message);
+    }
+
+    [Fact]
+    public void FromDto_NegativeSpecVersion_IsAMalformedFile()
+    {
+        var dto = ModPackMetadataMapper.ToDto(MinimalPack());
+        dto.SpecVersion = -3;
+
+        var exception = Assert.Throws<FormatException>(() => ModPackMetadataMapper.FromDto(dto));
+        Assert.Contains("spec version", exception.Message);
+    }
+
+    [Fact]
+    public void FromDto_SpecVersionAboveHighest_StillMaps()
+    {
+        var dto = ModPackMetadataMapper.ToDto(MinimalPack());
+        dto.SpecVersion = SpecVersions.Highest + 1;
+
+        Assert.Equal(SpecVersions.Highest + 1, ModPackMetadataMapper.FromDto(dto).SpecVersion);
+    }
+
+    [Theory]
+    [InlineData("mod")]
+    [InlineData("mod-loader")]
+    [InlineData("vehicle")]
+    public void FromDto_TypeThatIsNotAPack_IsRefused(string type)
+    {
+        var dto = ModPackMetadataMapper.ToDto(MinimalPack());
+        dto.Type = type;
+
+        var exception = Assert.Throws<FormatException>(() => ModPackMetadataMapper.FromDto(dto));
+        Assert.Contains("not a pack", exception.Message);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+}

--- a/tests/Borea.Storage.Tests/ModPacks/ModPackMetadataMapperTests.cs
+++ b/tests/Borea.Storage.Tests/ModPacks/ModPackMetadataMapperTests.cs
@@ -40,7 +40,7 @@ public sealed class ModPackMetadataMapperTests : IDisposable
         links: new Dictionary<string, string>
         {
             ["forums"] = "https://forums.example/thread/1",
-            ["homepage"] = "https://example.com/pack",
+            ["Homepage"] = "https://example.com/pack",
         },
         gameMin: "2026.8.3.5117",
         version: ModVersion.Parse("1.2.0-beta.2"),
@@ -73,7 +73,6 @@ public sealed class ModPackMetadataMapperTests : IDisposable
 
         Assert.Equal(original.SpecVersion, reloaded.SpecVersion);
         Assert.Equal(original.ModPackId, reloaded.ModPackId);
-        Assert.Equal(ContentType.ModPack, reloaded.Type);
         Assert.Equal(original.Source, reloaded.Source);
         Assert.Equal(original.Name, reloaded.Name);
         Assert.Equal(original.Authors, reloaded.Authors);
@@ -84,7 +83,7 @@ public sealed class ModPackMetadataMapperTests : IDisposable
         Assert.Equal(ModStatus.Deprecated, reloaded.Status);
         Assert.Equal(original.SupersededBy, reloaded.SupersededBy);
         Assert.Equal(original.ForumUrl, reloaded.ForumUrl);
-        Assert.Equal(original.Links["homepage"], reloaded.Links["homepage"]);
+        Assert.Equal("https://example.com/pack", reloaded.Links["homepage"]);
         Assert.Equal(original.GameMin, reloaded.GameMin);
         Assert.Equal(original.GameMax, reloaded.GameMax);
         Assert.Equal(original.Os, reloaded.Os);
@@ -138,6 +137,30 @@ public sealed class ModPackMetadataMapperTests : IDisposable
     }
 
     [Fact]
+    public async Task RoundTrip_EmptyOsList_StaysEmptyInsteadOfAbsent()
+    {
+        var original = new ModPackMetadata(
+            specVersion: SpecVersions.Highest,
+            modPackId: "NavigationStarterPack",
+            source: "TestSource",
+            name: "Navigation Starter Pack",
+            authors: new[] { "Maxi" },
+            abstractText: "Abstract.",
+            license: "CC0-1.0",
+            links: new Dictionary<string, string> { ["forums"] = "https://forums.example/thread/1" },
+            gameMin: "2026.7",
+            version: ModVersion.Parse("1.0.0"),
+            releasedAt: SampleTimestamp(),
+            mods: new[] { Entry("AdvancedFlightComputer", "0.7.0") },
+            os: Array.Empty<string>());
+
+        var (reloaded, _, _) = await RoundTripAsync(original);
+
+        Assert.NotNull(reloaded.Os);
+        Assert.Empty(reloaded.Os);
+    }
+
+    [Fact]
     public async Task RoundTrip_TimestampKeepsSubSecondPrecision()
     {
         var (reloaded, _, _) = await RoundTripAsync(MinimalPack());
@@ -160,6 +183,15 @@ public sealed class ModPackMetadataMapperTests : IDisposable
         dto.Status = null;
 
         Assert.Equal(ModStatus.Active, ModPackMetadataMapper.FromDto(dto).Status);
+    }
+
+    [Fact]
+    public void FromDto_UnknownStatus_ParsesToUnknown()
+    {
+        var dto = ModPackMetadataMapper.ToDto(MinimalPack());
+        dto.Status = "frozen";
+
+        Assert.Equal(ModStatus.Unknown, ModPackMetadataMapper.FromDto(dto).Status);
     }
 
     [Fact]
@@ -192,6 +224,7 @@ public sealed class ModPackMetadataMapperTests : IDisposable
     }
 
     [Theory]
+    [InlineData("")]
     [InlineData("mod")]
     [InlineData("mod-loader")]
     [InlineData("vehicle")]


### PR DESCRIPTION
Closes #31.

`ModPackMetadata` predates RFC 0031 and was the last type left on the pre-format shape.

It carries the shared authored core plus the pack extension now.

`ModPackEntry` moves to its own file and its id becomes `ContentId`, since the same shape now carries `[[vehicles]]` and `[[saves]]` as well. It validates the id and compares it case-insensitively, so entry equality cannot disagree with what the document calls a repeated pin.
