### PR TITLE
Read the installed game version from KSA.dll

### DIFF
--- a/Borea.slnx
+++ b/Borea.slnx
@@ -9,5 +9,7 @@
     <Project Path="tests/Borea.Core.Tests/Borea.Core.Tests.csproj" />
     <Project Path="tests/Borea.Network.Tests/Borea.Network.Tests.csproj" />
     <Project Path="tests/Borea.Storage.Tests/Borea.Storage.Tests.csproj" />
+    <Project Path="tests/Borea.Storage.Tests/Fixtures/GameVersionFixture/GameVersionFixture.csproj" />
+    <Project Path="tests/Borea.Storage.Tests/Fixtures/UnparseableVersionFixture/UnparseableVersionFixture.csproj" />
   </Folder>
 </Solution>

--- a/src/Borea.Core/Game/IInstalledGameVersionProvider.cs
+++ b/src/Borea.Core/Game/IInstalledGameVersionProvider.cs
@@ -1,0 +1,9 @@
+namespace Borea.Core.Game;
+
+public interface IInstalledGameVersionProvider
+{
+    /// <summary>
+    /// The installed build, or null when no version could be read at all.
+    /// </summary>
+    InstalledGameVersion? GetInstalledVersion();
+}

--- a/src/Borea.Core/Game/InstalledGameVersion.cs
+++ b/src/Borea.Core/Game/InstalledGameVersion.cs
@@ -1,0 +1,7 @@
+namespace Borea.Core.Game;
+
+/// <summary>
+/// The game build found on disk. Version is null when the string did not parse,
+/// RawVersion keeps it either way.
+/// </summary>
+public sealed record InstalledGameVersion(GameVersion? Version, string RawVersion);

--- a/src/Borea.Storage/Game/InstalledGameVersionProvider.cs
+++ b/src/Borea.Storage/Game/InstalledGameVersionProvider.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+using Borea.Core.Game;
+using Borea.Core.Paths;
+
+namespace Borea.Storage.Game;
+
+/// <summary>
+/// Reads the installed build from the version resource of KSA.dll, the first
+/// two steps of RFC 0017's chain.
+/// </summary>
+public sealed class InstalledGameVersionProvider : IInstalledGameVersionProvider
+{
+    private const string GameAssemblyFileName = "KSA.dll";
+
+    private readonly IGamePathProvider _pathProvider;
+
+    public InstalledGameVersionProvider(IGamePathProvider pathProvider)
+    {
+        _pathProvider = pathProvider ?? throw new ArgumentNullException(nameof(pathProvider));
+    }
+
+    public InstalledGameVersion? GetInstalledVersion()
+    {
+        var gameDirectory = _pathProvider.GetGameDirectoryPath();
+        if (string.IsNullOrWhiteSpace(gameDirectory))
+            return null;
+
+        FileVersionInfo info;
+        try
+        {
+            info = FileVersionInfo.GetVersionInfo(Path.Combine(gameDirectory, GameAssemblyFileName));
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return null;
+        }
+
+        // FileVersion first per RFC 0017: the plain string a user is shown.
+        // ProductVersion adds the commit hash, and a suffix on builds RFC 0017 scopes out.
+        var raw = FirstNonBlank(info.FileVersion, info.ProductVersion);
+        if (raw is null)
+            return null;
+
+        return new InstalledGameVersion(GameVersion.TryParse(raw, out var version) ? version : null, raw);
+    }
+
+    private static string? FirstNonBlank(string? fileVersion, string? productVersion) =>
+        !string.IsNullOrWhiteSpace(fileVersion) ? fileVersion
+        : !string.IsNullOrWhiteSpace(productVersion) ? productVersion
+        : null;
+}

--- a/tests/Borea.Storage.Tests/Borea.Storage.Tests.csproj
+++ b/tests/Borea.Storage.Tests/Borea.Storage.Tests.csproj
@@ -23,4 +23,29 @@
     <ProjectReference Include="..\..\src\Borea.Storage\Borea.Storage.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Own projects inside this folder, so their sources stay out of these globs. -->
+    <Compile Remove="Fixtures\**" />
+    <None Remove="Fixtures\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Built by the solution, never compiled against. -->
+    <VersionFixture Include="Fixtures\GameVersionFixture\GameVersionFixture.csproj" />
+    <VersionFixture Include="Fixtures\UnparseableVersionFixture\UnparseableVersionFixture.csproj" />
+    <ProjectReference Include="@(VersionFixture)" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <!-- Inside Build, so the copies reach FileWrites and Clean removes them. -->
+  <Target Name="CopyVersionFixtures" AfterTargets="CopyFilesToOutputDirectory">
+    <MSBuild Projects="@(VersionFixture)"
+             Targets="GetTargetPath"
+             Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework)">
+      <Output TaskParameter="TargetOutputs" ItemName="VersionFixtureAssembly" />
+    </MSBuild>
+    <Copy SourceFiles="@(VersionFixtureAssembly)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true">
+      <Output TaskParameter="CopiedFiles" ItemName="FileWrites" />
+    </Copy>
+  </Target>
+
 </Project>

--- a/tests/Borea.Storage.Tests/Fixtures/GameVersionFixture/GameVersionFixture.csproj
+++ b/tests/Borea.Storage.Tests/Fixtures/GameVersionFixture/GameVersionFixture.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- A version resource carrying a KSA build number. -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <FileVersion>2026.8.3.5117</FileVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/Borea.Storage.Tests/Fixtures/UnparseableVersionFixture/UnparseableVersionFixture.csproj
+++ b/tests/Borea.Storage.Tests/Fixtures/UnparseableVersionFixture/UnparseableVersionFixture.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Stands in for a file that is not the game. -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <FileVersion>1.0.0.0</FileVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/Borea.Storage.Tests/Game/InstalledGameVersionProviderTests.cs
+++ b/tests/Borea.Storage.Tests/Game/InstalledGameVersionProviderTests.cs
@@ -1,0 +1,79 @@
+using Borea.Storage.Game;
+using Borea.Storage.Tests.Paths;
+
+namespace Borea.Storage.Tests.Game;
+
+public sealed class InstalledGameVersionProviderTests : IDisposable
+{
+    private const string RealBuildFixture = "GameVersionFixture.dll";
+    private const string ForeignBuildFixture = "UnparseableVersionFixture.dll";
+
+    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+
+    private InstalledGameVersionProvider Provider(bool hasGameDirectory = true) =>
+        new(new TestGamePathProvider(_tempRoot, hasGameDirectory));
+
+    private string GameDirectory()
+    {
+        var directory = Path.Combine(_tempRoot, "Game");
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    /// <summary>Puts a fixture where the game's own assembly would be.</summary>
+    private void PlaceGameAssembly(string fixtureFileName) =>
+        File.Copy(Path.Combine(AppContext.BaseDirectory, fixtureFileName),
+                  Path.Combine(GameDirectory(), "KSA.dll"));
+
+    [Fact]
+    public void GetInstalledVersion_GameLocationUnknown_ReturnsNull()
+    {
+        Assert.Null(Provider(hasGameDirectory: false).GetInstalledVersion());
+    }
+
+    [Fact]
+    public void GetInstalledVersion_AssemblyMissing_ReturnsNull()
+    {
+        GameDirectory();
+
+        Assert.Null(Provider().GetInstalledVersion());
+    }
+
+    [Fact]
+    public void GetInstalledVersion_FileCarriesNoVersionResource_ReturnsNull()
+    {
+        File.WriteAllText(Path.Combine(GameDirectory(), "KSA.dll"), "not a portable executable");
+
+        Assert.Null(Provider().GetInstalledVersion());
+    }
+
+    [Fact]
+    public void GetInstalledVersion_VersionThatDoesNotParse_KeepsTheRawString()
+    {
+        PlaceGameAssembly(ForeignBuildFixture);
+
+        var installed = Provider().GetInstalledVersion();
+
+        Assert.NotNull(installed);
+        Assert.Null(installed!.Version);
+        Assert.Equal("1.0.0.0", installed.RawVersion);
+    }
+
+    [Fact]
+    public void GetInstalledVersion_RealBuildNumber_ParsesIt()
+    {
+        PlaceGameAssembly(RealBuildFixture);
+
+        var installed = Provider().GetInstalledVersion();
+
+        Assert.NotNull(installed);
+        Assert.Equal("2026.8.3.5117", installed!.RawVersion);
+        Assert.Equal(5117, installed.Version!.Value.Revision);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+}

--- a/tests/Borea.Storage.Tests/Paths/TestGamePathProvider.cs
+++ b/tests/Borea.Storage.Tests/Paths/TestGamePathProvider.cs
@@ -3,14 +3,19 @@
 namespace Borea.Storage.Tests.Paths;
 
 /// <summary>
-/// Minimal IGamePathProvider rooted at an arbitrary folder — used to exercise
+/// Minimal IGamePathProvider rooted at an arbitrary folder, used to exercise
 /// real disk I/O in tests without touching actual LocalAppData paths.
 /// </summary>
 internal sealed class TestGamePathProvider : IGamePathProvider
 {
     private readonly string _root;
+    private readonly bool _hasGameDirectory;
 
-    public TestGamePathProvider(string root) => _root = root;
+    public TestGamePathProvider(string root, bool hasGameDirectory = true)
+    {
+        _root = root;
+        _hasGameDirectory = hasGameDirectory;
+    }
 
     public string GetInstancesRoot() => Path.Combine(_root, "Instances");
     public string GetInstanceRoot(Guid instanceId) => Path.Combine(GetInstancesRoot(), instanceId.ToString());
@@ -24,6 +29,6 @@ internal sealed class TestGamePathProvider : IGamePathProvider
     public string GetModFavoritesPath() => Path.Combine(_root, "mod-favorites.toml");
     public string GetModPackFavoritesPath() => Path.Combine(_root, "modpack-favorites.toml");
     public string GetBoreaSettingsPath() => Path.Combine(_root, "borea-settings.toml");
-    public string GetGameDirectoryPath() => Path.Combine(_root, "Game");
+    public string? GetGameDirectoryPath() => _hasGameDirectory ? Path.Combine(_root, "Game") : null;
     public string GetStarMapDirectoryPath() => Path.Combine(_root, "StarMap");
 }


### PR DESCRIPTION
Closes #38.

Borea could not tell which game build is installed, so nothing could answer whether a mod fits it.

`InstalledGameVersionProvider` reads the version resource of `KSA.dll`, the first two steps of RFC 0017's chain. The `Content/Versions` fallback still needs to be done as a follow-up.

Four ways to have no answer all return null if the game location is unknown, the file is not there, it is not a PE, or it carries no version resource.

The tests need real version resources, so two fixture projects build assemblies that carry nothing else, and a test copies one in under the game's file name.

No caller acts on it yet. It feeds #55, where `installed?.Version` reaches `Compatibility.Evaluate` with no adapter and both null paths land on Unknown.
