### PR TITLE
Replace the single StarMap path with a path per loader

### DIFF
--- a/src/Borea.Core/Paths/IGamePathProvider.cs
+++ b/src/Borea.Core/Paths/IGamePathProvider.cs
@@ -65,12 +65,12 @@ public interface IGamePathProvider
     string? GetGameDirectoryPath();
 
     /// <summary>
-    /// Root directory of the StarMap installation. Used as the base
-    /// path for launching StarMap.
+    /// Root directory of one installed mod loader. Ids compare
+    /// case-insensitively, and no id at all throws.
     /// </summary>
     /// <returns><list type="bullet">
-    /// <item>null if path is unknown.</item>
+    /// <item>null if no path is known for that loader.</item>
     /// <item>string path if known.</item>
     /// </list></returns>
-    string? GetStarMapDirectoryPath();
+    string? GetLoaderDirectoryPath(string loaderId);
 }

--- a/src/Borea.Core/Settings/BoreaSettings.cs
+++ b/src/Borea.Core/Settings/BoreaSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace Borea.Core.Settings;
+﻿using Borea.Core.Mods;
+
+namespace Borea.Core.Settings;
 
 /// <summary>
 /// Borea's own cross-platform configuration. No app level settings
@@ -7,17 +9,36 @@
 public sealed class BoreaSettings
 {
     public string? GameDirectoryPath { get; }
-    public string? StarMapDirectoryPath { get; }
 
-    public BoreaSettings(string? gameDirectoryPath, string? starMapDirectoryPath)
+    /// <summary>
+    /// Where each installed mod loader lives, keyed by loader id. Empty means none.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> LoaderDirectoryPaths { get; }
+
+    public BoreaSettings(string? gameDirectoryPath, IReadOnlyDictionary<string, string>? loaderDirectoryPaths = null)
     {
         if (gameDirectoryPath is not null && string.IsNullOrWhiteSpace(gameDirectoryPath))
             throw new ArgumentException("Game directory path, if provided, cannot be whitespace.", nameof(gameDirectoryPath));
 
-        if (starMapDirectoryPath is not null && string.IsNullOrWhiteSpace(starMapDirectoryPath))
-            throw new ArgumentException("StarMap directory path, if provided, cannot be whitespace.", nameof(starMapDirectoryPath));
-
         GameDirectoryPath = gameDirectoryPath;
-        StarMapDirectoryPath = starMapDirectoryPath;
+        LoaderDirectoryPaths = Build(loaderDirectoryPaths, nameof(loaderDirectoryPaths));
+    }
+
+    private static IReadOnlyDictionary<string, string> Build(IReadOnlyDictionary<string, string>? paths, string paramName)
+    {
+        var built = new Dictionary<string, string>(ModIds.Comparer);
+
+        foreach (var (loaderId, path) in paths ?? new Dictionary<string, string>())
+        {
+            ModIds.Validate(loaderId, paramName);
+
+            if (string.IsNullOrWhiteSpace(path))
+                throw new ArgumentException($"The path for loader '{loaderId}' cannot be whitespace.", paramName);
+
+            if (!built.TryAdd(loaderId, path))
+                throw new ArgumentException($"Loader id '{loaderId}' appears more than once when compared case-insensitively.", paramName);
+        }
+
+        return built;
     }
 }

--- a/src/Borea.Storage/Paths/GamePathProvider.cs
+++ b/src/Borea.Storage/Paths/GamePathProvider.cs
@@ -18,13 +18,17 @@ public sealed class GamePathProvider : IGamePathProvider
         if (gameDirectory is not null && string.IsNullOrWhiteSpace(gameDirectory))
             throw new ArgumentException("Game directory, if provided, cannot be whitespace.", nameof(gameDirectory));
 
+        // Same rule as BoreaSettings, since this constructor is public too.
         var byId = new Dictionary<string, string>(ModIds.Comparer);
         foreach (var (loaderId, path) in loaderDirectories ?? new Dictionary<string, string>())
         {
+            ModIds.Validate(loaderId, nameof(loaderDirectories));
+
             if (string.IsNullOrWhiteSpace(path))
                 throw new ArgumentException($"The directory for loader '{loaderId}' cannot be whitespace.", nameof(loaderDirectories));
 
-            byId[loaderId] = path;
+            if (!byId.TryAdd(loaderId, path))
+                throw new ArgumentException($"Loader id '{loaderId}' appears more than once when compared case-insensitively.", nameof(loaderDirectories));
         }
 
         _gameDirectory = gameDirectory;

--- a/src/Borea.Storage/Paths/GamePathProvider.cs
+++ b/src/Borea.Storage/Paths/GamePathProvider.cs
@@ -1,27 +1,34 @@
 ﻿using System;
+using Borea.Core.Mods;
 using Borea.Core.Paths;
 
 namespace Borea.Storage.Paths;
 
 /// <summary>
-/// Resolves Borea's own %LocalAppData%-rooted paths directly, and KSA and StarMap paths from the provided settings.
+/// Resolves Borea's own %LocalAppData%-rooted paths directly, and KSA and mod loader paths from the provided settings.
 /// </summary>
 public sealed class GamePathProvider : IGamePathProvider
 {
     private readonly string _boreaRoot;
     private readonly string? _gameDirectory;
-    private readonly string? _starMapDirectory;
+    private readonly IReadOnlyDictionary<string, string> _loaderDirectories;
 
-    public GamePathProvider(string? gameDirectory, string? starMapDirectory)
+    public GamePathProvider(string? gameDirectory, IReadOnlyDictionary<string, string>? loaderDirectories = null)
     {
         if (gameDirectory is not null && string.IsNullOrWhiteSpace(gameDirectory))
             throw new ArgumentException("Game directory, if provided, cannot be whitespace.", nameof(gameDirectory));
 
-        if (starMapDirectory is not null && string.IsNullOrWhiteSpace(starMapDirectory))
-            throw new ArgumentException("StarMap directory, if provided, cannot be whitespace.", nameof(starMapDirectory));
+        var byId = new Dictionary<string, string>(ModIds.Comparer);
+        foreach (var (loaderId, path) in loaderDirectories ?? new Dictionary<string, string>())
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                throw new ArgumentException($"The directory for loader '{loaderId}' cannot be whitespace.", nameof(loaderDirectories));
+
+            byId[loaderId] = path;
+        }
 
         _gameDirectory = gameDirectory;
-        _starMapDirectory = starMapDirectory;
+        _loaderDirectories = byId;
         _boreaRoot = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Borea");
     }
 
@@ -39,5 +46,12 @@ public sealed class GamePathProvider : IGamePathProvider
     public string GetModPackFavoritesPath() => Path.Combine(_boreaRoot, "modpack-favorites.toml");
     public string GetBoreaSettingsPath() => Path.Combine(_boreaRoot, "borea-settings.toml");
     public string? GetGameDirectoryPath() => _gameDirectory;
-    public string? GetStarMapDirectoryPath() => _starMapDirectory;
+
+    public string? GetLoaderDirectoryPath(string loaderId)
+    {
+        if (string.IsNullOrWhiteSpace(loaderId))
+            throw new ArgumentException("Loader id cannot be null or whitespace.", nameof(loaderId));
+
+        return _loaderDirectories.TryGetValue(loaderId, out var path) ? path : null;
+    }
 }

--- a/src/Borea.Storage/Settings/BoreaSettingsDto.cs
+++ b/src/Borea.Storage/Settings/BoreaSettingsDto.cs
@@ -3,5 +3,10 @@
 public sealed class BoreaSettingsDto
 {
     public string? GameDirectoryPath { get; set; }
-    public string? StarMapDirectoryPath { get; set; }
+
+    /// <summary>
+    /// Loader id to install directory. Absent when none, so no empty table is written.
+    /// Keep last: TOML puts every key after a table header inside that table.
+    /// </summary>
+    public Dictionary<string, string>? LoaderDirectoryPaths { get; set; }
 }

--- a/src/Borea.Storage/Settings/BoreaSettingsMapper.cs
+++ b/src/Borea.Storage/Settings/BoreaSettingsMapper.cs
@@ -7,9 +7,11 @@ public static class BoreaSettingsMapper
     public static BoreaSettingsDto ToDto(BoreaSettings settings) => new()
     {
         GameDirectoryPath = settings.GameDirectoryPath,
-        StarMapDirectoryPath = settings.StarMapDirectoryPath,
+        LoaderDirectoryPaths = settings.LoaderDirectoryPaths.Count == 0
+            ? null
+            : settings.LoaderDirectoryPaths.ToDictionary(p => p.Key, p => p.Value),
     };
 
     public static BoreaSettings FromDto(BoreaSettingsDto dto) =>
-        new(dto.GameDirectoryPath, dto.StarMapDirectoryPath);
+        new(dto.GameDirectoryPath, dto.LoaderDirectoryPaths);
 }

--- a/tests/Borea.Core.Tests/Settings/BoreaSettingsTests.cs
+++ b/tests/Borea.Core.Tests/Settings/BoreaSettingsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Borea.Core.Settings;
 using Xunit;
 
@@ -6,40 +7,69 @@ namespace Borea.Core.Tests.Settings;
 
 public sealed class BoreaSettingsTests
 {
+    private static Dictionary<string, string> StarMapAt(string path = @"C:\Games\StarMap") =>
+        new() { ["StarMap"] = path };
+
     [Fact]
-    public void Constructor_BothNull_DoesNotThrow()
+    public void Constructor_NothingProvided_LeavesGameNullAndNoLoader()
     {
-        var settings = new BoreaSettings(null, null);
+        var settings = new BoreaSettings(null);
 
         Assert.Null(settings.GameDirectoryPath);
-        Assert.Null(settings.StarMapDirectoryPath);
+        Assert.Empty(settings.LoaderDirectoryPaths);
     }
 
     [Fact]
-    public void Constructor_OnlyGamePathProvided_LeavesStarMapNull()
+    public void Constructor_OnlyGamePathProvided_LeavesNoLoader()
     {
-        var settings = new BoreaSettings(@"C:\Games\KSA", null);
+        var settings = new BoreaSettings(@"C:\Games\KSA");
 
         Assert.Equal(@"C:\Games\KSA", settings.GameDirectoryPath);
-        Assert.Null(settings.StarMapDirectoryPath);
+        Assert.Empty(settings.LoaderDirectoryPaths);
     }
 
     [Fact]
-    public void Constructor_OnlyStarMapPathProvided_LeavesGameNull()
+    public void Constructor_OnlyLoaderProvided_LeavesGameNull()
     {
-        var settings = new BoreaSettings(null, @"C:\Games\StarMap");
+        var settings = new BoreaSettings(null, StarMapAt());
 
         Assert.Null(settings.GameDirectoryPath);
-        Assert.Equal(@"C:\Games\StarMap", settings.StarMapDirectoryPath);
+        Assert.Equal(@"C:\Games\StarMap", settings.LoaderDirectoryPaths["StarMap"]);
     }
 
     [Fact]
-    public void Constructor_BothProvided_SetsBoth()
+    public void Constructor_SeveralLoaders_KeepsEachOne()
     {
-        var settings = new BoreaSettings(@"C:\Games\KSA", @"C:\Games\StarMap");
+        var settings = new BoreaSettings(@"C:\Games\KSA", new Dictionary<string, string>
+        {
+            ["StarMap"] = @"C:\Games\StarMap",
+            ["Cheese-Loader"] = @"C:\Games\Cheese",
+        });
 
-        Assert.Equal(@"C:\Games\KSA", settings.GameDirectoryPath);
-        Assert.Equal(@"C:\Games\StarMap", settings.StarMapDirectoryPath);
+        Assert.Equal(2, settings.LoaderDirectoryPaths.Count);
+        Assert.Equal(@"C:\Games\Cheese", settings.LoaderDirectoryPaths["Cheese-Loader"]);
+    }
+
+    [Fact]
+    public void Constructor_LoaderId_ComparesCaseInsensitivelyAndKeepsTheAuthoredCasing()
+    {
+        var settings = new BoreaSettings(null, StarMapAt());
+
+        Assert.Equal(@"C:\Games\StarMap", settings.LoaderDirectoryPaths["starmap"]);
+        Assert.Contains("StarMap", settings.LoaderDirectoryPaths.Keys);
+    }
+
+    [Fact]
+    public void Constructor_LoaderIdsCollidingByCase_ThrowsArgumentException()
+    {
+        // TOML keys are case-sensitive, ids are not.
+        var paths = new Dictionary<string, string>
+        {
+            ["StarMap"] = @"C:\Games\StarMap",
+            ["starmap"] = @"C:\Games\Other",
+        };
+
+        Assert.Throws<ArgumentException>(() => new BoreaSettings(null, paths));
     }
 
     [Theory]
@@ -47,14 +77,36 @@ public sealed class BoreaSettingsTests
     [InlineData("   ")]
     public void Constructor_WhitespaceGamePath_ThrowsArgumentException(string gamePath)
     {
-        Assert.Throws<ArgumentException>(() => new BoreaSettings(gamePath, null));
+        Assert.Throws<ArgumentException>(() => new BoreaSettings(gamePath));
     }
 
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public void Constructor_WhitespaceStarMapPath_ThrowsArgumentException(string starMapPath)
+    public void Constructor_WhitespaceLoaderPath_ThrowsArgumentException(string loaderPath)
     {
-        Assert.Throws<ArgumentException>(() => new BoreaSettings(null, starMapPath));
+        Assert.Throws<ArgumentException>(() => new BoreaSettings(null, StarMapAt(loaderPath)));
+    }
+
+    [Theory]
+    [InlineData("not a valid id")]
+    [InlineData(".hidden")]
+    [InlineData("CON")]
+    public void Constructor_InvalidLoaderId_ThrowsArgumentException(string loaderId)
+    {
+        var paths = new Dictionary<string, string> { [loaderId] = @"C:\Games\Loader" };
+
+        Assert.Throws<ArgumentException>(() => new BoreaSettings(null, paths));
+    }
+
+    [Fact]
+    public void LoaderDirectoryPaths_IsACopy_SoLaterEditsDoNotReachIt()
+    {
+        var paths = StarMapAt();
+        var settings = new BoreaSettings(null, paths);
+
+        paths["StarMap"] = @"C:\Somewhere\Else";
+
+        Assert.Equal(@"C:\Games\StarMap", settings.LoaderDirectoryPaths["StarMap"]);
     }
 }

--- a/tests/Borea.Storage.Tests/Paths/GamePathProviderTests.cs
+++ b/tests/Borea.Storage.Tests/Paths/GamePathProviderTests.cs
@@ -4,13 +4,16 @@ namespace Borea.Storage.Tests.Paths;
 
 public sealed class GamePathProviderTests
 {
+    private static Dictionary<string, string> StarMapAt(string path = @"C:\Games\StarMap") =>
+        new() { ["StarMap"] = path };
+
     [Fact]
-    public void Constructor_NullGameAndStarMapPaths_DoesNotThrow()
+    public void Constructor_NoGameAndNoLoaders_DoesNotThrow()
     {
-        var provider = new GamePathProvider(null, null);
+        var provider = new GamePathProvider(null);
 
         Assert.Null(provider.GetGameDirectoryPath());
-        Assert.Null(provider.GetStarMapDirectoryPath());
+        Assert.Null(provider.GetLoaderDirectoryPath("StarMap"));
     }
 
     [Theory]
@@ -18,24 +21,64 @@ public sealed class GamePathProviderTests
     [InlineData("   ")]
     public void Constructor_WhitespaceGamePath_ThrowsArgumentException(string gamePath)
     {
-        Assert.Throws<ArgumentException>(() => new GamePathProvider(gamePath, null));
+        Assert.Throws<ArgumentException>(() => new GamePathProvider(gamePath));
     }
 
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public void Constructor_WhitespaceStarMapPath_ThrowsArgumentException(string starMapPath)
+    public void Constructor_WhitespaceLoaderPath_ThrowsArgumentException(string loaderPath)
     {
-        Assert.Throws<ArgumentException>(() => new GamePathProvider(null, starMapPath));
+        Assert.Throws<ArgumentException>(() => new GamePathProvider(null, StarMapAt(loaderPath)));
     }
 
     [Fact]
     public void Constructor_ValidPaths_ReturnsThemUnchanged()
     {
-        var provider = new GamePathProvider(@"C:\Games\KSA", @"C:\Games\StarMap");
+        var provider = new GamePathProvider(@"C:\Games\KSA", StarMapAt());
 
         Assert.Equal(@"C:\Games\KSA", provider.GetGameDirectoryPath());
-        Assert.Equal(@"C:\Games\StarMap", provider.GetStarMapDirectoryPath());
+        Assert.Equal(@"C:\Games\StarMap", provider.GetLoaderDirectoryPath("StarMap"));
+    }
+
+    [Fact]
+    public void GetLoaderDirectoryPath_ComparesTheIdCaseInsensitively()
+    {
+        var provider = new GamePathProvider(null, StarMapAt());
+
+        Assert.Equal(@"C:\Games\StarMap", provider.GetLoaderDirectoryPath("starmap"));
+    }
+
+    [Fact]
+    public void GetLoaderDirectoryPath_LoaderThatIsNotInstalled_ReturnsNull()
+    {
+        var provider = new GamePathProvider(null, StarMapAt());
+
+        Assert.Null(provider.GetLoaderDirectoryPath("Cheese-Loader"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetLoaderDirectoryPath_NoIdAtAll_ThrowsArgumentException(string? loaderId)
+    {
+        var provider = new GamePathProvider(null, StarMapAt());
+
+        Assert.Throws<ArgumentException>(() => provider.GetLoaderDirectoryPath(loaderId!));
+    }
+
+    [Fact]
+    public void GetLoaderDirectoryPath_SeveralLoaders_AnswersEachOne()
+    {
+        var provider = new GamePathProvider(null, new Dictionary<string, string>
+        {
+            ["StarMap"] = @"C:\Games\StarMap",
+            ["Cheese-Loader"] = @"C:\Games\Cheese",
+        });
+
+        Assert.Equal(@"C:\Games\StarMap", provider.GetLoaderDirectoryPath("StarMap"));
+        Assert.Equal(@"C:\Games\Cheese", provider.GetLoaderDirectoryPath("Cheese-Loader"));
     }
 
     [Fact]
@@ -52,7 +95,7 @@ public sealed class GamePathProviderTests
     [Fact]
     public void InstancePaths_AreNestedUnderInstanceRoot()
     {
-        var provider = new GamePathProvider(null, null);
+        var provider = new GamePathProvider(null);
         var instanceId = Guid.NewGuid();
 
         var root = provider.GetInstanceRoot(instanceId);
@@ -69,7 +112,7 @@ public sealed class GamePathProviderTests
     [Fact]
     public void InstanceRoot_IncludesInstanceIdInPath()
     {
-        var provider = new GamePathProvider(null, null);
+        var provider = new GamePathProvider(null);
         var instanceId = Guid.NewGuid();
 
         var root = provider.GetInstanceRoot(instanceId);
@@ -80,7 +123,7 @@ public sealed class GamePathProviderTests
     [Fact]
     public void DifferentInstanceIds_ProduceDifferentPaths()
     {
-        var provider = new GamePathProvider(null, null);
+        var provider = new GamePathProvider(null);
 
         var pathA = provider.GetInstanceRoot(Guid.NewGuid());
         var pathB = provider.GetInstanceRoot(Guid.NewGuid());
@@ -93,7 +136,7 @@ public sealed class GamePathProviderTests
     {
         // Regression guard: confirms active-instance pointer, both favorites
         // files, and Borea settings never accidentally collide on one path.
-        var provider = new GamePathProvider(null, null);
+        var provider = new GamePathProvider(null);
 
         var paths = new[]
         {
@@ -110,7 +153,7 @@ public sealed class GamePathProviderTests
     [Fact]
     public void GlobalPaths_AreNotNestedUnderInstancesRoot()
     {
-        var provider = new GamePathProvider(null, null);
+        var provider = new GamePathProvider(null);
 
         Assert.DoesNotContain(provider.GetInstancesRoot(), provider.GetActiveInstancePointerPath());
         Assert.DoesNotContain(provider.GetInstancesRoot(), provider.GetBoreaSettingsPath());

--- a/tests/Borea.Storage.Tests/Paths/GamePathProviderTests.cs
+++ b/tests/Borea.Storage.Tests/Paths/GamePathProviderTests.cs
@@ -69,6 +69,30 @@ public sealed class GamePathProviderTests
     }
 
     [Fact]
+    public void Constructor_LoaderIdsCollidingByCase_ThrowsArgumentException()
+    {
+        // Same rule as BoreaSettings
+        var paths = new Dictionary<string, string>
+        {
+            ["StarMap"] = @"C:\Games\StarMap",
+            ["starmap"] = @"C:\Games\Other",
+        };
+
+        Assert.Throws<ArgumentException>(() => new GamePathProvider(null, paths));
+    }
+
+    [Theory]
+    [InlineData("not a valid id")]
+    [InlineData(".hidden")]
+    [InlineData("CON")]
+    public void Constructor_InvalidLoaderId_ThrowsArgumentException(string loaderId)
+    {
+        var paths = new Dictionary<string, string> { [loaderId] = @"C:\Games\Loader" };
+
+        Assert.Throws<ArgumentException>(() => new GamePathProvider(null, paths));
+    }
+
+    [Fact]
     public void GetLoaderDirectoryPath_SeveralLoaders_AnswersEachOne()
     {
         var provider = new GamePathProvider(null, new Dictionary<string, string>

--- a/tests/Borea.Storage.Tests/Paths/TestGamePathProvider.cs
+++ b/tests/Borea.Storage.Tests/Paths/TestGamePathProvider.cs
@@ -32,5 +32,10 @@ internal sealed class TestGamePathProvider : IGamePathProvider
     public string GetModPackFavoritesPath() => Path.Combine(_root, "modpack-favorites.toml");
     public string GetBoreaSettingsPath() => Path.Combine(_root, "borea-settings.toml");
     public string? GetGameDirectoryPath() => _hasGameDirectory ? Path.Combine(_root, "Game") : null;
-    public string GetStarMapDirectoryPath() => Path.Combine(_root, "StarMap");
+    public string? GetLoaderDirectoryPath(string loaderId)
+    {
+        ModIds.Validate(loaderId, nameof(loaderId));
+
+        return ModIds.Equals(loaderId, "StarMap") ? Path.Combine(_root, "StarMap") : null;
+    }
 }

--- a/tests/Borea.Storage.Tests/Paths/TestGamePathProvider.cs
+++ b/tests/Borea.Storage.Tests/Paths/TestGamePathProvider.cs
@@ -1,4 +1,5 @@
-﻿using Borea.Core.Paths;
+﻿using Borea.Core.Mods;
+using Borea.Core.Paths;
 
 namespace Borea.Storage.Tests.Paths;
 

--- a/tests/Borea.Storage.Tests/Settings/FileBoreaSettingsRepositoryTests.cs
+++ b/tests/Borea.Storage.Tests/Settings/FileBoreaSettingsRepositoryTests.cs
@@ -26,16 +26,22 @@ public sealed class FileBoreaSettingsRepositoryTests : IDisposable
     }
 
     [Fact]
-    public async Task SaveThenGet_RoundTripsBothPaths()
+    public async Task SaveThenGet_RoundTripsTheGameAndTheLoaders()
     {
-        var settings = new BoreaSettings(@"C:\Games\KSA", @"C:\Games\StarMap");
+        var settings = new BoreaSettings(@"C:\Games\KSA", new Dictionary<string, string>
+        {
+            ["StarMap"] = @"C:\Games\StarMap",
+            ["Cheese-Loader"] = @"C:\Games\Cheese",
+        });
 
         await _repository.SaveAsync(settings);
         var reloaded = await _repository.GetAsync();
 
         Assert.NotNull(reloaded);
         Assert.Equal(@"C:\Games\KSA", reloaded!.GameDirectoryPath);
-        Assert.Equal(@"C:\Games\StarMap", reloaded.StarMapDirectoryPath);
+        Assert.Equal(2, reloaded.LoaderDirectoryPaths.Count);
+        Assert.Equal(@"C:\Games\StarMap", reloaded.LoaderDirectoryPaths["StarMap"]);
+        Assert.Equal(@"C:\Games\Cheese", reloaded.LoaderDirectoryPaths["Cheese-Loader"]);
     }
 
     [Fact]
@@ -43,38 +49,61 @@ public sealed class FileBoreaSettingsRepositoryTests : IDisposable
     {
         // Confirms the "installed one, not the other" scenario this whole
         // nullable design was built for actually persists correctly.
-        var settings = new BoreaSettings(@"C:\Games\KSA", null);
+        var settings = new BoreaSettings(@"C:\Games\KSA");
 
         await _repository.SaveAsync(settings);
         var reloaded = await _repository.GetAsync();
 
         Assert.Equal(@"C:\Games\KSA", reloaded!.GameDirectoryPath);
-        Assert.Null(reloaded.StarMapDirectoryPath);
+        Assert.Empty(reloaded.LoaderDirectoryPaths);
     }
 
     [Fact]
-    public async Task SaveThenGet_RoundTripsPartialSettings_StarMapOnly()
+    public async Task SaveThenGet_RoundTripsPartialSettings_LoaderOnly()
     {
-        var settings = new BoreaSettings(null, @"C:\Games\StarMap");
+        var settings = new BoreaSettings(null, new Dictionary<string, string> { ["StarMap"] = @"C:\Games\StarMap" });
 
         await _repository.SaveAsync(settings);
         var reloaded = await _repository.GetAsync();
 
         Assert.Null(reloaded!.GameDirectoryPath);
-        Assert.Equal(@"C:\Games\StarMap", reloaded.StarMapDirectoryPath);
+        Assert.Equal(@"C:\Games\StarMap", reloaded.LoaderDirectoryPaths["StarMap"]);
     }
 
     [Fact]
-    public async Task SaveThenGet_RoundTripsBothNull()
+    public async Task SaveThenGet_RoundTripsNothingSet()
     {
-        var settings = new BoreaSettings(null, null);
+        var settings = new BoreaSettings(null);
 
         await _repository.SaveAsync(settings);
         var reloaded = await _repository.GetAsync();
 
-        Assert.NotNull(reloaded); // Distinct from "never saved" (null) — a file exists, both fields just happen to be empty.
+        Assert.NotNull(reloaded); // Distinct from "never saved" (null): a file exists, it just carries nothing.
         Assert.Null(reloaded!.GameDirectoryPath);
-        Assert.Null(reloaded.StarMapDirectoryPath);
+        Assert.Empty(reloaded.LoaderDirectoryPaths);
+    }
+
+    [Fact]
+    public async Task SaveAsync_NoLoaders_WritesNoTable()
+    {
+        await _repository.SaveAsync(new BoreaSettings(@"C:\Games\KSA"));
+
+        var text = await File.ReadAllTextAsync(_pathProvider.GetBoreaSettingsPath());
+
+        Assert.DoesNotContain("LoaderDirectoryPaths", text);
+    }
+
+    [Fact]
+    public async Task GetAsync_LoaderIdsDifferingOnlyInCase_IsRejected()
+    {
+        Directory.CreateDirectory(_tempRoot);
+        await File.WriteAllTextAsync(_pathProvider.GetBoreaSettingsPath(), """
+            [LoaderDirectoryPaths]
+            StarMap = 'C:\Games\StarMap'
+            starmap = 'C:\Games\Other'
+            """);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _repository.GetAsync());
     }
 
     [Fact]


### PR DESCRIPTION
Closes #42.

`BoreaSettings` carries a loader-id-to-path map now, and `IGamePathProvider.GetStarMapDirectoryPath` becomes `GetLoaderDirectoryPath(loaderId)`. Ids compare case-insensitively through `ModIds.Comparer` .

It touches `TestGamePathProvider` on the two lines #57 also touches, so whichever of the two merges second needs to resolve them by keeping both.
