### PR TITLE
Carry the authored install and provides tables

### DIFF
--- a/src/Borea.Core/ModLoaders/ConfigureFormat.cs
+++ b/src/Borea.Core/ModLoaders/ConfigureFormat.cs
@@ -1,0 +1,16 @@
+namespace Borea.Core.ModLoaders;
+
+/// <summary>
+/// The format of a loader's own configuration file.
+/// </summary>
+public enum ConfigureFormat
+{
+    Json = 0,
+
+    Toml = 1,
+
+    /// <summary>
+    /// The index rejects it at publish time, a client keeps the listing.
+    /// </summary>
+    Unknown = 2,
+}

--- a/src/Borea.Core/ModLoaders/LoaderConfigure.cs
+++ b/src/Borea.Core/ModLoaders/LoaderConfigure.cs
@@ -1,0 +1,32 @@
+using Borea.Core.Mods;
+
+namespace Borea.Core.ModLoaders;
+
+/// <summary>
+/// The [provides.configure] table of RFC 0035.
+/// </summary>
+public sealed class LoaderConfigure
+{
+    /// <summary>Relative to the loader's install location.</summary>
+    public string File { get; }
+
+    public ConfigureFormat Format { get; }
+
+    /// <summary>
+    /// The key that receives the game directory, dot-separated from the root.
+    /// </summary>
+    public string? GamePath { get; }
+
+    public LoaderConfigure(string file, ConfigureFormat format, string? gamePath = null)
+    {
+        if (string.IsNullOrWhiteSpace(file))
+            throw new ArgumentException("The configuration file is required.", nameof(file));
+
+        if (gamePath is not null && string.IsNullOrWhiteSpace(gamePath))
+            throw new ArgumentException("The game path key, if provided, cannot be whitespace.", nameof(gamePath));
+
+        File = RelativePaths.Contained(file, nameof(file))!;
+        Format = format;
+        GamePath = gamePath;
+    }
+}

--- a/src/Borea.Core/ModLoaders/LoaderProvides.cs
+++ b/src/Borea.Core/ModLoaders/LoaderProvides.cs
@@ -1,0 +1,38 @@
+using Borea.Core.Mods;
+
+namespace Borea.Core.ModLoaders;
+
+/// <summary>
+/// The authored [provides] table of RFC 0035.
+/// </summary>
+public sealed class LoaderProvides
+{
+    public string? Launch { get; }
+
+    /// <summary>
+    /// Null means the loader reads none,
+    /// Unknown means a manager must not guess which.
+    /// </summary>
+    public InstallAnchor? ContentDir { get; }
+
+    /// <summary>Null means the anchor itself.</summary>
+    public string? ContentPath { get; }
+
+    /// <summary>The configuration file a manager may write.</summary>
+    public LoaderConfigure? Configure { get; }
+
+    public LoaderProvides(
+        string? launch = null,
+        InstallAnchor? contentDir = null,
+        string? contentPath = null,
+        LoaderConfigure? configure = null)
+    {
+        if (contentPath is not null && contentDir is null)
+            throw new ArgumentException("A content path needs the content directory it sits below.", nameof(contentPath));
+
+        Launch = RelativePaths.Contained(launch, nameof(launch));
+        ContentDir = contentDir;
+        ContentPath = RelativePaths.Contained(contentPath, nameof(contentPath));
+        Configure = configure;
+    }
+}

--- a/src/Borea.Core/Mods/InstallDescriptor.cs
+++ b/src/Borea.Core/Mods/InstallDescriptor.cs
@@ -1,0 +1,64 @@
+using System.Collections.ObjectModel;
+
+namespace Borea.Core.Mods;
+
+/// <summary>
+/// The authored [install] table of RFC 0035. <see cref="InstallInfo"/> is the stamped half.
+/// </summary>
+public sealed class InstallDescriptor
+{
+    /// <summary>The directory inside the archive. Null means derived.</summary>
+    public string? Root { get; }
+
+    /// <summary>Null means the type default, Unknown means a manager must not guess.</summary>
+    public InstallAnchor? Target { get; }
+
+    /// <summary>The path below the anchor. Null means the anchor itself.</summary>
+    public string? Path { get; }
+
+    /// <summary>Paths the content owns and a manager must not edit.</summary>
+    public IReadOnlyList<string>? Manages { get; }
+
+    /// <summary>
+    /// Prose, never parsed for actions. Null means the author said nothing,
+    /// empty means they said there is none.
+    /// </summary>
+    public IReadOnlyList<string>? Steps { get; }
+
+    /// <summary>How to remove the content cleanly. Prose, like Steps.</summary>
+    public IReadOnlyList<string>? Uninstall { get; }
+
+    public InstallDescriptor(
+        string? root = null,
+        InstallAnchor? target = null,
+        string? path = null,
+        IReadOnlyList<string>? manages = null,
+        IReadOnlyList<string>? steps = null,
+        IReadOnlyList<string>? uninstall = null)
+    {
+        Root = RelativePaths.Contained(root, nameof(root));
+        Target = target;
+        Path = RelativePaths.Contained(path, nameof(path));
+        Manages = Copy(manages, nameof(manages));
+        Steps = steps is null ? null : new ReadOnlyCollection<string>(steps.ToArray());
+        Uninstall = uninstall is null ? null : new ReadOnlyCollection<string>(uninstall.ToArray());
+
+        // ModManifest.Save regenerates it from the game's own list.
+        if (Target == InstallAnchor.UserData && Path is null && Manages?.Any(IsGameManifest) == true)
+            throw new ArgumentException("manifest.toml under user-data belongs to the game and cannot be managed.", nameof(manages));
+    }
+
+    private static bool IsGameManifest(string claimed) =>
+        string.Equals(claimed.TrimStart('.', '/').TrimEnd('/'), "manifest.toml", StringComparison.OrdinalIgnoreCase);
+
+    private static IReadOnlyList<string>? Copy(IReadOnlyList<string>? manages, string paramName)
+    {
+        if (manages is null)
+            return null;
+
+        foreach (var claimed in manages)
+            RelativePaths.Contained(claimed, paramName);
+
+        return new ReadOnlyCollection<string>(manages.ToArray());
+    }
+}

--- a/src/Borea.Core/Mods/InstallInfo.cs
+++ b/src/Borea.Core/Mods/InstallInfo.cs
@@ -25,32 +25,9 @@ public sealed class InstallInfo
 
     public InstallInfo(string? root, bool derived, InstallAnchor? target = null, string? path = null)
     {
-        Root = Contained(root, nameof(root));
+        Root = RelativePaths.Contained(root, nameof(root));
         Derived = derived;
         Target = target;
-        Path = Contained(path, nameof(path));
-    }
-
-    /// <summary>
-    /// The value as a relative, '/' separated path that stays inside its anchor
-    /// (RFC 0035 rules 1 and 2). Null passes through, empty does not. A backslash
-    /// is rejected rather than read as a separator, the way the index stamps it.
-    /// </summary>
-    private static string? Contained(string? value, string paramName)
-    {
-        if (value is null)
-            return null;
-
-        if (string.IsNullOrWhiteSpace(value))
-            throw new ArgumentException("A stated path cannot be empty, leave it absent instead.", paramName);
-
-        if (value.StartsWith('/') || value.StartsWith('~') || value.Contains('\\') ||
-            value.Contains(':') || value.Split('/').Any(segment => segment == ".."))
-        {
-            throw new ArgumentException(
-                "A path must be relative, '/' separated, and must stay inside its anchor.", paramName);
-        }
-
-        return value;
+        Path = RelativePaths.Contained(path, nameof(path));
     }
 }

--- a/src/Borea.Core/Mods/ModMetadata.cs
+++ b/src/Borea.Core/Mods/ModMetadata.cs
@@ -110,10 +110,10 @@ public sealed class ModMetadata
     /// </summary>
     public IReadOnlyList<ModDependency> Dependencies { get; }
 
-    /// <summary>
-    /// Authored override of the install root for archives with an unusual layout.
-    /// </summary>
-    public string? InstallRootOverride { get; }
+    /// <summary>Where the content goes. Null means the type default.</summary>
+    public InstallDescriptor? Install { get; }
+
+    public LoaderProvides? Provides { get; }
 
     public ModMetadata(
         int specVersion,
@@ -135,7 +135,8 @@ public sealed class ModMetadata
         IReadOnlyList<string>? os = null,
         LoaderRequirement? loader = null,
         IReadOnlyList<ModDependency>? dependencies = null,
-        string? installRootOverride = null)
+        InstallDescriptor? install = null,
+        LoaderProvides? provides = null)
     {
         if (specVersion < 1)
             throw new ArgumentOutOfRangeException(nameof(specVersion), "Spec version must be a positive integer.");
@@ -147,6 +148,17 @@ public sealed class ModMetadata
 
         if (loader is not null && type != ContentType.Mod)
             throw new ArgumentException("Only a mod can declare a loader requirement.", nameof(loader));
+
+        if (provides is not null && type != ContentType.ModLoader)
+            throw new ArgumentException("Only a mod loader can declare what it provides.", nameof(provides));
+
+        // A loader has no default to fall back on, so a stated table needs a
+        // target. No table at all is valid and means undescribed.
+        if (install is not null && install.Target is null && type == ContentType.ModLoader)
+            throw new ArgumentException("A mod loader has no default install target, so it must state one.", nameof(install));
+
+        if (install?.Target == InstallAnchor.Standalone && provides?.Launch is null)
+            throw new ArgumentException("A standalone install target needs the launch target that reaches it.", nameof(install));
 
         if (string.IsNullOrWhiteSpace(source))
             throw new ArgumentException("Source cannot be null or whitespace.", nameof(source));
@@ -195,6 +207,7 @@ public sealed class ModMetadata
         Os = os is null ? null : new ReadOnlyCollection<string>(os.ToArray());
         Loader = loader;
         Dependencies = dependencies is null ? Array.Empty<ModDependency>() : new ReadOnlyCollection<ModDependency>(dependencies.ToArray());
-        InstallRootOverride = installRootOverride;
+        Install = install;
+        Provides = provides;
     }
 }

--- a/src/Borea.Core/Mods/RelativePaths.cs
+++ b/src/Borea.Core/Mods/RelativePaths.cs
@@ -1,0 +1,29 @@
+namespace Borea.Core.Mods;
+
+/// <summary>
+/// The path rule every install descriptor shares (RFC 0035 rules 1 and 2).
+/// </summary>
+public static class RelativePaths
+{
+    /// <summary>
+    /// A relative, '/' separated path that stays inside its anchor. Null passes
+    /// through, empty does not.
+    /// </summary>
+    public static string? Contained(string? value, string paramName)
+    {
+        if (value is null)
+            return null;
+
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("A stated path cannot be empty, leave it absent instead.", paramName);
+
+        if (value.StartsWith('/') || value.StartsWith('~') || value.Contains('\\') ||
+            value.Contains(':') || value.Split('/').Any(segment => segment == ".."))
+        {
+            throw new ArgumentException(
+                "A path must be relative, '/' separated, and must stay inside its anchor.", paramName);
+        }
+
+        return value;
+    }
+}

--- a/src/Borea.Network/Sources/CompositeModRepository.cs
+++ b/src/Borea.Network/Sources/CompositeModRepository.cs
@@ -92,7 +92,8 @@ public sealed class CompositeModRepository : IModRepository
         original.Os,
         original.Loader,
         original.Dependencies,
-        original.InstallRootOverride);
+        original.Install,
+        original.Provides);
 
     private static ModVersionMetadata Tag(ModVersionMetadata original, string source) => new(
         original.SpecVersion,

--- a/src/Borea.Storage/Mods/InstallDescriptorDto.cs
+++ b/src/Borea.Storage/Mods/InstallDescriptorDto.cs
@@ -1,0 +1,17 @@
+namespace Borea.Storage.Mods;
+
+/// <summary>
+/// TOML-serializable representation of the authored InstallDescriptor.
+/// </summary>
+public sealed class InstallDescriptorDto
+{
+    public string? Root { get; set; }
+
+    /// <summary>The anchor, lowercase.</summary>
+    public string? Target { get; set; }
+
+    public string? Path { get; set; }
+    public List<string>? Manages { get; set; }
+    public List<string>? Steps { get; set; }
+    public List<string>? Uninstall { get; set; }
+}

--- a/src/Borea.Storage/Mods/InstallDescriptorMapper.cs
+++ b/src/Borea.Storage/Mods/InstallDescriptorMapper.cs
@@ -1,0 +1,24 @@
+using Borea.Core.Mods;
+
+namespace Borea.Storage.Mods;
+
+public static class InstallDescriptorMapper
+{
+    public static InstallDescriptorDto ToDto(InstallDescriptor install) => new()
+    {
+        Root = install.Root,
+        Target = install.Target is { } target ? MetadataEnumMapper.ToDto(target) : null,
+        Path = install.Path,
+        Manages = install.Manages?.ToList(),
+        Steps = install.Steps?.ToList(),
+        Uninstall = install.Uninstall?.ToList(),
+    };
+
+    public static InstallDescriptor FromDto(InstallDescriptorDto dto) => new(
+        dto.Root,
+        dto.Target is null ? null : MetadataEnumMapper.ParseAnchor(dto.Target),
+        dto.Path,
+        dto.Manages,
+        dto.Steps,
+        dto.Uninstall);
+}

--- a/src/Borea.Storage/Mods/LoaderProvidesDto.cs
+++ b/src/Borea.Storage/Mods/LoaderProvidesDto.cs
@@ -1,0 +1,29 @@
+namespace Borea.Storage.Mods;
+
+/// <summary>
+/// TOML-serializable representation of the authored LoaderProvides.
+/// </summary>
+public sealed class LoaderProvidesDto
+{
+    public string? Launch { get; set; }
+
+    /// <summary>The anchor, lowercase.</summary>
+    public string? ContentDir { get; set; }
+
+    public string? ContentPath { get; set; }
+
+    public LoaderConfigureDto? Configure { get; set; }
+}
+
+/// <summary>
+/// TOML-serializable representation of the [provides.configure] table.
+/// </summary>
+public sealed class LoaderConfigureDto
+{
+    public string File { get; set; } = string.Empty;
+
+    /// <summary>Lowercase ("json", "toml").</summary>
+    public string Format { get; set; } = string.Empty;
+
+    public string? GamePath { get; set; }
+}

--- a/src/Borea.Storage/Mods/LoaderProvidesMapper.cs
+++ b/src/Borea.Storage/Mods/LoaderProvidesMapper.cs
@@ -1,0 +1,32 @@
+using Borea.Core.ModLoaders;
+
+namespace Borea.Storage.Mods;
+
+public static class LoaderProvidesMapper
+{
+    public static LoaderProvidesDto ToDto(LoaderProvides provides) => new()
+    {
+        Launch = provides.Launch,
+        ContentDir = provides.ContentDir is { } anchor ? MetadataEnumMapper.ToDto(anchor) : null,
+        ContentPath = provides.ContentPath,
+        Configure = provides.Configure is null ? null : ToDto(provides.Configure),
+    };
+
+    public static LoaderProvides FromDto(LoaderProvidesDto dto) => new(
+        dto.Launch,
+        dto.ContentDir is null ? null : MetadataEnumMapper.ParseAnchor(dto.ContentDir),
+        dto.ContentPath,
+        dto.Configure is null ? null : FromDto(dto.Configure));
+
+    public static LoaderConfigureDto ToDto(LoaderConfigure configure) => new()
+    {
+        File = configure.File,
+        Format = MetadataEnumMapper.ToDto(configure.Format),
+        GamePath = configure.GamePath,
+    };
+
+    public static LoaderConfigure FromDto(LoaderConfigureDto dto) => new(
+        dto.File,
+        MetadataEnumMapper.ParseConfigureFormat(dto.Format),
+        dto.GamePath);
+}

--- a/src/Borea.Storage/Mods/MetadataEnumMapper.cs
+++ b/src/Borea.Storage/Mods/MetadataEnumMapper.cs
@@ -96,6 +96,20 @@ public static class MetadataEnumMapper
         _ => InstallAnchor.Unknown,
     };
 
+    public static string ToDto(Core.ModLoaders.ConfigureFormat format) => format switch
+    {
+        Core.ModLoaders.ConfigureFormat.Json => "json",
+        Core.ModLoaders.ConfigureFormat.Toml => "toml",
+        _ => "unknown",
+    };
+
+    public static Core.ModLoaders.ConfigureFormat ParseConfigureFormat(string value) => value.ToLowerInvariant() switch
+    {
+        "json" => Core.ModLoaders.ConfigureFormat.Json,
+        "toml" => Core.ModLoaders.ConfigureFormat.Toml,
+        _ => Core.ModLoaders.ConfigureFormat.Unknown,
+    };
+
     public static string? ToDto(MetadataSource? source) => source switch
     {
         null => null,

--- a/src/Borea.Storage/Mods/ModMetadataDto.cs
+++ b/src/Borea.Storage/Mods/ModMetadataDto.cs
@@ -38,5 +38,7 @@ public sealed class ModMetadataDto
 
     public LoaderRequirementDto? Loader { get; set; }
     public List<ModDependencyDto> Dependencies { get; set; } = new();
-    public string? InstallRootOverride { get; set; }
+    public InstallDescriptorDto? Install { get; set; }
+
+    public LoaderProvidesDto? Provides { get; set; }
 }

--- a/src/Borea.Storage/Mods/ModMetadataMapper.cs
+++ b/src/Borea.Storage/Mods/ModMetadataMapper.cs
@@ -25,7 +25,8 @@ public static class ModMetadataMapper
         Os = metadata.Os?.ToList(),
         Loader = metadata.Loader is null ? null : LoaderRequirementMapper.ToDto(metadata.Loader),
         Dependencies = metadata.Dependencies.Select(ModDependencyMapper.ToDto).ToList(),
-        InstallRootOverride = metadata.InstallRootOverride,
+        Install = metadata.Install is null ? null : InstallDescriptorMapper.ToDto(metadata.Install),
+        Provides = metadata.Provides is null ? null : LoaderProvidesMapper.ToDto(metadata.Provides),
     };
 
     public static ModMetadata FromDto(ModMetadataDto dto)
@@ -55,6 +56,7 @@ public static class ModMetadataMapper
         os: dto.Os,
         loader: dto.Loader is null ? null : LoaderRequirementMapper.FromDto(dto.Loader),
         dependencies: dto.Dependencies.Select(ModDependencyMapper.FromDto).ToList(),
-        installRootOverride: dto.InstallRootOverride);
+        install: dto.Install is null ? null : InstallDescriptorMapper.FromDto(dto.Install),
+        provides: dto.Provides is null ? null : LoaderProvidesMapper.FromDto(dto.Provides));
     }
 }

--- a/tests/Borea.Core.Tests/ModLoaders/LoaderProvidesTests.cs
+++ b/tests/Borea.Core.Tests/ModLoaders/LoaderProvidesTests.cs
@@ -1,0 +1,85 @@
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+
+namespace Borea.Core.Tests.ModLoaders;
+
+public sealed class LoaderProvidesTests
+{
+    [Fact]
+    public void Constructor_TheStarMapShape_IsAccepted()
+    {
+        var provides = new LoaderProvides(
+            launch: "StarMap.exe",
+            contentDir: InstallAnchor.Mods,
+            configure: new LoaderConfigure("StarMapConfig.json", ConfigureFormat.Json, "GameLocation"));
+
+        Assert.Equal("StarMap.exe", provides.Launch);
+        Assert.Equal(InstallAnchor.Mods, provides.ContentDir);
+        Assert.Null(provides.ContentPath);
+        Assert.Equal("GameLocation", provides.Configure!.GamePath);
+    }
+
+    [Fact]
+    public void Constructor_NothingStated_ReadsNoContentDirectory()
+    {
+        var provides = new LoaderProvides();
+
+        Assert.Null(provides.Launch);
+        Assert.Null(provides.ContentDir);
+        Assert.Null(provides.Configure);
+    }
+
+    [Fact]
+    public void Constructor_UnknownContentDir_IsKeptSoTheListingStaysReadable()
+    {
+        var provides = new LoaderProvides(contentDir: InstallAnchor.Unknown);
+
+        Assert.Equal(InstallAnchor.Unknown, provides.ContentDir);
+    }
+
+    [Fact]
+    public void Constructor_ContentPathWithoutItsAnchor_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => new LoaderProvides(contentPath: "loaders"));
+    }
+
+    [Theory]
+    [InlineData("/absolute/StarMap.exe")]
+    [InlineData("../StarMap.exe")]
+    public void Constructor_LaunchLeavingItsAnchor_ThrowsArgumentException(string launch)
+    {
+        Assert.Throws<ArgumentException>(() => new LoaderProvides(launch: launch));
+    }
+
+    [Fact]
+    public void Configure_UnknownFormat_IsKeptSoTheListingStaysReadable()
+    {
+        var configure = new LoaderConfigure("Config.ini", ConfigureFormat.Unknown);
+
+        Assert.Equal(ConfigureFormat.Unknown, configure.Format);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Configure_NoFile_ThrowsArgumentException(string? file)
+    {
+        Assert.Throws<ArgumentException>(() => new LoaderConfigure(file!, ConfigureFormat.Json));
+    }
+
+    [Fact]
+    public void Configure_FileLeavingItsAnchor_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => new LoaderConfigure("../StarMapConfig.json", ConfigureFormat.Json));
+    }
+
+    [Fact]
+    public void Configure_NestedGamePathKey_IsAccepted()
+    {
+        // Addressed dot-separated from the document root.
+        var configure = new LoaderConfigure("Config.toml", ConfigureFormat.Toml, "loader.game.path");
+
+        Assert.Equal("loader.game.path", configure.GamePath);
+    }
+}

--- a/tests/Borea.Core.Tests/Mods/InstallDescriptorTests.cs
+++ b/tests/Borea.Core.Tests/Mods/InstallDescriptorTests.cs
@@ -1,0 +1,109 @@
+using Borea.Core.Mods;
+
+namespace Borea.Core.Tests.Mods;
+
+public sealed class InstallDescriptorTests
+{
+    [Fact]
+    public void Constructor_NothingStated_LeavesEveryFieldAbsent()
+    {
+        var install = new InstallDescriptor();
+
+        Assert.Null(install.Root);
+        Assert.Null(install.Target);
+        Assert.Null(install.Path);
+        Assert.Null(install.Manages);
+        Assert.Null(install.Steps);
+        Assert.Null(install.Uninstall);
+    }
+
+    [Fact]
+    public void Constructor_TheStarMapShape_IsAccepted()
+    {
+        var install = new InstallDescriptor(
+            target: InstallAnchor.Standalone,
+            uninstall: new[] { "Delete the StarMap directory." });
+
+        Assert.Equal(InstallAnchor.Standalone, install.Target);
+        Assert.Single(install.Uninstall!);
+    }
+
+    [Fact]
+    public void Constructor_EmptyProseList_StaysDistinctFromAbsent()
+    {
+        // Absent is not empty.
+        var install = new InstallDescriptor(steps: Array.Empty<string>());
+
+        Assert.Empty(install.Steps!);
+        Assert.Null(install.Uninstall);
+    }
+
+    [Fact]
+    public void Constructor_UnknownTarget_IsKeptSoTheListingStaysReadable()
+    {
+        var install = new InstallDescriptor(target: InstallAnchor.Unknown);
+
+        Assert.Equal(InstallAnchor.Unknown, install.Target);
+    }
+
+    [Theory]
+    [InlineData("/absolute")]
+    [InlineData("~/home")]
+    [InlineData("back\\slash")]
+    [InlineData("C:/drive")]
+    [InlineData("../escape")]
+    public void Constructor_PathLeavingItsAnchor_ThrowsArgumentException(string path)
+    {
+        Assert.Throws<ArgumentException>(() => new InstallDescriptor(path: path));
+    }
+
+    [Fact]
+    public void Constructor_ManagedPathLeavingItsAnchor_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => new InstallDescriptor(manages: new[] { "../elsewhere.json" }));
+    }
+
+    [Theory]
+    [InlineData("manifest.toml")]
+    [InlineData("Manifest.TOML")]
+    [InlineData("./manifest.toml")]
+    [InlineData("manifest.toml/")]
+    public void Constructor_ManagesTheGamesManifest_ThrowsArgumentException(string claimed)
+    {
+        // ModManifest.Save regenerates it from the game's own list.
+        Assert.Throws<ArgumentException>(() =>
+            new InstallDescriptor(target: InstallAnchor.UserData, manages: new[] { claimed }));
+    }
+
+    [Fact]
+    public void Constructor_ManifestBelowAPath_IsSomebodyElsesFile()
+    {
+        // This claims Saves/manifest.toml, which the game does not own.
+        var install = new InstallDescriptor(
+            target: InstallAnchor.UserData,
+            path: "Saves",
+            manages: new[] { "manifest.toml" });
+
+        Assert.Single(install.Manages!);
+    }
+
+    [Fact]
+    public void Constructor_ManifestUnderAnotherAnchor_IsAccepted()
+    {
+        // The rule is about the game's file, not the name.
+        var install = new InstallDescriptor(target: InstallAnchor.Standalone, manages: new[] { "manifest.toml" });
+
+        Assert.Single(install.Manages!);
+    }
+
+    [Fact]
+    public void Manages_IsACopy_SoLaterEditsDoNotReachIt()
+    {
+        var manages = new List<string> { "config/settings.json" };
+        var install = new InstallDescriptor(manages: manages);
+
+        manages.Add("another.json");
+
+        Assert.Single(install.Manages!);
+    }
+}

--- a/tests/Borea.Core.Tests/Mods/ModMetadataTests.cs
+++ b/tests/Borea.Core.Tests/Mods/ModMetadataTests.cs
@@ -15,7 +15,9 @@ public sealed class ModMetadataTests
         ContentType type = ContentType.Mod,
         LoaderRequirement? loader = null,
         string? supersededBy = null,
-        int specVersion = SpecVersions.Highest) =>
+        int specVersion = SpecVersions.Highest,
+        InstallDescriptor? install = null,
+        LoaderProvides? provides = null) =>
         new(
             specVersion: specVersion,
             modId: modId,
@@ -28,7 +30,9 @@ public sealed class ModMetadataTests
             gameMin: "2026.7.4.2131",
             type: type,
             loader: loader,
-            supersededBy: supersededBy);
+            supersededBy: supersededBy,
+            install: install,
+            provides: provides);
 
     [Fact]
     public void Constructor_ValidInput_SetsAllProperties()
@@ -127,5 +131,61 @@ public sealed class ModMetadataTests
         var metadata = Build(specVersion: SpecVersions.Highest + 1);
 
         Assert.True(SpecVersions.IsAboveHighest(metadata.SpecVersion));
+    }
+
+    [Fact]
+    public void Constructor_ProvidesOnAMod_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => Build(provides: new LoaderProvides(launch: "Loader.exe")));
+    }
+
+    [Fact]
+    public void Constructor_ModLoaderStatingInstallWithoutATarget_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            Build(type: ContentType.ModLoader, install: new InstallDescriptor(root: "StarMap")));
+    }
+
+    [Fact]
+    public void Constructor_ModLoaderWithNoInstallTableAtAll_IsUndescribed()
+    {
+        // the manager installs nothing and shows the links.
+        var metadata = Build(type: ContentType.ModLoader);
+
+        Assert.Null(metadata.Install);
+    }
+
+    [Fact]
+    public void Constructor_ModWithoutAnInstallTarget_IsAccepted()
+    {
+        var metadata = Build(install: new InstallDescriptor(root: "build/Mod"));
+
+        Assert.Null(metadata.Install!.Target);
+    }
+
+    [Fact]
+    public void Constructor_StandaloneWithoutALaunchTarget_ThrowsArgumentException()
+    {
+        // A directory nothing ever runs from is not an install.
+        Assert.Throws<ArgumentException>(() => Build(
+            type: ContentType.ModLoader,
+            install: new InstallDescriptor(target: InstallAnchor.Standalone)));
+    }
+
+    [Fact]
+    public void Constructor_TheStarMapListing_IsAccepted()
+    {
+        var metadata = Build(
+            type: ContentType.ModLoader,
+            install: new InstallDescriptor(
+                target: InstallAnchor.Standalone,
+                uninstall: new[] { "Delete the StarMap directory." }),
+            provides: new LoaderProvides(
+                launch: "StarMap.exe",
+                contentDir: InstallAnchor.Mods,
+                configure: new LoaderConfigure("StarMapConfig.json", ConfigureFormat.Json, "GameLocation")));
+
+        Assert.Equal(InstallAnchor.Standalone, metadata.Install!.Target);
+        Assert.Equal("StarMap.exe", metadata.Provides!.Launch);
     }
 }

--- a/tests/Borea.Network.Tests/Sources/CompositeModRepositoryTests.cs
+++ b/tests/Borea.Network.Tests/Sources/CompositeModRepositoryTests.cs
@@ -85,7 +85,7 @@ public sealed class CompositeModRepositoryTests
         Assert.Equal(original.Dependencies.Count, tagged.Dependencies.Count);
         Assert.Equal(original.Dependencies[0].ModId, tagged.Dependencies[0].ModId);
         Assert.True(tagged.Dependencies[1].IsAnyOf);
-        Assert.Equal(original.InstallRootOverride, tagged.InstallRootOverride);
+        Assert.Equal(original.Install!.Root, tagged.Install!.Root);
     }
 
     [Fact]

--- a/tests/Borea.Network.Tests/Temp/TestFixture.cs
+++ b/tests/Borea.Network.Tests/Temp/TestFixture.cs
@@ -71,7 +71,7 @@ internal static class TestFixtures
                     new ModDependencyAlternative("audio-b"),
                 }),
             },
-            installRootOverride: "UnusualRoot");
+            install: new InstallDescriptor(root: "UnusualRoot"));
 
     /// <summary>
     /// A release with every optional field populated, including yanked.

--- a/tests/Borea.Storage.Tests/Mods/MetadataFixtures.cs
+++ b/tests/Borea.Storage.Tests/Mods/MetadataFixtures.cs
@@ -63,7 +63,11 @@ internal static class MetadataFixtures
                 new ModDependencyAlternative("audio-b"),
             }),
         },
-        installRootOverride: "UnusualRoot");
+        install: new InstallDescriptor(
+            root: "UnusualRoot",
+            manages: new[] { "config/settings.json" },
+            steps: new[] { "Relaunch the game once to enable it." },
+            uninstall: Array.Empty<string>()));
 
     public static DownloadInfo SampleDownload() =>
         new("https://example.com/mod.zip", new string('A', 64), 1024, "application/zip", new[] { "https://mirror.example/mod.zip" });

--- a/tests/Borea.Storage.Tests/Mods/ModMetadataMapperTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/ModMetadataMapperTests.cs
@@ -1,4 +1,5 @@
-﻿using Borea.Core.Mods;
+﻿using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
 using Borea.Storage.Mods;
 using Borea.Storage.Toml;
 
@@ -40,7 +41,11 @@ public sealed class ModMetadataMapperTests : IDisposable
         Assert.Equal(original.GameMin, reloaded.GameMin);
         Assert.Equal(original.GameMax, reloaded.GameMax);
         Assert.Equal(original.Os, reloaded.Os);
-        Assert.Equal(original.InstallRootOverride, reloaded.InstallRootOverride);
+        Assert.Equal(original.Install!.Root, reloaded.Install!.Root);
+        Assert.Equal(original.Install.Manages, reloaded.Install.Manages);
+        Assert.Equal(original.Install.Steps, reloaded.Install.Steps);
+        // Absent is not empty.
+        Assert.Empty(reloaded.Install.Uninstall!);
 
         Assert.NotNull(reloaded.Releases);
         Assert.Equal("github", reloaded.Releases!.Authority);
@@ -65,7 +70,7 @@ public sealed class ModMetadataMapperTests : IDisposable
         Assert.Contains("SupersededBy", tomlText);
         Assert.Contains("GameMax", tomlText);
         Assert.Contains("Os = ", tomlText);
-        Assert.Contains("InstallRootOverride", tomlText);
+        Assert.Contains("[Install]", tomlText);
 
         // The enum vocabulary on disk stays the format's lowercase spelling.
         Assert.Contains("Status = \"deprecated\"", tomlText);
@@ -87,7 +92,8 @@ public sealed class ModMetadataMapperTests : IDisposable
         Assert.Null(reloadedDto.GameMax);
         Assert.Null(reloadedDto.Os);
         Assert.Null(reloadedDto.Loader);
-        Assert.Null(reloadedDto.InstallRootOverride);
+        Assert.Null(reloadedDto.Install);
+        Assert.Null(reloadedDto.Provides);
 
         Assert.Null(reloaded.Description);
         Assert.Null(reloaded.GameMax);
@@ -100,7 +106,7 @@ public sealed class ModMetadataMapperTests : IDisposable
         Assert.DoesNotContain("SupersededBy", tomlText);
         Assert.DoesNotContain("GameMax", tomlText);
         Assert.DoesNotContain("Os = ", tomlText);
-        Assert.DoesNotContain("InstallRootOverride", tomlText);
+        Assert.DoesNotContain("[Install]", tomlText);
     }
 
     [Fact]
@@ -144,6 +150,52 @@ public sealed class ModMetadataMapperTests : IDisposable
 
         Assert.Equal(ModStatus.Unknown, reloaded.Status);
         Assert.Equal(ContentType.Unknown, reloaded.Type);
+    }
+
+    [Fact]
+    public async Task RoundTrip_TheStarMapListing_KeepsInstallAndProvides()
+    {
+        var original = new ModMetadata(
+            specVersion: 1,
+            modId: "StarMap",
+            source: "TestSource",
+            name: "StarMap",
+            authors: new[] { "KlaasWhite" },
+            abstractText: "Mod loader that runs code mods.",
+            license: "MIT",
+            links: MetadataFixtures.SampleLinks(),
+            gameMin: "2026.8.3.5117",
+            type: ContentType.ModLoader,
+            install: new InstallDescriptor(
+                target: InstallAnchor.Standalone,
+                uninstall: new[] { "Delete the StarMap directory." }),
+            provides: new LoaderProvides(
+                launch: "StarMap.exe",
+                contentDir: InstallAnchor.Mods,
+                configure: new LoaderConfigure("StarMapConfig.json", ConfigureFormat.Json, "GameLocation")));
+
+        var (reloaded, _, tomlText) = await RoundTripAsync(original);
+
+        Assert.Equal(InstallAnchor.Standalone, reloaded.Install!.Target);
+        Assert.Single(reloaded.Install.Uninstall!);
+        Assert.Null(reloaded.Install.Steps);
+        Assert.Equal("StarMap.exe", reloaded.Provides!.Launch);
+        Assert.Equal(InstallAnchor.Mods, reloaded.Provides.ContentDir);
+        Assert.Equal(ConfigureFormat.Json, reloaded.Provides.Configure!.Format);
+        Assert.Equal("GameLocation", reloaded.Provides.Configure.GamePath);
+
+        Assert.Contains("Target = \"standalone\"", tomlText);
+        Assert.Contains("ContentDir = \"mods\"", tomlText);
+        Assert.Contains("Format = \"json\"", tomlText);
+    }
+
+    [Fact]
+    public void FromDto_UnknownInstallTarget_ParsesToUnknown()
+    {
+        var dto = ModMetadataMapper.ToDto(MetadataFixtures.FullMetadata());
+        dto.Install!.Target = "somewhere-new";
+
+        Assert.Equal(InstallAnchor.Unknown, ModMetadataMapper.FromDto(dto).Install!.Target);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #43.

The StarMap listing in the live index already carries the whole `[install]` and `[provides]` tables and`InstallDescriptor` and `LoaderProvides` carry them now.
