### PR TITLE
Answer every dependency kind

### DIFF
--- a/src/Borea.Core/Dependencies/DependencyEvaluation.cs
+++ b/src/Borea.Core/Dependencies/DependencyEvaluation.cs
@@ -1,0 +1,37 @@
+using Borea.Core.Mods;
+
+namespace Borea.Core.Dependencies;
+
+public sealed class DependencyEvaluation
+{
+    public ModDependency Dependency { get; }
+
+    public DependencyOutcome Outcome { get; }
+
+    public string? DeclaredBy { get; }
+
+    /// <summary>
+    /// The installed mod that meets the entry or stands in the way of a conflict,
+    /// which for an any_of entry names the alternative that answered it. Null when
+    /// no installed mod does either.
+    /// </summary>
+    public string? InstalledModId { get; }
+
+    public DependencyEvaluation(
+        ModDependency dependency,
+        DependencyOutcome outcome,
+        string? declaredBy = null,
+        string? installedModId = null)
+    {
+        Dependency = dependency ?? throw new ArgumentNullException(nameof(dependency));
+        Outcome = outcome;
+        DeclaredBy = declaredBy;
+        InstalledModId = installedModId;
+    }
+
+    public override string ToString()
+    {
+        var declaredBy = DeclaredBy is null ? "" : $" declared by '{DeclaredBy}'";
+        return $"{Outcome}: {Dependency}{declaredBy}";
+    }
+}

--- a/src/Borea.Core/Dependencies/DependencyOutcome.cs
+++ b/src/Borea.Core/Dependencies/DependencyOutcome.cs
@@ -1,0 +1,21 @@
+namespace Borea.Core.Dependencies;
+
+public enum DependencyOutcome
+{
+    /// <summary>The instance meets the entry.</summary>
+    Satisfied = 0,
+
+    /// <summary>Required and missing.</summary>
+    Install = 1,
+
+    /// <summary>Recommended and missing. Preselected, deselectable.</summary>
+    SelectByDefault = 2,
+
+    /// <summary>Optional or suggested and missing. Listed, not selected.</summary>
+    Offer = 3,
+
+    /// <summary>An installed version falls inside a conflicting range.</summary>
+    Conflict = 4,
+
+    Unknown = 5,
+}

--- a/src/Borea.Core/Dependencies/ModDependencyResolver.cs
+++ b/src/Borea.Core/Dependencies/ModDependencyResolver.cs
@@ -11,7 +11,8 @@ public sealed class ModDependencyResolver
 {
     /// <summary>
     /// Weighs every entry that bears on installing a release into an instance.
-    /// the ones the release declares, in document order.
+    /// the ones the release declares, in document order, then the ones installed
+    /// mods declare against it. group by <see cref="DependencyEvaluation.InstalledModId"/>.
     /// </summary>
     public IReadOnlyList<DependencyEvaluation> Evaluate(Instance instance, ModVersionMetadata candidate)
     {
@@ -22,6 +23,8 @@ public sealed class ModDependencyResolver
 
         foreach (var dependency in candidate.Dependencies)
             evaluations.Add(EvaluateDeclared(instance, dependency));
+
+        evaluations.AddRange(DeclaredAgainst(instance, candidate));
 
         return evaluations;
     }
@@ -78,6 +81,38 @@ public sealed class ModDependencyResolver
         return dependency.Kind == ModDependencyKind.Conflict
             ? new DependencyEvaluation(dependency, DependencyOutcome.Conflict, installedModId: match.ModId)
             : new DependencyEvaluation(dependency, DependencyOutcome.Satisfied, installedModId: match.ModId);
+    }
+
+    private static IEnumerable<DependencyEvaluation> DeclaredAgainst(Instance instance, ModVersionMetadata candidate)
+    {
+        foreach (var installed in instance.Mods)
+        {
+            // An update replaces the copy of the same id
+            if (ModIds.Equals(installed.ModId, candidate.ModId))
+                continue;
+
+            foreach (var dependency in installed.Metadata.Dependencies)
+            {
+                // An any_of entry has no single id
+                if (!ModIds.Equals(dependency.ModId, candidate.ModId))
+                    continue;
+
+                if (dependency.Kind == ModDependencyKind.Unknown)
+                {
+                    yield return new DependencyEvaluation(dependency, DependencyOutcome.Unknown, declaredBy: installed.ModId);
+                    continue;
+                }
+
+                if (dependency.Kind != ModDependencyKind.Conflict || !dependency.BoundsContain(candidate.Version))
+                    continue;
+
+                yield return new DependencyEvaluation(
+                    dependency,
+                    DependencyOutcome.Conflict,
+                    declaredBy: installed.ModId,
+                    installedModId: installed.ModId);
+            }
+        }
     }
 
     private static DependencyOutcome MissingOutcome(ModDependencyKind kind) => kind switch

--- a/src/Borea.Core/Dependencies/ModDependencyResolver.cs
+++ b/src/Borea.Core/Dependencies/ModDependencyResolver.cs
@@ -4,32 +4,33 @@ using Borea.Core.Mods;
 namespace Borea.Core.Dependencies;
 
 /// <summary>
-/// Computes dependency relationships between mods within a specific instance.
-/// Evaluates required entries; the other kinds are carried but not acted on.
+/// Computes dependency relationships between mods within a specific instance,
+/// following the dependency kinds of RFC 0031.
 /// </summary>
 public sealed class ModDependencyResolver
 {
     /// <summary>
-    /// Gets the list of unsatisfied required dependencies for a release within an instance.
+    /// Weighs every entry that bears on installing a release into an instance.
+    /// the ones the release declares, in document order.
     /// </summary>
-    public IReadOnlyList<ModDependency> GetUnsatisfiedDependencies(Instance instance, ModVersionMetadata candidate)
+    public IReadOnlyList<DependencyEvaluation> Evaluate(Instance instance, ModVersionMetadata candidate)
     {
         if (instance is null) throw new ArgumentNullException(nameof(instance));
         if (candidate is null) throw new ArgumentNullException(nameof(candidate));
 
-        var unsatisfied = new List<ModDependency>();
+        var evaluations = new List<DependencyEvaluation>();
 
         foreach (var dependency in candidate.Dependencies)
-        {
-            if (dependency.Kind != ModDependencyKind.Required)
-                continue;
+            evaluations.Add(EvaluateDeclared(instance, dependency));
 
-            if (!IsSatisfied(instance, dependency))
-                unsatisfied.Add(dependency);
-        }
-
-        return unsatisfied;
+        return evaluations;
     }
+
+    public IReadOnlyList<ModDependency> GetUnsatisfiedDependencies(Instance instance, ModVersionMetadata candidate)
+        => Evaluate(instance, candidate)
+            .Where(e => e.Outcome == DependencyOutcome.Install)
+            .Select(e => e.Dependency)
+            .ToList();
 
     /// <summary>
     /// Checks if a mod can be uninstalled from an instance, returning the list of dependent mods that would be affected.
@@ -48,13 +49,44 @@ public sealed class ModDependencyResolver
         return new UninstallCheck(instance.InstanceId, modId, version, dependents, isActive);
     }
 
-    private static bool IsSatisfied(Instance instance, ModDependency dependency)
+    private static DependencyEvaluation EvaluateDeclared(Instance instance, ModDependency dependency)
     {
-        if (dependency.IsAnyOf)
-            return dependency.AnyOf.Any(a => FindInstalled(instance, a.ModId) is { } m && a.BoundsContain(m.Version));
+        if (dependency.Kind == ModDependencyKind.Unknown)
+            return new DependencyEvaluation(dependency, DependencyOutcome.Unknown);
 
-        return FindInstalled(instance, dependency.ModId) is { } installed && dependency.BoundsContain(installed.Version);
+        if (dependency.IsAnyOf)
+        {
+            foreach (var alternative in dependency.AnyOf)
+            {
+                var alternativeMatch = FindInstalled(instance, alternative.ModId);
+                if (alternativeMatch is not null && alternative.BoundsContain(alternativeMatch.Version))
+                    return new DependencyEvaluation(dependency, DependencyOutcome.Satisfied, installedModId: alternativeMatch.ModId);
+            }
+
+            return new DependencyEvaluation(dependency, MissingOutcome(dependency.Kind));
+        }
+
+        var match = FindInstalled(instance, dependency.ModId);
+
+        if (match is null || !dependency.BoundsContain(match.Version))
+        {
+            return dependency.Kind == ModDependencyKind.Conflict
+                ? new DependencyEvaluation(dependency, DependencyOutcome.Satisfied)
+                : new DependencyEvaluation(dependency, MissingOutcome(dependency.Kind));
+        }
+
+        return dependency.Kind == ModDependencyKind.Conflict
+            ? new DependencyEvaluation(dependency, DependencyOutcome.Conflict, installedModId: match.ModId)
+            : new DependencyEvaluation(dependency, DependencyOutcome.Satisfied, installedModId: match.ModId);
     }
+
+    private static DependencyOutcome MissingOutcome(ModDependencyKind kind) => kind switch
+    {
+        ModDependencyKind.Required => DependencyOutcome.Install,
+        ModDependencyKind.Recommends => DependencyOutcome.SelectByDefault,
+        ModDependencyKind.Optional or ModDependencyKind.Suggests => DependencyOutcome.Offer,
+        _ => DependencyOutcome.Unknown,
+    };
 
     private static bool WouldBreakOnRemoval(Instance instance, ModDependency dependency, string removedId, ModVersion removedVersion)
     {

--- a/tests/Borea.Core.Tests/Dependencies/DependencyEvaluationTests.cs
+++ b/tests/Borea.Core.Tests/Dependencies/DependencyEvaluationTests.cs
@@ -1,0 +1,275 @@
+using Borea.Core.Dependencies;
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+using Borea.Core.Tests.Mods;
+
+namespace Borea.Core.Tests.Dependencies;
+
+/// <summary>
+/// The dependency kinds of RFC 0031.
+/// </summary>
+public sealed class DependencyEvaluationTests
+{
+    private readonly ModDependencyResolver _resolver = new();
+
+    private static Instance NewInstance() => new("Test", InstanceSource.Custom.Value);
+
+    private static ModDependency Entry(string modId, ModDependencyKind kind, string? min = null, string? max = null) =>
+        new(modId, kind,
+            min is null ? null : ModVersion.Parse(min),
+            max is null ? null : ModVersion.Parse(max));
+
+    private DependencyEvaluation Single(Instance instance, ModDependency dependency)
+    {
+        var candidate = TestFixtures.SampleVersionMetadata("candidate", dependencies: new[] { dependency });
+        return Assert.Single(_resolver.Evaluate(instance, candidate));
+    }
+
+    #region The four kinds a manager may install
+
+    [Theory]
+    [InlineData(ModDependencyKind.Required, DependencyOutcome.Install)]
+    [InlineData(ModDependencyKind.Recommends, DependencyOutcome.SelectByDefault)]
+    [InlineData(ModDependencyKind.Suggests, DependencyOutcome.Offer)]
+    [InlineData(ModDependencyKind.Optional, DependencyOutcome.Offer)]
+    public void Missing_ReportsTheOutcomeOfItsKind(ModDependencyKind kind, DependencyOutcome expected)
+    {
+        var evaluation = Single(NewInstance(), Entry("missing-mod", kind, "1.0.0"));
+
+        Assert.Equal(expected, evaluation.Outcome);
+        Assert.Null(evaluation.InstalledModId);
+        Assert.Null(evaluation.DeclaredBy);
+    }
+
+    [Theory]
+    [InlineData(ModDependencyKind.Required)]
+    [InlineData(ModDependencyKind.Recommends)]
+    [InlineData(ModDependencyKind.Suggests)]
+    [InlineData(ModDependencyKind.Optional)]
+    public void InstalledWithinBounds_IsSatisfied(ModDependencyKind kind)
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod("lib", "1.5.0"));
+
+        var evaluation = Single(instance, Entry("lib", kind, "1.0.0", "2.0.0"));
+
+        Assert.Equal(DependencyOutcome.Satisfied, evaluation.Outcome);
+        Assert.Equal("lib", evaluation.InstalledModId);
+    }
+
+    [Theory]
+    [InlineData("0.9.0")]
+    [InlineData("2.0.1")]
+    public void InstalledOutsideBounds_CountsAsMissing(string installedVersion)
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod("lib", installedVersion));
+
+        var evaluation = Single(instance, Entry("lib", ModDependencyKind.Required, "1.0.0", "2.0.0"));
+
+        Assert.Equal(DependencyOutcome.Install, evaluation.Outcome);
+        Assert.Null(evaluation.InstalledModId);
+    }
+
+    [Theory]
+    [InlineData("1.0.0")]
+    [InlineData("2.0.0")]
+    public void BoundsAreInclusive(string installedVersion)
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod("lib", installedVersion));
+
+        var evaluation = Single(instance, Entry("lib", ModDependencyKind.Required, "1.0.0", "2.0.0"));
+
+        Assert.Equal(DependencyOutcome.Satisfied, evaluation.Outcome);
+    }
+
+    [Fact]
+    public void AnAbsentMaximumLeavesTheUpperEndOpen()
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod("lib", "99.0.0"));
+
+        var evaluation = Single(instance, Entry("lib", ModDependencyKind.Required, "1.0.0"));
+
+        Assert.Equal(DependencyOutcome.Satisfied, evaluation.Outcome);
+    }
+
+    #endregion
+
+    #region Conflicts
+
+    [Fact]
+    public void Conflict_NothingInstalled_IsSatisfied()
+    {
+        var evaluation = Single(NewInstance(), Entry("rival", ModDependencyKind.Conflict, "1.0.0"));
+
+        Assert.Equal(DependencyOutcome.Satisfied, evaluation.Outcome);
+        Assert.Null(evaluation.InstalledModId);
+    }
+
+    [Fact]
+    public void Conflict_InstalledWithinTheConflictingRange_Conflicts()
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod("rival", "1.5.0"));
+
+        var evaluation = Single(instance, Entry("rival", ModDependencyKind.Conflict, "1.0.0", "2.0.0"));
+
+        Assert.Equal(DependencyOutcome.Conflict, evaluation.Outcome);
+        Assert.Equal("rival", evaluation.InstalledModId);
+        Assert.Null(evaluation.DeclaredBy);
+    }
+
+    [Theory]
+    [InlineData("0.9.0")]
+    [InlineData("2.0.1")]
+    public void Conflict_InstalledOutsideTheConflictingRange_IsSatisfied(string installedVersion)
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod("rival", installedVersion));
+
+        var evaluation = Single(instance, Entry("rival", ModDependencyKind.Conflict, "1.0.0", "2.0.0"));
+
+        Assert.Equal(DependencyOutcome.Satisfied, evaluation.Outcome);
+    }
+
+    [Theory]
+    [InlineData("0.0.1")]
+    [InlineData("1.5.0")]
+    [InlineData("99.0.0")]
+    public void Conflict_WithoutBounds_ConflictsWithEveryVersion(string installedVersion)
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod("rival", installedVersion));
+
+        var evaluation = Single(instance, Entry("rival", ModDependencyKind.Conflict));
+
+        Assert.Equal(DependencyOutcome.Conflict, evaluation.Outcome);
+    }
+
+    #endregion
+
+    #region any_of
+
+    private static ModDependency AnyOf(ModDependencyKind kind) =>
+        ModDependency.OfAlternatives(kind, new[]
+        {
+            new ModDependencyAlternative("lib-a", ModVersion.Parse("2.0.0")),
+            new ModDependencyAlternative("lib-b", ModVersion.Parse("1.1.0")),
+        });
+
+    [Fact]
+    public void AnyOf_OneAlternativeInstalled_IsSatisfiedAndNamesIt()
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod("lib-b", "1.2.0"));
+
+        var evaluation = Single(instance, AnyOf(ModDependencyKind.Required));
+
+        Assert.Equal(DependencyOutcome.Satisfied, evaluation.Outcome);
+        Assert.Equal("lib-b", evaluation.InstalledModId);
+    }
+
+    [Theory]
+    [InlineData(ModDependencyKind.Required, DependencyOutcome.Install)]
+    [InlineData(ModDependencyKind.Recommends, DependencyOutcome.SelectByDefault)]
+    public void AnyOf_NoAlternativeInstalled_ReportsTheOutcomeOfItsKind(ModDependencyKind kind, DependencyOutcome expected)
+    {
+        var evaluation = Single(NewInstance(), AnyOf(kind));
+
+        Assert.Equal(expected, evaluation.Outcome);
+        Assert.Null(evaluation.InstalledModId);
+    }
+
+    [Fact]
+    public void AnyOf_AlternativeInstalledBelowItsOwnMinimum_CountsAsMissing()
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod("lib-b", "1.0.0"));
+
+        var evaluation = Single(instance, AnyOf(ModDependencyKind.Required));
+
+        Assert.Equal(DependencyOutcome.Install, evaluation.Outcome);
+    }
+
+    #endregion
+
+    #region A kind this build does not know
+
+    [Fact]
+    public void UnknownKind_IsReportedAndNothingIsClaimed()
+    {
+        var evaluation = Single(NewInstance(), Entry("mystery", ModDependencyKind.Unknown));
+
+        Assert.Equal(DependencyOutcome.Unknown, evaluation.Outcome);
+    }
+
+    [Fact]
+    public void UnknownKind_StaysUnknownEvenWhenItsIdIsInstalled()
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod("mystery", "1.5.0"));
+
+        var evaluation = Single(instance, Entry("mystery", ModDependencyKind.Unknown, "1.0.0"));
+
+        Assert.Equal(DependencyOutcome.Unknown, evaluation.Outcome);
+        Assert.Null(evaluation.InstalledModId);
+    }
+
+    #endregion
+
+    #region The list as a whole
+
+    [Fact]
+    public void Evaluate_NoDependencies_ReturnsEmpty()
+    {
+        Assert.Empty(_resolver.Evaluate(NewInstance(), TestFixtures.SampleVersionMetadata("candidate")));
+    }
+
+    [Fact]
+    public void Evaluate_KeepsDocumentOrder()
+    {
+        var candidate = TestFixtures.SampleVersionMetadata("candidate", dependencies: new[]
+        {
+            Entry("first", ModDependencyKind.Required, "1.0.0"),
+            Entry("second", ModDependencyKind.Suggests),
+        });
+
+        var evaluations = _resolver.Evaluate(NewInstance(), candidate);
+
+        Assert.Equal(2, evaluations.Count);
+        Assert.Equal("first", evaluations[0].Dependency.ModId);
+        Assert.Equal("second", evaluations[1].Dependency.ModId);
+    }
+
+    [Fact]
+    public void Evaluate_ComparesIdsCaseInsensitively()
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod("Lib", "1.5.0"));
+
+        var evaluation = Single(instance, Entry("lib", ModDependencyKind.Required, "1.0.0"));
+
+        Assert.Equal(DependencyOutcome.Satisfied, evaluation.Outcome);
+        Assert.Equal("Lib", evaluation.InstalledModId);
+    }
+
+    [Fact]
+    public void Evaluate_NullArguments_Throw()
+    {
+        var instance = NewInstance();
+        var candidate = TestFixtures.SampleVersionMetadata();
+
+        Assert.Throws<ArgumentNullException>(() => _resolver.Evaluate(null!, candidate));
+        Assert.Throws<ArgumentNullException>(() => _resolver.Evaluate(instance, null!));
+    }
+
+    [Fact]
+    public void Evaluation_WithoutADependency_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new DependencyEvaluation(null!, DependencyOutcome.Satisfied));
+    }
+
+    #endregion
+}

--- a/tests/Borea.Core.Tests/Dependencies/DependencyEvaluationTests.cs
+++ b/tests/Borea.Core.Tests/Dependencies/DependencyEvaluationTests.cs
@@ -148,6 +148,92 @@ public sealed class DependencyEvaluationTests
         Assert.Equal(DependencyOutcome.Conflict, evaluation.Outcome);
     }
 
+    [Fact]
+    public void Conflict_DeclaredByAnInstalledMod_IsReportedAgainstTheCandidate()
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod(
+            "incumbent",
+            dependencies: new[] { Entry("candidate", ModDependencyKind.Conflict, "1.0.0") }));
+        var candidate = TestFixtures.SampleVersionMetadata("candidate", "1.2.0");
+
+        var evaluation = Assert.Single(_resolver.Evaluate(instance, candidate));
+
+        Assert.Equal(DependencyOutcome.Conflict, evaluation.Outcome);
+        Assert.Equal("incumbent", evaluation.DeclaredBy);
+        Assert.Equal("incumbent", evaluation.InstalledModId);
+    }
+
+    [Fact]
+    public void Conflict_DeclaredByAnInstalledModAgainstAnotherVersion_IsNotReported()
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod(
+            "incumbent",
+            dependencies: new[] { Entry("candidate", ModDependencyKind.Conflict, "1.0.0", "1.1.0") }));
+        var candidate = TestFixtures.SampleVersionMetadata("candidate", "1.2.0");
+
+        Assert.Empty(_resolver.Evaluate(instance, candidate));
+    }
+
+    [Fact]
+    public void Conflict_DeclaredByTheCopyTheCandidateReplaces_IsNotReported()
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod(
+            "candidate",
+            "1.0.0",
+            dependencies: new[] { Entry("candidate", ModDependencyKind.Conflict) }));
+        var candidate = TestFixtures.SampleVersionMetadata("candidate", "1.2.0");
+
+        Assert.Empty(_resolver.Evaluate(instance, candidate));
+    }
+
+    [Fact]
+    public void Conflict_DeclaredByAnInstalledMod_ComparesIdsCaseInsensitively()
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod(
+            "incumbent",
+            dependencies: new[] { Entry("Candidate", ModDependencyKind.Conflict) }));
+        var candidate = TestFixtures.SampleVersionMetadata("candidate", "1.2.0");
+
+        Assert.Equal(DependencyOutcome.Conflict, Assert.Single(_resolver.Evaluate(instance, candidate)).Outcome);
+    }
+
+    [Fact]
+    public void Conflict_DeclaredByBothSides_IsReportedOncePerDeclaringSide()
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod(
+            "rival",
+            dependencies: new[] { Entry("candidate", ModDependencyKind.Conflict) }));
+        var candidate = TestFixtures.SampleVersionMetadata("candidate", dependencies: new[]
+        {
+            Entry("rival", ModDependencyKind.Conflict),
+        });
+
+        var evaluations = _resolver.Evaluate(instance, candidate);
+
+        Assert.Equal(2, evaluations.Count);
+        Assert.All(evaluations, e => Assert.Equal(DependencyOutcome.Conflict, e.Outcome));
+        // Both name the same installed mod, so grouping collapses them.
+        Assert.Single(evaluations.Select(e => e.InstalledModId).Distinct());
+        Assert.Equal(new string?[] { null, "rival" }, evaluations.Select(e => e.DeclaredBy));
+    }
+
+    [Fact]
+    public void Conflict_NonConflictEntriesOfInstalledModsAreNotReadBackwards()
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod(
+            "incumbent",
+            dependencies: new[] { Entry("candidate", ModDependencyKind.Required, "1.0.0") }));
+        var candidate = TestFixtures.SampleVersionMetadata("candidate", "1.2.0");
+
+        Assert.Empty(_resolver.Evaluate(instance, candidate));
+    }
+
     #endregion
 
     #region any_of
@@ -217,6 +303,35 @@ public sealed class DependencyEvaluationTests
         Assert.Null(evaluation.InstalledModId);
     }
 
+    [Fact]
+    public void UnknownKind_DeclaredByAnInstalledMod_IsReportedRatherThanDropped()
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod(
+            "incumbent",
+            dependencies: new[] { Entry("candidate", ModDependencyKind.Unknown, "1.0.0") }));
+        var candidate = TestFixtures.SampleVersionMetadata("candidate", "1.2.0");
+
+        var evaluation = Assert.Single(_resolver.Evaluate(instance, candidate));
+
+        Assert.Equal(DependencyOutcome.Unknown, evaluation.Outcome);
+        Assert.Equal("incumbent", evaluation.DeclaredBy);
+        Assert.Null(evaluation.InstalledModId);
+    }
+
+    [Fact]
+    public void UnknownKind_DeclaredByAnInstalledMod_IsReportedWhateverItsBoundsSay()
+    {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod(
+            "incumbent",
+            dependencies: new[] { Entry("candidate", ModDependencyKind.Unknown, "9.0.0") }));
+        var candidate = TestFixtures.SampleVersionMetadata("candidate", "1.2.0");
+
+        // Bounds of an unreadable kind say nothing, so they go unread.
+        Assert.Equal(DependencyOutcome.Unknown, Assert.Single(_resolver.Evaluate(instance, candidate)).Outcome);
+    }
+
     #endregion
 
     #region The list as a whole
@@ -228,19 +343,24 @@ public sealed class DependencyEvaluationTests
     }
 
     [Fact]
-    public void Evaluate_KeepsDocumentOrder()
+    public void Evaluate_KeepsDocumentOrderAndPutsIncomingConflictsLast()
     {
+        var instance = NewInstance();
+        instance.AddMod(TestFixtures.SampleInstalledMod(
+            "incumbent",
+            dependencies: new[] { Entry("candidate", ModDependencyKind.Conflict) }));
         var candidate = TestFixtures.SampleVersionMetadata("candidate", dependencies: new[]
         {
             Entry("first", ModDependencyKind.Required, "1.0.0"),
             Entry("second", ModDependencyKind.Suggests),
         });
 
-        var evaluations = _resolver.Evaluate(NewInstance(), candidate);
+        var evaluations = _resolver.Evaluate(instance, candidate);
 
-        Assert.Equal(2, evaluations.Count);
+        Assert.Equal(3, evaluations.Count);
         Assert.Equal("first", evaluations[0].Dependency.ModId);
         Assert.Equal("second", evaluations[1].Dependency.ModId);
+        Assert.Equal("incumbent", evaluations[2].DeclaredBy);
     }
 
     [Fact]

--- a/tests/Borea.Core.Tests/Dependencies/ModDependencyResolverTests.cs
+++ b/tests/Borea.Core.Tests/Dependencies/ModDependencyResolverTests.cs
@@ -108,6 +108,17 @@ public sealed class ModDependencyResolverTests
     }
 
     [Fact]
+    public void GetUnsatisfiedDependencies_ConflictTheCandidateDeclares_IsNotReported()
+    {
+        var instance = new Instance("Test", InstanceSource.Custom.Value);
+        instance.AddMod(TestFixtures.SampleInstalledMod("rival", "1.5.0"));
+        var dependency = new ModDependency("rival", ModDependencyKind.Conflict);
+        var candidate = TestFixtures.SampleVersionMetadata("candidate", dependencies: new[] { dependency });
+
+        Assert.Empty(_resolver.GetUnsatisfiedDependencies(instance, candidate));
+    }
+
+    [Fact]
     public void GetUnsatisfiedDependencies_NullArguments_Throw()
     {
         var instance = new Instance("Test", InstanceSource.Custom.Value);

--- a/tests/Borea.Core.Tests/Dependencies/ModDependencyResolverTests.cs
+++ b/tests/Borea.Core.Tests/Dependencies/ModDependencyResolverTests.cs
@@ -119,6 +119,17 @@ public sealed class ModDependencyResolverTests
     }
 
     [Fact]
+    public void GetUnsatisfiedDependencies_ConflictAnInstalledModDeclares_IsNotReported()
+    {
+        var instance = new Instance("Test", InstanceSource.Custom.Value);
+        var dependency = new ModDependency("candidate", ModDependencyKind.Conflict);
+        instance.AddMod(TestFixtures.SampleInstalledMod("incumbent", dependencies: new[] { dependency }));
+        var candidate = TestFixtures.SampleVersionMetadata("candidate");
+
+        Assert.Empty(_resolver.GetUnsatisfiedDependencies(instance, candidate));
+    }
+
+    [Fact]
     public void GetUnsatisfiedDependencies_NullArguments_Throw()
     {
         var instance = new Instance("Test", InstanceSource.Custom.Value);

--- a/tests/Borea.Core.Tests/Dependencies/ModDependencyResolverTests.cs
+++ b/tests/Borea.Core.Tests/Dependencies/ModDependencyResolverTests.cs
@@ -154,13 +154,16 @@ public sealed class ModDependencyResolverTests
         Assert.False(check.CanUninstall);
     }
 
-    [Fact]
-    public void CheckUninstall_OnlyNonRequiredDependents_CanUninstall()
+    [Theory]
+    [InlineData(ModDependencyKind.Optional)]
+    [InlineData(ModDependencyKind.Recommends)]
+    [InlineData(ModDependencyKind.Suggests)]
+    public void CheckUninstall_OnlyNonRequiredDependents_CanUninstall(ModDependencyKind kind)
     {
         var instance = new Instance("Test", InstanceSource.Custom.Value);
         instance.AddMod(TestFixtures.SampleInstalledMod("library-mod"));
-        var dependency = new ModDependency("library-mod", ModDependencyKind.Optional, ModVersion.Parse("1.0.0"));
-        instance.AddMod(TestFixtures.SampleInstalledMod("dependent-mod"));
+        var dependency = new ModDependency("library-mod", kind, ModVersion.Parse("1.0.0"));
+        instance.AddMod(TestFixtures.SampleInstalledMod("dependent-mod", dependencies: new[] { dependency }));
 
         var check = _resolver.CheckUninstall(instance, "library-mod", ModVersion.Parse("1.0.0"), isActive: true);
 
@@ -172,7 +175,8 @@ public sealed class ModDependencyResolverTests
     {
         var instance = new Instance("Test", InstanceSource.Custom.Value);
         instance.AddMod(TestFixtures.SampleInstalledMod("library-mod", "1.0.0"));
-        instance.AddMod(TestFixtures.SampleInstalledMod("dependent-mod"));
+        var dependency = new ModDependency("library-mod", ModDependencyKind.Required, ModVersion.Parse("2.0.0"));
+        instance.AddMod(TestFixtures.SampleInstalledMod("dependent-mod", dependencies: new[] { dependency }));
 
         var check = _resolver.CheckUninstall(instance, "library-mod", ModVersion.Parse("1.0.0"), isActive: true);
 
@@ -207,7 +211,7 @@ public sealed class ModDependencyResolverTests
             new ModDependencyAlternative("lib-a", ModVersion.Parse("2.0.0")),
             new ModDependencyAlternative("lib-b", ModVersion.Parse("1.1.0")),
         });
-        instance.AddMod(TestFixtures.SampleInstalledMod("dependent-mod"));
+        instance.AddMod(TestFixtures.SampleInstalledMod("dependent-mod", dependencies: new[] { dependency }));
 
         var check = _resolver.CheckUninstall(instance, "lib-a", ModVersion.Parse("2.0.0"), isActive: true);
 


### PR DESCRIPTION
Closes #28.

`ModDependencyResolver` read one of the five dependency kinds. it kept `required` and skipped the rest.

`Evaluate` now weighs every entry of a release against an instance, and `GetUnsatisfiedDependencies` becomes a filter over it, so what counts as satisfied is decided in one place.
`CheckUninstall` is unchanged.

No caller acts on the outcomes yet. The install path is #6.

The first commit repairs three `CheckUninstall` tests that built a dependency and never attached it to the dependent mod, so they passed without exercising one.
