### PR TITLE
Follow the game's rules for manifest.toml

### DIFF
--- a/src/Borea.Core/State/IModStateRepository.cs
+++ b/src/Borea.Core/State/IModStateRepository.cs
@@ -1,28 +1,48 @@
-﻿namespace Borea.Core.State;
+namespace Borea.Core.State;
 
 /// <summary>
-/// Tracks which mods are currently active within a specific instance.
+/// Reads and writes the manifest that decides which mods an instance loads.
+/// The file belongs to the game, so this holds no state of its own in it and re-reads
+/// it before every write. Callers running operations in parallel serialize them
+/// per instance themselves and nothing here does. Re-reading also does not close
+/// the window against the running game, which rewrites the file from a snapshot
+/// of its own (GameSettings.SaveChanges).
 /// </summary>
 public interface IModStateRepository
 {
-    /// <summary>
-    /// Returns true if the given mod is currently active within the instance, else false
-    /// </summary>
+    /// <summary>Every entry, in load order. Empty when there is no manifest.</summary>
+    Task<IReadOnlyList<ModManifestEntry>> GetEntriesAsync(Guid instanceId, CancellationToken cancellationToken = default);
+
+    /// <summary>Whether any entry naming the mod is enabled.</summary>
     Task<bool> IsActiveAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Returns all currently active mods within the instance.
-    /// </summary>
+    /// <summary>One id per active mod, in load order.</summary>
     Task<IReadOnlyList<string>> GetAllActiveModIdsAsync(Guid instanceId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Activates the given mod within the instance. No-op if the mod is already active.
+    /// Adds an entry for a mod that is on disk, at the end. Writes
+    /// nothing while the files are missing, and nothing over an entry that
+    /// exists, so a mod disabled in the game stays disabled through an install.
     /// </summary>
-    Task SetActiveAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default);
+    Task<ModEntryAddResult> AddEntryAsync(Guid instanceId, string modId, bool enabled, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Deactivates the given mod within the instance. No-op if the mod is
-    /// not currently active.
+    /// Makes the game load the mod, returning whether that changed anything.
+    /// Creates nothing; that is <see cref="AddEntryAsync"/>.
     /// </summary>
-    Task SetInactiveAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default);
+    Task<bool> SetActiveAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default);
+
+    /// <summary>Stops the game loading the mod, returning whether that changed anything.</summary>
+    Task<bool> SetInactiveAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Puts the entries in the given order, returning whether the order changed.
+    /// The only operation that moves an entry.
+    /// </summary>
+    /// <param name="modIds">Every entry naming a mod, once each, in the wanted order.</param>
+    /// <exception cref="ArgumentException">
+    /// The list does not name exactly those entries. Also fires when the file
+    /// changed since <see cref="GetEntriesAsync"/>; read it again.
+    /// </exception>
+    Task<bool> ReorderAsync(Guid instanceId, IReadOnlyList<string> modIds, CancellationToken cancellationToken = default);
 }

--- a/src/Borea.Core/State/ModEntryAddResult.cs
+++ b/src/Borea.Core/State/ModEntryAddResult.cs
@@ -1,0 +1,17 @@
+namespace Borea.Core.State;
+
+/// <summary>
+/// Outcome of <see cref="IModStateRepository.AddEntryAsync"/>. Not re-derivable
+/// afterwards without reading the file again.
+/// </summary>
+public enum ModEntryAddResult
+{
+    /// <summary>The entry was written.</summary>
+    Added = 0,
+
+    /// <summary>Already listed, left as it was, enabled flag included.</summary>
+    AlreadyListed = 1,
+
+    /// <summary>The mod is not on disk, so nothing was written.</summary>
+    NotOnDisk = 2,
+}

--- a/src/Borea.Core/State/ModManifestEntry.cs
+++ b/src/Borea.Core/State/ModManifestEntry.cs
@@ -1,0 +1,7 @@
+namespace Borea.Core.State;
+
+/// <summary>
+/// One manifest.toml entry. List position is load order (ModLibrary.PrepareAll).
+/// <see cref="ModId"/> is empty when the entry names no mod.
+/// </summary>
+public sealed record ModManifestEntry(string ModId, bool Enabled);

--- a/src/Borea.Storage/State/FileModStateRepository.cs
+++ b/src/Borea.Storage/State/FileModStateRepository.cs
@@ -1,4 +1,4 @@
-﻿using Borea.Core.Mods;
+using Borea.Core.Mods;
 using Borea.Core.Paths;
 using Borea.Core.State;
 using Borea.Storage.Toml;
@@ -6,11 +6,15 @@ using Borea.Storage.Toml;
 namespace Borea.Storage.State;
 
 /// <summary>
-/// File-backed implementation of IModStateRepository, reading and writing
-/// the instance's manifest.toml directly.
+/// File-backed <see cref="IModStateRepository"/> over the instance's
+/// manifest.toml. ModManifest.Save regenerates that file from the game's own
+/// list and emits only id and enabled, so Borea keeps nothing of its own in it
+/// and re-reads before every write.
 /// </summary>
 public sealed class FileModStateRepository : IModStateRepository
 {
+    private const string ModDefinitionFileName = "mod.toml";
+
     private readonly IGamePathProvider _pathProvider;
 
     public FileModStateRepository(IGamePathProvider pathProvider)
@@ -18,43 +22,189 @@ public sealed class FileModStateRepository : IModStateRepository
         _pathProvider = pathProvider ?? throw new ArgumentNullException(nameof(pathProvider));
     }
 
-    public async Task<bool> IsActiveAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<ModManifestEntry>> GetEntriesAsync(Guid instanceId, CancellationToken cancellationToken = default)
     {
         var manifest = await ReadManifestAsync(instanceId, cancellationToken).ConfigureAwait(false);
-        return manifest.Mods.FirstOrDefault(m => ModIds.Equals(m.Id, modId))?.Enabled ?? false;
+        return manifest.Mods.Select(m => new ModManifestEntry(m.Id, m.Enabled)).ToList();
+    }
+
+    public async Task<bool> IsActiveAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default)
+    {
+        RequireLookupId(modId);
+
+        var manifest = await ReadManifestAsync(instanceId, cancellationToken).ConfigureAwait(false);
+
+        return Matches(manifest, modId).Any(m => m.Enabled);
     }
 
     public async Task<IReadOnlyList<string>> GetAllActiveModIdsAsync(Guid instanceId, CancellationToken cancellationToken = default)
     {
         var manifest = await ReadManifestAsync(instanceId, cancellationToken).ConfigureAwait(false);
-        return manifest.Mods.Where(m => m.Enabled).Select(m => m.Id).ToList();
+
+        // One id per mod, the way IsActiveAsync counts them: two enabled case
+        // variants are one loaded mod, and a blank id names none.
+        return manifest.Mods
+            .Where(m => m.Enabled && !string.IsNullOrWhiteSpace(m.Id))
+            .Select(m => m.Id)
+            .Distinct(ModIds.Comparer)
+            .ToList();
     }
 
-    public async Task SetActiveAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default)
+    public async Task<ModEntryAddResult> AddEntryAsync(Guid instanceId, string modId, bool enabled, CancellationToken cancellationToken = default)
     {
-        var manifest = await ReadManifestAsync(instanceId, cancellationToken).ConfigureAwait(false);
-        var entry = manifest.Mods.FirstOrDefault(m => ModIds.Equals(m.Id, modId));
+        // ModManifest.Save writes the id unescaped, so a quote corrupts the file.
+        ModIds.Validate(modId, nameof(modId));
 
-        if (entry is null)
-            manifest.Mods.Add(new ModManifestEntryDto { Id = modId, Enabled = true });
-        else if (!entry.Enabled)
-            entry.Enabled = true;
+        var modFolder = ResolveModFolder(instanceId, modId);
+        if (modFolder is null)
+            return ModEntryAddResult.NotOnDisk;
+
+        var manifest = await ReadManifestAsync(instanceId, cancellationToken).ConfigureAwait(false);
+
+        if (Matches(manifest, modId).Any())
+            return ModEntryAddResult.AlreadyListed;
+
+        // the game builds paths from the id
+        // (ModEntry.Exists) and compares ids ordinally (ModLibrary.AddMods), so a
+        // case mismatch is a duplicate entry on Windows and a deleted one
+        // elsewhere. Valid by construction, since it equals a validated id apart
+        // from case and every ModIds rule ignores case.
+        var folderName = Path.GetFileName(modFolder);
+
+        manifest.Mods.Add(new ModManifestEntryDto { Id = folderName, Enabled = enabled });
+
+        await WriteManifestAsync(instanceId, manifest, cancellationToken).ConfigureAwait(false);
+        return ModEntryAddResult.Added;
+    }
+
+    public Task<bool> SetActiveAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default)
+        => SetEnabledAsync(instanceId, modId, enabled: true, cancellationToken);
+
+    public Task<bool> SetInactiveAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default)
+        => SetEnabledAsync(instanceId, modId, enabled: false, cancellationToken);
+
+    public async Task<bool> ReorderAsync(Guid instanceId, IReadOnlyList<string> modIds, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(modIds);
+
+        var manifest = await ReadManifestAsync(instanceId, cancellationToken).ConfigureAwait(false);
+
+        // An entry naming no mod cannot be placed by a caller and carries no load
+        // order: ModLibrary.PrepareManifest removes it on the next launch. It
+        // keeps its index, rather than making the manifest unorderable.
+        var pinned = new List<(int Index, ModManifestEntryDto Entry)>();
+        var remaining = new List<ModManifestEntryDto>();
+
+        for (var i = 0; i < manifest.Mods.Count; i++)
+        {
+            if (string.IsNullOrWhiteSpace(manifest.Mods[i].Id))
+                pinned.Add((i, manifest.Mods[i]));
+            else
+                remaining.Add(manifest.Mods[i]);
+        }
+
+        var reordered = new List<ModManifestEntryDto>(manifest.Mods.Count);
+
+        foreach (var modId in modIds)
+        {
+            var index = remaining.FindIndex(m => ModIds.Equals(m.Id, modId));
+            if (index < 0)
+            {
+                throw new ArgumentException(
+                    $"The manifest has no entry left to place for '{modId}'.", nameof(modIds));
+            }
+
+            reordered.Add(remaining[index]);
+            remaining.RemoveAt(index);
+        }
+
+        if (remaining.Count > 0)
+        {
+            throw new ArgumentException(
+                $"The order leaves out {remaining.Count} manifest entries, starting with '{remaining[0].Id}'.",
+                nameof(modIds));
+        }
+
+        foreach (var (index, entry) in pinned)
+            reordered.Insert(index, entry);
+
+        if (reordered.SequenceEqual(manifest.Mods, ReferenceEqualityComparer.Instance))
+            return false;
+
+        manifest.Mods = reordered;
+        await WriteManifestAsync(instanceId, manifest, cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+
+    private async Task<bool> SetEnabledAsync(Guid instanceId, string modId, bool enabled, CancellationToken cancellationToken)
+    {
+        RequireLookupId(modId);
+
+        var manifest = await ReadManifestAsync(instanceId, cancellationToken).ConfigureAwait(false);
+        var matches = Matches(manifest, modId).ToList();
+
+        var enabledMatches = matches.Where(m => m.Enabled).ToList();
+
+        if (enabled)
+        {
+            if (matches.Count == 0 || enabledMatches.Count > 0)
+                return false;
+
+            // SerializedCollection.Register drops the second mod of equal
+            // KeyHash, so enabling both would switch on a deliberate off.
+            matches[0].Enabled = true;
+        }
         else
-            return;
+        {
+            if (enabledMatches.Count == 0)
+                return false;
+
+            // All of them, because any enabled entry loads the mod.
+            foreach (var match in enabledMatches)
+                match.Enabled = false;
+        }
 
         await WriteManifestAsync(instanceId, manifest, cancellationToken).ConfigureAwait(false);
+        return true;
     }
 
-    public async Task SetInactiveAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Every entry naming the mod, in file order. ModLibrary.AddMods compares ids
+    /// ordinally so a manifest can hold two case variants, while KeyHash.Make
+    /// lowercases, which makes them one mod downstream.
+    /// </summary>
+    private static IEnumerable<ModManifestEntryDto> Matches(ManifestDto manifest, string modId)
+        => manifest.Mods.Where(m => ModIds.Equals(m.Id, modId));
+
+    /// <summary>
+    /// The mod's folder, or null when the mod is not there. The mod.toml decides,
+    /// not the folder (ModLibrary.AddMods, ModEntry.Exists). Only the instance's
+    /// mods folder is searched. Resolved by comparison, since ids ignore case and Linux paths
+    /// do not.
+    /// </summary>
+    private string? ResolveModFolder(Guid instanceId, string modId)
     {
-        var manifest = await ReadManifestAsync(instanceId, cancellationToken).ConfigureAwait(false);
-        var entry = manifest.Mods.FirstOrDefault(m => ModIds.Equals(m.Id, modId));
+        var modsFolder = _pathProvider.GetInstanceModsFolder(instanceId);
+        if (!Directory.Exists(modsFolder))
+            return null;
 
-        if (entry is null || !entry.Enabled)
-            return;
+        var modFolder = Directory.EnumerateDirectories(modsFolder)
+            .FirstOrDefault(d => ModIds.Equals(Path.GetFileName(d), modId));
 
-        entry.Enabled = false;
-        await WriteManifestAsync(instanceId, manifest, cancellationToken).ConfigureAwait(false);
+        if (modFolder is null)
+            return null;
+
+        return File.Exists(Path.Combine(modFolder, ModDefinitionFileName)) ? modFolder : null;
+    }
+
+    /// <summary>
+    /// Weaker than the ModIds.Validate AddEntryAsync uses, because a lookup has to
+    /// reach entries the game wrote, Core among them.
+    /// </summary>
+    private static void RequireLookupId(string modId)
+    {
+        if (string.IsNullOrWhiteSpace(modId))
+            throw new ArgumentException("Mod ID cannot be null or whitespace.", nameof(modId));
     }
 
     private async Task<ManifestDto> ReadManifestAsync(Guid instanceId, CancellationToken cancellationToken)

--- a/src/Borea.Storage/State/ManifestDto.cs
+++ b/src/Borea.Storage/State/ManifestDto.cs
@@ -1,12 +1,13 @@
-﻿using System.Text.Json.Serialization;
+using Tomlyn.Serialization;
 
 namespace Borea.Storage.State;
 
 /// <summary>
-/// Root of StarMap's manifest.toml — a single [[mods]] array of entries.
+/// Root of the game's manifest.toml. The key is stated, not derived since Tomlyn maps
+/// a property to its own name, and [[Mods]] is a manifest the game reads as empty.
 /// </summary>
 public sealed class ManifestDto
 {
-    [JsonPropertyName("mods")]
+    [TomlPropertyName("mods")]
     public List<ModManifestEntryDto> Mods { get; set; } = new();
 }

--- a/src/Borea.Storage/State/ModManifestEntryDto.cs
+++ b/src/Borea.Storage/State/ModManifestEntryDto.cs
@@ -1,15 +1,20 @@
-﻿using System.Text.Json.Serialization;
+using Tomlyn.Serialization;
 
 namespace Borea.Storage.State;
 
 /// <summary>
-/// A single [[mods]] entry in StarMap's manifest.toml.
+/// One [[mods]] entry. ModManifest.Save writes these two keys and destroys the
+/// rest, so this is the whole schema.
 /// </summary>
 public sealed class ModManifestEntryDto
 {
-    [JsonPropertyName("id")]
+    [TomlPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
-    [JsonPropertyName("enabled")]
-    public bool Enabled { get; set; }
+    /// <summary>
+    /// Absent means enabled, the way ModEntry.Enabled's initializer leaves it.
+    /// An entry the game creates for a new folder states false instead.
+    /// </summary>
+    [TomlPropertyName("enabled")]
+    public bool Enabled { get; set; } = true;
 }

--- a/src/Borea.Storage/Toml/TomlFileStore.cs
+++ b/src/Borea.Storage/Toml/TomlFileStore.cs
@@ -33,8 +33,10 @@ public static class TomlFileStore
     /// <summary>
     /// Serializes <paramref name="value"/> to TOML and writes it to
     /// <paramref name="path"/>, creating the containing directory if needed.
-    /// Overwrites any existing file.
+    /// Replaces any existing file, and leaves it untouched when the write does
+    /// not finish.
     /// </summary>
+    /// <remarks>Not safe against a second writer of the same path.</remarks>
     public static async Task WriteAsync<T>(string path, T value, CancellationToken cancellationToken = default)
         where T : class
     {
@@ -46,7 +48,40 @@ public static class TomlFileStore
             Directory.CreateDirectory(directory);
 
         var text = TomlSerializer.Serialize(value, Options);
-        await File.WriteAllTextAsync(path, text, cancellationToken).ConfigureAwait(false);
+
+        // Written beside the file and moved onto it, because writing in place
+        // truncates first and the game parses manifest.toml with no error
+        // handling. Same directory, so the move is atomic. The name is unique per
+        // write, so a second writer cannot delete this one's temporary file.
+        var tempPath = $"{path}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            await File.WriteAllTextAsync(tempPath, text, cancellationToken).ConfigureAwait(false);
+            File.Move(tempPath, path, overwrite: true);
+        }
+        finally
+        {
+            TryDeleteLeftover(tempPath);
+        }
+    }
+
+    /// <summary>
+    /// Clears the temporary file when the write did not reach the move, without
+    /// replacing the error that caused it.
+    /// </summary>
+    private static void TryDeleteLeftover(string tempPath)
+    {
+        try
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
     }
 
     /// <summary>

--- a/tests/Borea.Storage.Tests/State/FileModStateRepositoryTests.cs
+++ b/tests/Borea.Storage.Tests/State/FileModStateRepositoryTests.cs
@@ -1,4 +1,5 @@
-﻿using Borea.Storage.State;
+using Borea.Core.State;
+using Borea.Storage.State;
 using Borea.Storage.Tests.Paths;
 
 namespace Borea.Storage.Tests.State;
@@ -17,13 +18,12 @@ public sealed class FileModStateRepositoryTests : IDisposable
         _repository = new FileModStateRepository(_pathProvider);
     }
 
+    #region Reading
+
     [Fact]
-    public async Task ReadsExistingManifest_MatchingStarMapFormat()
+    public async Task ReadsExistingManifest_MatchingTheGamesFormat()
     {
-        // Simulates a manifest KSA itself already wrote.
-        var manifestPath = _pathProvider.GetInstanceManifestPath(_instanceId);
-        Directory.CreateDirectory(Path.GetDirectoryName(manifestPath)!);
-        File.WriteAllText(manifestPath, """
+        WriteManifest("""
             [[mods]]
             id="Core"
             enabled = true
@@ -35,14 +35,12 @@ public sealed class FileModStateRepositoryTests : IDisposable
 
         Assert.True(await _repository.IsActiveAsync(_instanceId, "Core"));
         Assert.False(await _repository.IsActiveAsync(_instanceId, "some-other-mod"));
-
-        var active = await _repository.GetAllActiveModIdsAsync(_instanceId);
-        Assert.Equal(new[] { "Core" }, active);
+        Assert.Equal(new[] { "Core" }, await _repository.GetAllActiveModIdsAsync(_instanceId));
 
         // Ids compare case-insensitively, matching the folder-name identity.
         Assert.True(await _repository.IsActiveAsync(_instanceId, "core"));
 
-        await _repository.SetInactiveAsync(_instanceId, "CORE");
+        Assert.True(await _repository.SetInactiveAsync(_instanceId, "CORE"));
         Assert.False(await _repository.IsActiveAsync(_instanceId, "Core"));
         Assert.Empty(await _repository.GetAllActiveModIdsAsync(_instanceId));
     }
@@ -52,34 +50,609 @@ public sealed class FileModStateRepositoryTests : IDisposable
     {
         Assert.False(await _repository.IsActiveAsync(_instanceId, "anything"));
         Assert.Empty(await _repository.GetAllActiveModIdsAsync(_instanceId));
+        Assert.Empty(await _repository.GetEntriesAsync(_instanceId));
     }
 
     [Fact]
-    public async Task SetActiveAsync_CreatesEntryWhenMissing()
+    public async Task GetEntriesAsync_ReportsFileOrderAndState()
     {
-        await _repository.SetActiveAsync(_instanceId, "new-mod");
+        // ModLibrary.PrepareAll walks by index, so file order is load order.
+        WriteManifest("""
+            [[mods]]
+            id = "Core"
+            enabled = true
 
+            [[mods]]
+            id = "second"
+            enabled = false
+
+            [[mods]]
+            id = "third"
+            enabled = true
+            """);
+
+        var entries = await _repository.GetEntriesAsync(_instanceId);
+
+        Assert.Equal(new[] { "Core", "second", "third" }, entries.Select(e => e.ModId));
+        Assert.Equal(new[] { true, false, true }, entries.Select(e => e.Enabled));
+    }
+
+    [Fact]
+    public async Task EntryWithoutEnabledKey_ReadsAsEnabled()
+    {
+        // ModEntry.Enabled starts out true, so the game loads such an entry.
+        WriteManifest("""
+            [[mods]]
+            id = "Core"
+            """);
+
+        Assert.True(await _repository.IsActiveAsync(_instanceId, "Core"));
+    }
+
+    [Fact]
+    public async Task Read_ToleratesCommentsQuotingAndUnknownKeys()
+    {
+        // The game and a human both edit this file.
+        WriteManifest("""
+            # a comment somebody left
+            [[mods]]
+            # and one inside an entry
+            id = 'Core'
+            enabled=true
+            note = "a key the game will destroy on its next save"
+
+            [[mods]]
+            id = "second"
+            enabled   =    false
+            """);
+
+        var entries = await _repository.GetEntriesAsync(_instanceId);
+
+        Assert.Equal(new[] { "Core", "second" }, entries.Select(e => e.ModId));
+        Assert.True(await _repository.IsActiveAsync(_instanceId, "Core"));
+        Assert.False(await _repository.IsActiveAsync(_instanceId, "second"));
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task IsActiveAsync_IsTrueWhenAnyEntryForTheModIsEnabled(bool firstEnabled, bool secondEnabled)
+    {
+        // ModLibrary.AddMods compares ordinally so both entries exist, KeyHash.Make
+        // lowercases so they are one mod, and PrepareAll skips the disabled one.
+        WriteManifest($"""
+            [[mods]]
+            id = "MyMod"
+            enabled = {TomlBool(firstEnabled)}
+
+            [[mods]]
+            id = "mymod"
+            enabled = {TomlBool(secondEnabled)}
+            """);
+
+        Assert.True(await _repository.IsActiveAsync(_instanceId, "MYMOD"));
+    }
+
+    [Fact]
+    public async Task GetAllActiveModIdsAsync_ReportsOneIdPerModAndNoBlanks()
+    {
+        // A blank id names no mod, and two enabled case variants are one loaded
+        // mod, so neither may reach a caller that feeds ids back in.
+        WriteManifest("""
+            [[mods]]
+            id = "MyMod"
+            enabled = true
+
+            [[mods]]
+            enabled = true
+
+            [[mods]]
+            id = "mymod"
+            enabled = true
+
+            [[mods]]
+            id = "other"
+            enabled = true
+            """);
+
+        Assert.Equal(new[] { "MyMod", "other" }, await _repository.GetAllActiveModIdsAsync(_instanceId));
+    }
+
+    [Fact]
+    public async Task EntryWithoutAnId_IsKeptRatherThanDropped()
+    {
+        // Borea does not silently drop an entry it did not understand.
+        WriteManifest("""
+            [[mods]]
+            enabled = true
+
+            [[mods]]
+            id = "Core"
+            enabled = true
+            """);
+
+        var entries = await _repository.GetEntriesAsync(_instanceId);
+        Assert.Equal(2, entries.Count);
+        Assert.Equal(string.Empty, entries[0].ModId);
+
+        await _repository.SetInactiveAsync(_instanceId, "Core");
+
+        Assert.Equal(2, (await _repository.GetEntriesAsync(_instanceId)).Count);
+    }
+
+    #endregion
+
+    #region Adding an entry
+
+    [Fact]
+    public async Task AddEntryAsync_WritesTheEntryOnceTheModFolderIsThere()
+    {
+        CreateModFolder("new-mod");
+
+        Assert.Equal(ModEntryAddResult.Added, await _repository.AddEntryAsync(_instanceId, "new-mod", enabled: true));
         Assert.True(await _repository.IsActiveAsync(_instanceId, "new-mod"));
+    }
+
+    [Fact]
+    public async Task AddEntryAsync_WithoutTheModFolder_WritesNothing()
+    {
+        // ModLibrary.PrepareManifest deletes an entry written ahead of its files.
+        Assert.Equal(ModEntryAddResult.NotOnDisk, await _repository.AddEntryAsync(_instanceId, "new-mod", enabled: true));
+        Assert.False(File.Exists(ManifestPath));
+    }
+
+    [Fact]
+    public async Task AddEntryAsync_WithoutAModToml_WritesNothing()
+    {
+        // ModEntry.Exists probes for the mod.toml, not for the folder.
+        Directory.CreateDirectory(Path.Combine(_pathProvider.GetInstanceModsFolder(_instanceId), "new-mod"));
+
+        Assert.Equal(ModEntryAddResult.NotOnDisk, await _repository.AddEntryAsync(_instanceId, "new-mod", enabled: true));
+        Assert.False(File.Exists(ManifestPath));
+    }
+
+    [Fact]
+    public async Task AddEntryAsync_WritesTheFolderNameRatherThanTheCallersSpelling()
+    {
+        // A case mismatch is a duplicate disabled entry on Windows, and one
+        // ModLibrary.PrepareManifest deletes elsewhere.
+        CreateModFolder("MyMod");
+
+        Assert.Equal(ModEntryAddResult.Added, await _repository.AddEntryAsync(_instanceId, "mymod", enabled: true));
+
+        var entries = await _repository.GetEntriesAsync(_instanceId);
+        Assert.Equal(new[] { "MyMod" }, entries.Select(e => e.ModId));
+        Assert.Contains("id = \"MyMod\"", await File.ReadAllTextAsync(ManifestPath));
+    }
+
+    [Fact]
+    public async Task AddEntryAsync_AppendsAtTheEnd()
+    {
+        // ModLibrary.AddMods appends, and entry order is load order.
+        WriteManifest("""
+            [[mods]]
+            id = "Core"
+            enabled = true
+
+            [[mods]]
+            id = "second"
+            enabled = true
+            """);
+        CreateModFolder("third");
+
+        Assert.Equal(ModEntryAddResult.Added, await _repository.AddEntryAsync(_instanceId, "third", enabled: true));
+
+        var entries = await _repository.GetEntriesAsync(_instanceId);
+        Assert.Equal(new[] { "Core", "second", "third" }, entries.Select(e => e.ModId));
+    }
+
+    [Fact]
+    public async Task AddEntryAsync_LeavesAnEntryThatAlreadyExists()
+    {
+        // A mod disabled in the game stays disabled through an install.
+        WriteManifest("""
+            [[mods]]
+            id = "existing"
+            enabled = false
+            """);
+        CreateModFolder("existing");
+
+        Assert.Equal(ModEntryAddResult.AlreadyListed, await _repository.AddEntryAsync(_instanceId, "EXISTING", enabled: true));
+
+        Assert.False(await _repository.IsActiveAsync(_instanceId, "existing"));
+        Assert.Single(await _repository.GetEntriesAsync(_instanceId));
+    }
+
+    [Fact]
+    public async Task AddEntryAsync_RejectsAnIdThatWouldCorruptTheManifest()
+    {
+        // ModManifest.Save writes the id unescaped.
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _repository.AddEntryAsync(_instanceId, "has\"quote", enabled: true));
+    }
+
+    [Theory]
+    [InlineData("has space")]
+    [InlineData(".leading-dot")]
+    [InlineData("Core")]
+    public async Task AddEntryAsync_RejectsAnIdBoreaWillNotPublish(string modId)
+    {
+        // Borea policy, not a game rule: the game would load all three.
+        // Core is the game's own, so a lookup still reaches it.
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _repository.AddEntryAsync(_instanceId, modId, enabled: true));
+    }
+
+    #endregion
+
+    #region Enabling and disabling
+
+    [Fact]
+    public async Task SetActiveAsync_OnAModWithNoEntry_WritesNothing()
+    {
+        // Creating it here would decide load order as a side effect.
+        CreateModFolder("new-mod");
+
+        Assert.False(await _repository.SetActiveAsync(_instanceId, "new-mod"));
+        Assert.False(File.Exists(ManifestPath));
+    }
+
+    [Fact]
+    public async Task SetActiveAsync_FlipsAnEntryTheGameWrote()
+    {
+        WriteManifest("""
+            [[mods]]
+            id = "found-by-the-game"
+            enabled = false
+            """);
+
+        Assert.True(await _repository.SetActiveAsync(_instanceId, "found-by-the-game"));
+        Assert.True(await _repository.IsActiveAsync(_instanceId, "found-by-the-game"));
+    }
+
+    [Fact]
+    public async Task SetActiveAsync_DoesNotMoveTheEntry()
+    {
+        // Entry order is load order (ModLibrary.PrepareAll walks by index).
+        WriteManifest("""
+            [[mods]]
+            id = "first"
+            enabled = false
+
+            [[mods]]
+            id = "second"
+            enabled = true
+
+            [[mods]]
+            id = "third"
+            enabled = true
+            """);
+
+        await _repository.SetActiveAsync(_instanceId, "first");
+        await _repository.SetInactiveAsync(_instanceId, "second");
+
+        var entries = await _repository.GetEntriesAsync(_instanceId);
+        Assert.Equal(new[] { "first", "second", "third" }, entries.Select(e => e.ModId));
+        Assert.Equal(new[] { true, false, true }, entries.Select(e => e.Enabled));
+    }
+
+    [Fact]
+    public async Task SetActiveAsync_OnAnEntryAlreadyEnabled_WritesNothing()
+    {
+        WriteManifest("""
+            [[mods]]
+            id = "Core"
+            enabled = true
+            """);
+        var before = await File.ReadAllTextAsync(ManifestPath);
+
+        Assert.False(await _repository.SetActiveAsync(_instanceId, "Core"));
+        Assert.Equal(before, await File.ReadAllTextAsync(ManifestPath));
+    }
+
+    [Fact]
+    public async Task SetActiveAsync_EnablesOneOfTwoEntriesDifferingOnlyInCase()
+    {
+        // One enabled entry is enough to load the mod.
+        WriteManifest("""
+            [[mods]]
+            id = "MyMod"
+            enabled = false
+
+            [[mods]]
+            id = "mymod"
+            enabled = false
+            """);
+
+        Assert.True(await _repository.SetActiveAsync(_instanceId, "mymod"));
+
+        var entries = await _repository.GetEntriesAsync(_instanceId);
+        Assert.Equal(new[] { true, false }, entries.Select(e => e.Enabled));
+    }
+
+    [Fact]
+    public async Task SetInactiveAsync_ClearsEveryEntryForTheMod()
+    {
+        // Any enabled entry loads the mod.
+        WriteManifest("""
+            [[mods]]
+            id = "MyMod"
+            enabled = false
+
+            [[mods]]
+            id = "mymod"
+            enabled = true
+            """);
+
+        Assert.True(await _repository.SetInactiveAsync(_instanceId, "MYMOD"));
+
+        Assert.False(await _repository.IsActiveAsync(_instanceId, "MyMod"));
+        Assert.Empty(await _repository.GetAllActiveModIdsAsync(_instanceId));
+    }
+
+    [Fact]
+    public async Task SetInactiveAsync_OnAnEntryAlreadyDisabled_WritesNothing()
+    {
+        WriteManifest("""
+            [[mods]]
+            id = "Core"
+            enabled = false
+            """);
+        var before = await File.ReadAllTextAsync(ManifestPath);
+
+        Assert.False(await _repository.SetInactiveAsync(_instanceId, "Core"));
+        Assert.Equal(before, await File.ReadAllTextAsync(ManifestPath));
+    }
+
+    [Fact]
+    public async Task SetInactiveAsync_OnUntrackedMod_IsNoOp()
+    {
+        Assert.False(await _repository.SetInactiveAsync(_instanceId, "never-existed"));
+
+        Assert.False(File.Exists(ManifestPath));
     }
 
     [Fact]
     public async Task SetActiveAsync_PreservesOtherEntries()
     {
+        WriteManifest("""
+            [[mods]]
+            id = "mod-a"
+            enabled = false
+
+            [[mods]]
+            id = "mod-b"
+            enabled = true
+            """);
+
         await _repository.SetActiveAsync(_instanceId, "mod-a");
-        await _repository.SetActiveAsync(_instanceId, "mod-b");
         await _repository.SetInactiveAsync(_instanceId, "mod-a");
 
         Assert.False(await _repository.IsActiveAsync(_instanceId, "mod-a"));
         Assert.True(await _repository.IsActiveAsync(_instanceId, "mod-b"));
     }
 
-    [Fact]
-    public async Task SetInactiveAsync_OnUntrackedMod_IsNoOp()
-    {
-        await _repository.SetInactiveAsync(_instanceId, "never-existed");
+    #endregion
 
-        var manifestPath = _pathProvider.GetInstanceManifestPath(_instanceId);
-        Assert.False(File.Exists(manifestPath)); // Should not have created a file for a no-op.
+    #region The file changing underneath
+
+    [Fact]
+    public async Task Write_KeepsAnEntryThatAppearedSinceTheLastRead()
+    {
+        // ModLibrary.AddMods adds a folder the user dropped in, so the file grows
+        // between two Borea operations.
+        WriteManifest("""
+            [[mods]]
+            id = "Core"
+            enabled = true
+            """);
+
+        Assert.True(await _repository.IsActiveAsync(_instanceId, "Core"));
+
+        WriteManifest("""
+            [[mods]]
+            id = "Core"
+            enabled = true
+
+            [[mods]]
+            id = "dropped-in-by-the-user"
+            enabled = false
+            """);
+
+        Assert.True(await _repository.SetInactiveAsync(_instanceId, "Core"));
+
+        var entries = await _repository.GetEntriesAsync(_instanceId);
+        Assert.Equal(new[] { "Core", "dropped-in-by-the-user" }, entries.Select(e => e.ModId));
+        Assert.Equal(new[] { false, false }, entries.Select(e => e.Enabled));
+    }
+
+    [Fact]
+    public async Task Write_EmitsOnlyIdAndEnabled()
+    {
+        // ModManifest.Save destroys anything else anyway, so Borea keeps no state here.
+        WriteManifest("""
+            [[mods]]
+            id = "Core"
+            enabled = true
+            borea_note = "gone on the next save either way"
+            """);
+
+        await _repository.SetInactiveAsync(_instanceId, "Core");
+
+        var written = await File.ReadAllTextAsync(ManifestPath);
+        Assert.Contains("id = \"Core\"", written);
+        Assert.Contains("enabled = false", written);
+        Assert.DoesNotContain("borea_note", written);
+    }
+
+    [Fact]
+    public async Task Write_ProducesAManifestTheRepositoryReadsBack()
+    {
+        CreateModFolder("written-by-borea");
+
+        await _repository.AddEntryAsync(_instanceId, "written-by-borea", enabled: true);
+
+        // The table name is the game's, so it survives in the game's spelling.
+        Assert.Contains("[[mods]]", await File.ReadAllTextAsync(ManifestPath));
+        Assert.True(await _repository.IsActiveAsync(_instanceId, "written-by-borea"));
+    }
+
+    [Fact]
+    public async Task Write_LeavesNoTemporaryFileBehind()
+    {
+        CreateModFolder("written-by-borea");
+
+        await _repository.AddEntryAsync(_instanceId, "written-by-borea", enabled: true);
+
+        Assert.Empty(Directory.GetFiles(Path.GetDirectoryName(ManifestPath)!, "*.tmp"));
+    }
+
+    #endregion
+
+    #region Reordering
+
+    [Fact]
+    public async Task ReorderAsync_ChangesLoadOrder()
+    {
+        WriteManifest("""
+            [[mods]]
+            id = "first"
+            enabled = true
+
+            [[mods]]
+            id = "second"
+            enabled = false
+
+            [[mods]]
+            id = "third"
+            enabled = true
+            """);
+
+        Assert.True(await _repository.ReorderAsync(_instanceId, new[] { "third", "FIRST", "second" }));
+
+        var entries = await _repository.GetEntriesAsync(_instanceId);
+        Assert.Equal(new[] { "third", "first", "second" }, entries.Select(e => e.ModId));
+        Assert.Equal(new[] { true, true, false }, entries.Select(e => e.Enabled));
+    }
+
+    [Fact]
+    public async Task ReorderAsync_WithTheOrderItAlreadyHas_WritesNothing()
+    {
+        WriteManifest("""
+            [[mods]]
+            id = "first"
+            enabled = true
+
+            [[mods]]
+            id = "second"
+            enabled = true
+            """);
+        var before = await File.ReadAllTextAsync(ManifestPath);
+
+        Assert.False(await _repository.ReorderAsync(_instanceId, new[] { "first", "second" }));
+        Assert.Equal(before, await File.ReadAllTextAsync(ManifestPath));
+    }
+
+    [Fact]
+    public async Task ReorderAsync_BreaksATieBetweenTwoCasesByFileOrder()
+    {
+        // One rule wherever an id has to pick an entry: the first match in file order.
+        WriteManifest("""
+            [[mods]]
+            id = "MyMod"
+            enabled = true
+
+            [[mods]]
+            id = "other"
+            enabled = true
+
+            [[mods]]
+            id = "mymod"
+            enabled = false
+            """);
+
+        Assert.True(await _repository.ReorderAsync(_instanceId, new[] { "other", "mymod", "MyMod" }));
+
+        var entries = await _repository.GetEntriesAsync(_instanceId);
+        Assert.Equal(new[] { "other", "MyMod", "mymod" }, entries.Select(e => e.ModId));
+        Assert.Equal(new[] { true, true, false }, entries.Select(e => e.Enabled));
+    }
+
+    [Fact]
+    public async Task ReorderAsync_KeepsAnEntryNamingNoModAtItsIndex()
+    {
+        // A caller cannot name it, and demanding it would make the manifest
+        // unorderable until ModLibrary.PrepareManifest removes it.
+        WriteManifest("""
+            [[mods]]
+            id = "first"
+            enabled = true
+
+            [[mods]]
+            enabled = true
+
+            [[mods]]
+            id = "second"
+            enabled = true
+            """);
+
+        Assert.True(await _repository.ReorderAsync(_instanceId, new[] { "second", "first" }));
+
+        var entries = await _repository.GetEntriesAsync(_instanceId);
+        Assert.Equal(new[] { "second", string.Empty, "first" }, entries.Select(e => e.ModId));
+    }
+
+    [Fact]
+    public async Task ReorderAsync_RejectsAnOrderThatLeavesAnEntryOut()
+    {
+        WriteManifest("""
+            [[mods]]
+            id = "first"
+            enabled = true
+
+            [[mods]]
+            id = "second"
+            enabled = true
+            """);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _repository.ReorderAsync(_instanceId, new[] { "first" }));
+
+        var entries = await _repository.GetEntriesAsync(_instanceId);
+        Assert.Equal(new[] { "first", "second" }, entries.Select(e => e.ModId));
+    }
+
+    [Fact]
+    public async Task ReorderAsync_RejectsAnIdThatIsNotInTheManifest()
+    {
+        WriteManifest("""
+            [[mods]]
+            id = "first"
+            enabled = true
+            """);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _repository.ReorderAsync(_instanceId, new[] { "first", "stranger" }));
+    }
+
+    #endregion
+
+    private string ManifestPath => _pathProvider.GetInstanceManifestPath(_instanceId);
+
+    private static string TomlBool(bool value) => value ? "true" : "false";
+
+    private void WriteManifest(string content)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(ManifestPath)!);
+        File.WriteAllText(ManifestPath, content);
+    }
+
+    /// <summary>A mod folder the way the game recognizes one: a directory holding a mod.toml.</summary>
+    private void CreateModFolder(string folderName)
+    {
+        var modFolder = Path.Combine(_pathProvider.GetInstanceModsFolder(_instanceId), folderName);
+        Directory.CreateDirectory(modFolder);
+        File.WriteAllText(Path.Combine(modFolder, "mod.toml"), $"name = \"{folderName}\"\n");
     }
 
     public void Dispose()


### PR DESCRIPTION
Closes #53.

`FileModStateRepository` appended an entry for any id it was asked to enable, flipped entries it had not written, and read the file as if Borea had written it.

It follows the game's rules now: entry order is load order and only `ReorderAsync` changes it, `AddEntryAsync` is the only place an entry is created and writes nothing while the mod's `mod.toml` is missing, an entry that already exists is never flipped, and a lookup reaches what the game and a human write.

Removing an entry stays out. The game's startup sweep drops one whose files are gone, and reconciling folders against entries is #52.
