### PR TITLE
Add a composition root for Borea.App and Borea.Cli

### DIFF
--- a/Borea.slnx
+++ b/Borea.slnx
@@ -1,11 +1,13 @@
 <Solution>
   <Folder Name="/src/">
     <Project Path="src/Borea.App/Borea.App.csproj" />
+    <Project Path="src/Borea.Composition/Borea.Composition.csproj" />
     <Project Path="src/Borea.Core/Borea.Core.csproj" />
     <Project Path="src/Borea.Network/Borea.Network.csproj" />
     <Project Path="src/Borea.Storage/Borea.Storage.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Borea.Composition.Tests/Borea.Composition.Tests.csproj" />
     <Project Path="tests/Borea.Core.Tests/Borea.Core.Tests.csproj" />
     <Project Path="tests/Borea.Network.Tests/Borea.Network.Tests.csproj" />
     <Project Path="tests/Borea.Storage.Tests/Borea.Storage.Tests.csproj" />

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Borea is a cross-platform complete general content manager for Kitten Space Agen
 | `src\Borea.Core` | Contains all the core information about Borea's mods, mod packs, path providers, and more. Also contains the required interfaces to make a project compatible with Borea. |
 | `src\Borea.Storage` | Contains all the code for storing the data from `Borea.Core` to the disk. |
 | `src\Borea.Network` | Contains all the code for retrieving content from mod/content indexers and saves them to the disk. |
+| `src\Borea.Composition` | The composition root. Builds every service from the saved settings, once, for `Borea.App` and later `Borea.Cli`. |
 | `src\Borea.App` | A desktop level application that the user will interact will. Combines `Borea.Core`, `Borea.Storage`, and `Borea.Network` and handles the cross project references to make the full Borea project work smoothly. |
 
 # Features

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Borea is a cross-platform complete general content manager for Kitten Space Agen
 | `src\Borea.Storage` | Contains all the code for storing the data from `Borea.Core` to the disk. |
 | `src\Borea.Network` | Contains all the code for retrieving content from mod/content indexers and saves them to the disk. |
 | `src\Borea.Composition` | The composition root. Builds every service from the saved settings, once, for `Borea.App` and later `Borea.Cli`. |
-| `src\Borea.App` | A desktop level application that the user will interact will. Combines `Borea.Core`, `Borea.Storage`, and `Borea.Network` and handles the cross project references to make the full Borea project work smoothly. |
+| `src\Borea.App` | A desktop level application that the user will interact with. Gets its services from `Borea.Composition`. |
 
 # Features
 tba

--- a/src/Borea.App/App.axaml.cs
+++ b/src/Borea.App/App.axaml.cs
@@ -1,13 +1,30 @@
+using System;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Borea.App.ViewModels;
 using Borea.App.Views;
+using Borea.Composition;
 
 namespace Borea.App;
 
 public partial class App : Application
 {
+    /// <summary>
+    /// The services Main built from the saved settings. Null only in the XAML
+    /// previewer, which builds the App without going through Main.
+    /// </summary>
+    public BoreaServices? Services { get; }
+
+    public App()
+    {
+    }
+
+    public App(BoreaServices services)
+    {
+        Services = services ?? throw new ArgumentNullException(nameof(services));
+    }
+
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Borea.App/Borea.App.csproj
+++ b/src/Borea.App/Borea.App.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Borea.Composition\Borea.Composition.csproj" />
     <ProjectReference Include="..\Borea.Core\Borea.Core.csproj" />
-    <ProjectReference Include="..\Borea.Storage\Borea.Storage.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Borea.App/Program.cs
+++ b/src/Borea.App/Program.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia;
+using Avalonia;
+using Borea.Composition;
 using System;
 
 namespace Borea.App;
@@ -9,12 +10,23 @@ sealed class Program
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
     // yet and stuff might break.
     [STAThread]
-    public static void Main(string[] args) => BuildAvaloniaApp()
-        .StartWithClassicDesktopLifetime(args);
+    public static int Main(string[] args)
+    {
+        using var services = BoreaServices.BuildAsync().GetAwaiter().GetResult();
+
+        return BuildAvaloniaApp(services).StartWithClassicDesktopLifetime(args);
+    }
 
     // Avalonia configuration, don't remove; also used by visual designer.
+    // The designer calls this method instead of Main, so its App gets no services.
     public static AppBuilder BuildAvaloniaApp()
-        => AppBuilder.Configure<App>()
+        => Configure(AppBuilder.Configure<App>());
+
+    private static AppBuilder BuildAvaloniaApp(BoreaServices services)
+        => Configure(AppBuilder.Configure(() => new App(services)));
+
+    private static AppBuilder Configure(AppBuilder builder)
+        => builder
             .UsePlatformDetect()
 #if DEBUG
             .WithDeveloperTools()

--- a/src/Borea.Composition/Borea.Composition.csproj
+++ b/src/Borea.Composition/Borea.Composition.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Borea.Core\Borea.Core.csproj" />
+    <ProjectReference Include="..\Borea.Network\Borea.Network.csproj" />
+    <ProjectReference Include="..\Borea.Storage\Borea.Storage.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Borea.Composition/BoreaServices.cs
+++ b/src/Borea.Composition/BoreaServices.cs
@@ -1,0 +1,148 @@
+using System.Net.Http.Headers;
+using Borea.Core.Game;
+using Borea.Core.Instances;
+using Borea.Core.ModPacks;
+using Borea.Core.Mods;
+using Borea.Core.Paths;
+using Borea.Core.Settings;
+using Borea.Core.State;
+using Borea.Network.MasterServer;
+using Borea.Network.Sources;
+using Borea.Network.SpaceDock;
+using Borea.Storage.Instances;
+using Borea.Storage.ModPacks;
+using Borea.Storage.Mods;
+using Borea.Storage.Paths;
+using Borea.Storage.Settings;
+using Borea.Storage.State;
+
+namespace Borea.Composition;
+
+/// <summary>
+/// The composition root.
+/// Builds every service an executable uses, once, from the saved settings.
+/// Borea.Storage and Borea.Network do not reference each other,
+/// so this is the one place that names their classes.
+/// An executable sees only the Borea.Core interfaces.
+/// The paths are fixed when the graph is built, because GamePathProvider takes
+/// them in its constructor. To apply changed settings, save them through
+/// <see cref="SettingsRepository"/>, dispose this instance, and build again.
+/// </summary>
+public sealed class BoreaServices : IDisposable
+{
+    /// <summary>
+    /// The client lives as long as the process, so its handler must drop pooled
+    /// connections after this time. If it keeps them, the client sends to the old
+    /// address after a DNS change.
+    /// </summary>
+    private static readonly TimeSpan ConnectionLifetime = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// The one HttpClient every network service shares. It names Borea in its
+    /// User-Agent and its handler recycles pooled connections, so nothing creates
+    /// a second one. LatestVersionPing caches per instance, so the single instance
+    /// built here is the one to use.
+    /// </summary>
+    private readonly HttpClient _http;
+
+    /// <summary>
+    /// The settings the graph was built from. Empty settings when no file was
+    /// saved yet.
+    /// </summary>
+    public required BoreaSettings Settings { get; init; }
+
+    public required IGamePathProvider Paths { get; init; }
+
+    public required IBoreaSettingsRepository SettingsRepository { get; init; }
+
+    public required IInstanceRepository Instances { get; init; }
+
+    public required IModStateRepository ModState { get; init; }
+
+    public required IModFavoritesRepository ModFavorites { get; init; }
+
+    public required IModPackFavoritesRepository ModPackFavorites { get; init; }
+
+    public required IModUninstaller Uninstaller { get; init; }
+
+    /// <summary>
+    /// Every mod source behind one repository, each listing tagged with its source.
+    /// </summary>
+    public required IModRepository Mods { get; init; }
+
+    public required IModDownloader Downloader { get; init; }
+
+    public required ILatestVersionPing LatestVersion { get; init; }
+
+    private BoreaServices(HttpClient http)
+    {
+        _http = http;
+    }
+
+    /// <summary>
+    /// Builds the services from the settings under Borea's default root,
+    /// %LocalAppData%\Borea.
+    /// </summary>
+    public static Task<BoreaServices> BuildAsync(CancellationToken cancellationToken = default)
+        => BuildAsync(boreaRoot: null, cancellationToken);
+
+    /// <summary>
+    /// Builds the services from the settings under <paramref name="boreaRoot"/>.
+    /// Reads the settings file and writes nothing.
+    /// </summary>
+    /// <param name="boreaRoot">
+    /// Where Borea keeps its own files. Null means the default root of
+    /// <see cref="GamePathProvider"/>, %LocalAppData%\Borea.
+    /// </param>
+    public static async Task<BoreaServices> BuildAsync(string? boreaRoot, CancellationToken cancellationToken = default)
+    {
+        // the settings file lives under Borea's own root and needs no
+        // game path to be found, so a provider without one reads it.
+        var bootstrapPaths = new GamePathProvider(gameDirectory: null, boreaRoot: boreaRoot);
+        var saved = await new FileBoreaSettingsRepository(bootstrapPaths).GetAsync(cancellationToken).ConfigureAwait(false);
+        var settings = saved ?? new BoreaSettings(gameDirectoryPath: null);
+
+        // every other service resolves its paths through the provider
+        // built from those settings.
+        var paths = new GamePathProvider(settings.GameDirectoryPath, settings.LoaderDirectoryPaths, boreaRoot);
+
+        // Network. Every service that talks to a remote host is built here on the
+        // one client. The resolver is shared because the downloader registers the
+        // true mod id that the repository then resolves, and its map lives as long
+        // as this instance.
+        var http = BuildHttpClient();
+        var resolver = new SpaceDockResolver();
+        var sources = new Dictionary<string, IModRepository>
+        {
+            [SpaceDockModRepository.SourceName] = new SpaceDockModRepository(http, resolver),
+        };
+
+        return new BoreaServices(http)
+        {
+            Settings = settings,
+            Paths = paths,
+            SettingsRepository = new FileBoreaSettingsRepository(paths),
+            Instances = new FileInstanceRepository(paths),
+            ModState = new FileModStateRepository(paths),
+            ModFavorites = new FileModFavoritesRepository(paths),
+            ModPackFavorites = new FileModPackFavoritesRepository(paths),
+            Uninstaller = new FileModUninstaller(paths),
+            Mods = new CompositeModRepository(sources),
+            Downloader = new SpaceDockModDownloader(http, resolver),
+            LatestVersion = new LatestVersionPing(http),
+        };
+    }
+
+    private static HttpClient BuildHttpClient()
+    {
+        var handler = new SocketsHttpHandler { PooledConnectionLifetime = ConnectionLifetime };
+        var http = new HttpClient(handler);
+
+        var version = typeof(BoreaServices).Assembly.GetName().Version?.ToString(3);
+        http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Borea", version));
+
+        return http;
+    }
+
+    public void Dispose() => _http.Dispose();
+}

--- a/src/Borea.Network/SpaceDock/SpaceDockModDownloader.cs
+++ b/src/Borea.Network/SpaceDock/SpaceDockModDownloader.cs
@@ -9,7 +9,7 @@ namespace Borea.Network.SpaceDock;
 /// <summary>
 /// IModDownloader implementation against SpaceDock. Downloads the mod's zip
 /// to a temp file, computes a SHA256 checksum, then extracts into
-/// destinationDirectory. Resolves modId via SpaceDockResolver — a raw
+/// destinationDirectory. Resolves modId via SpaceDockResolver: a raw
 /// integer placeholder (pre-mod.toml) or a previously-registered true
 /// ModId (post-mod.toml) both work identically.
 /// </summary>
@@ -46,7 +46,7 @@ public sealed class SpaceDockModDownloader : IModDownloader
             throw new InvalidOperationException($"Could not resolve SpaceDock mod '{modId}' to a numeric SpaceDock ID.");
 
         var dto = await _httpClient.GetFromJsonAsync<SpaceDockModDto>(
-            $"api/mod/{spaceDockId}", JsonOptions, cancellationToken).ConfigureAwait(false)
+            $"{SpaceDockModRepository.BaseUrl}/api/mod/{spaceDockId}", JsonOptions, cancellationToken).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"SpaceDock mod '{spaceDockId}' not found.");
 
         // Rows can normalize to the same version; the default row wins the
@@ -58,7 +58,7 @@ public sealed class SpaceDockModDownloader : IModDownloader
             ?? throw new InvalidOperationException($"Version '{version}' not found for SpaceDock mod '{spaceDockId}'.");
 
         using var response = await _httpClient.GetAsync(
-            matchingVersion.DownloadPath, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            $"{SpaceDockModRepository.BaseUrl}{matchingVersion.DownloadPath}", HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
         var totalBytes = response.Content.Headers.ContentLength ?? -1;

--- a/src/Borea.Network/SpaceDock/SpaceDockModRepository .cs
+++ b/src/Borea.Network/SpaceDock/SpaceDockModRepository .cs
@@ -31,7 +31,11 @@ public sealed class SpaceDockModRepository : IModRepository
     // SpaceDock's internal database ID for KSA.
     private const int KsaGameId = 22409;
 
-    private const string SourceName = "spacedock";
+    /// <summary>
+    /// The source tag on every listing and release from SpaceDock, and the key a
+    /// composite repository registers this source under.
+    /// </summary>
+    public const string SourceName = "spacedock";
     /// <summary>
     /// Every request names the host, so the client needs no base address.
     /// </summary>

--- a/src/Borea.Network/SpaceDock/SpaceDockModRepository .cs
+++ b/src/Borea.Network/SpaceDock/SpaceDockModRepository .cs
@@ -32,7 +32,10 @@ public sealed class SpaceDockModRepository : IModRepository
     private const int KsaGameId = 22409;
 
     private const string SourceName = "spacedock";
-    private const string BaseUrl = "https://spacedock.info";
+    /// <summary>
+    /// Every request names the host, so the client needs no base address.
+    /// </summary>
+    internal const string BaseUrl = "https://spacedock.info";
     private const string KsaForumsHost = "forums.ahwoo.com";
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -54,7 +57,7 @@ public sealed class SpaceDockModRepository : IModRepository
         // Single page: /api/browse pages at 500 and IModRepository has no
         // paging concept. Revisit if KSA's catalog outgrows one page.
         var response = await _httpClient.GetFromJsonAsync<SpaceDockBrowseResponseDto>(
-            $"api/browse?game_id={KsaGameId}&count=500", JsonOptions, cancellationToken).ConfigureAwait(false);
+            $"{BaseUrl}/api/browse?game_id={KsaGameId}&count=500", JsonOptions, cancellationToken).ConfigureAwait(false);
 
         return (response?.Result ?? new()).Where(IsKsaMod).Select(MapToListing).ToList();
     }
@@ -109,7 +112,7 @@ public sealed class SpaceDockModRepository : IModRepository
         // Live search results carry game_id per mod (undocumented in api.md,
         // confirmed by real response); IsKsaMod filters on it.
         var results = await _httpClient.GetFromJsonAsync<List<SpaceDockModDto>>(
-            $"api/search/mod?query={Uri.EscapeDataString(query)}", JsonOptions, cancellationToken).ConfigureAwait(false);
+            $"{BaseUrl}/api/search/mod?query={Uri.EscapeDataString(query)}", JsonOptions, cancellationToken).ConfigureAwait(false);
 
         return (results ?? new()).Where(IsKsaMod).Select(MapToListing).ToList();
     }
@@ -122,7 +125,7 @@ public sealed class SpaceDockModRepository : IModRepository
         try
         {
             var dto = await _httpClient.GetFromJsonAsync<SpaceDockModDto>(
-                $"api/mod/{spaceDockId}", JsonOptions, cancellationToken).ConfigureAwait(false);
+                $"{BaseUrl}/api/mod/{spaceDockId}", JsonOptions, cancellationToken).ConfigureAwait(false);
 
             return dto is null || !IsKsaMod(dto) ? null : dto;
         }

--- a/src/Borea.Storage/Paths/GamePathProvider.cs
+++ b/src/Borea.Storage/Paths/GamePathProvider.cs
@@ -5,7 +5,8 @@ using Borea.Core.Paths;
 namespace Borea.Storage.Paths;
 
 /// <summary>
-/// Resolves Borea's own %LocalAppData%-rooted paths directly, and KSA and mod loader paths from the provided settings.
+/// Resolves Borea's own paths under its root, %LocalAppData%\Borea unless another
+/// root is given, and KSA and mod loader paths from the provided settings.
 /// </summary>
 public sealed class GamePathProvider : IGamePathProvider
 {
@@ -13,10 +14,13 @@ public sealed class GamePathProvider : IGamePathProvider
     private readonly string? _gameDirectory;
     private readonly IReadOnlyDictionary<string, string> _loaderDirectories;
 
-    public GamePathProvider(string? gameDirectory, IReadOnlyDictionary<string, string>? loaderDirectories = null)
+    public GamePathProvider(string? gameDirectory, IReadOnlyDictionary<string, string>? loaderDirectories = null, string? boreaRoot = null)
     {
         if (gameDirectory is not null && string.IsNullOrWhiteSpace(gameDirectory))
             throw new ArgumentException("Game directory, if provided, cannot be whitespace.", nameof(gameDirectory));
+
+        if (boreaRoot is not null && string.IsNullOrWhiteSpace(boreaRoot))
+            throw new ArgumentException("Borea root, if provided, cannot be whitespace.", nameof(boreaRoot));
 
         // Same rule as BoreaSettings, since this constructor is public too.
         var byId = new Dictionary<string, string>(ModIds.Comparer);
@@ -33,7 +37,7 @@ public sealed class GamePathProvider : IGamePathProvider
 
         _gameDirectory = gameDirectory;
         _loaderDirectories = byId;
-        _boreaRoot = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Borea");
+        _boreaRoot = boreaRoot ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Borea");
     }
 
     public string GetIndexPath() => Path.Combine(_boreaRoot, "index.json");

--- a/tests/Borea.Composition.Tests/Borea.Composition.Tests.csproj
+++ b/tests/Borea.Composition.Tests/Borea.Composition.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Borea.Composition\Borea.Composition.csproj" />
+    <ProjectReference Include="..\..\src\Borea.Core\Borea.Core.csproj" />
+    <ProjectReference Include="..\..\src\Borea.Network\Borea.Network.csproj" />
+    <ProjectReference Include="..\..\src\Borea.Storage\Borea.Storage.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Borea.Composition.Tests/BoreaServicesTests.cs
+++ b/tests/Borea.Composition.Tests/BoreaServicesTests.cs
@@ -1,0 +1,137 @@
+using Borea.Core.Mods;
+using Borea.Core.Settings;
+using Borea.Network.Sources;
+using Borea.Storage.Paths;
+using Borea.Storage.Settings;
+
+namespace Borea.Composition.Tests;
+
+public sealed class BoreaServicesTests : IDisposable
+{
+    private const string GamePath = @"C:\Games\KSA";
+    private const string StarMapPath = @"C:\Games\StarMap";
+
+    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+
+    [Fact]
+    public async Task BuildAsync_NoSettingsFile_KnowsNoGameAndNoLoader()
+    {
+        using var services = await BoreaServices.BuildAsync(_tempRoot);
+
+        Assert.Null(services.Settings.GameDirectoryPath);
+        Assert.Empty(services.Settings.LoaderDirectoryPaths);
+        Assert.Null(services.Paths.GetGameDirectoryPath());
+        Assert.Null(services.Paths.GetLoaderDirectoryPath("StarMap"));
+    }
+
+    [Fact]
+    public async Task BuildAsync_NoSettingsFile_WritesNothing()
+    {
+        using var services = await BoreaServices.BuildAsync(_tempRoot);
+
+        Assert.False(Directory.Exists(_tempRoot));
+    }
+
+    [Fact]
+    public async Task BuildAsync_SettingsNamingNoGame_KnowsTheLoaderOnly()
+    {
+        await SaveAsync(new BoreaSettings(null, new Dictionary<string, string> { ["StarMap"] = StarMapPath }));
+
+        using var services = await BoreaServices.BuildAsync(_tempRoot);
+
+        Assert.Null(services.Paths.GetGameDirectoryPath());
+        Assert.Equal(StarMapPath, services.Paths.GetLoaderDirectoryPath("StarMap"));
+    }
+
+    [Fact]
+    public async Task BuildAsync_FullSettings_KnowsTheGameAndTheLoader()
+    {
+        await SaveAsync(new BoreaSettings(GamePath, new Dictionary<string, string> { ["StarMap"] = StarMapPath }));
+
+        using var services = await BoreaServices.BuildAsync(_tempRoot);
+
+        Assert.Equal(GamePath, services.Settings.GameDirectoryPath);
+        Assert.Equal(GamePath, services.Paths.GetGameDirectoryPath());
+        Assert.Equal(StarMapPath, services.Paths.GetLoaderDirectoryPath("StarMap"));
+    }
+
+    [Fact]
+    public async Task BuildAsync_RootsBoreaPathsAtTheGivenRoot()
+    {
+        using var services = await BoreaServices.BuildAsync(_tempRoot);
+
+        Assert.StartsWith(_tempRoot, services.Paths.GetBoreaSettingsPath());
+        Assert.StartsWith(_tempRoot, services.Paths.GetInstancesRoot());
+    }
+
+    [Fact]
+    public async Task BuildAsync_SettingsFileThatDoesNotLoad_Throws()
+    {
+        // Loader ids that collide by case are rejected by BoreaSettings, and a
+        // build must surface that instead of starting with empty settings.
+        Directory.CreateDirectory(_tempRoot);
+        await File.WriteAllTextAsync(SettingsPath, """
+            [LoaderDirectoryPaths]
+            StarMap = 'C:\Games\StarMap'
+            starmap = 'C:\Games\Other'
+            """);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => BoreaServices.BuildAsync(_tempRoot));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task BuildAsync_WhitespaceRoot_ThrowsArgumentException(string boreaRoot)
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => BoreaServices.BuildAsync(boreaRoot));
+    }
+
+    [Fact]
+    public async Task SettingsRepository_WritesWhereThePathsPoint_AndTheNextBuildReadsIt()
+    {
+        using (var services = await BoreaServices.BuildAsync(_tempRoot))
+        {
+            await services.SettingsRepository.SaveAsync(new BoreaSettings(GamePath));
+
+            Assert.True(File.Exists(services.Paths.GetBoreaSettingsPath()));
+        }
+
+        using var rebuilt = await BoreaServices.BuildAsync(_tempRoot);
+
+        Assert.Equal(GamePath, rebuilt.Paths.GetGameDirectoryPath());
+    }
+
+    [Fact]
+    public async Task Mods_IsTheCompositeRepository()
+    {
+        using var services = await BoreaServices.BuildAsync(_tempRoot);
+
+        Assert.IsType<CompositeModRepository>(services.Mods);
+    }
+
+    [Fact]
+    public async Task Dispose_ClosesTheOneClientEveryNetworkServiceUses()
+    {
+        var services = await BoreaServices.BuildAsync(_tempRoot);
+
+        services.Dispose();
+
+        // A disposed client refuses a request before it reaches any host, so each
+        // probe proves that the service holds the shared client and sends nothing.
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => services.LatestVersion.PingAsync());
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => services.Mods.GetAvailableModsAsync());
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => services.Downloader.DownloadAsync("1", new ModVersion(1, 0, 0), _tempRoot));
+    }
+
+    private string SettingsPath => new GamePathProvider(gameDirectory: null, boreaRoot: _tempRoot).GetBoreaSettingsPath();
+
+    private Task SaveAsync(BoreaSettings settings)
+        => new FileBoreaSettingsRepository(new GamePathProvider(gameDirectory: null, boreaRoot: _tempRoot)).SaveAsync(settings);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+}

--- a/tests/Borea.Network.Tests/Temp/FakeHttpMessageHandler.cs
+++ b/tests/Borea.Network.Tests/Temp/FakeHttpMessageHandler.cs
@@ -24,7 +24,7 @@ internal sealed class FakeHttpMessageHandler : HttpMessageHandler
     public static HttpClient BuildClient(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder, out FakeHttpMessageHandler handler)
     {
         handler = new FakeHttpMessageHandler(responder);
-        return new HttpClient(handler) { BaseAddress = new Uri("https://spacedock.info/") };
+        return new HttpClient(handler);
     }
 
     public static HttpResponseMessage JsonResponse(string json) => new(System.Net.HttpStatusCode.OK)

--- a/tests/Borea.Storage.Tests/Paths/GamePathProviderTests.cs
+++ b/tests/Borea.Storage.Tests/Paths/GamePathProviderTests.cs
@@ -16,6 +16,33 @@ public sealed class GamePathProviderTests
         Assert.Null(provider.GetLoaderDirectoryPath("StarMap"));
     }
 
+    [Fact]
+    public void Constructor_NoBoreaRoot_RootsBoreaPathsUnderLocalAppData()
+    {
+        var provider = new GamePathProvider(null);
+
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        Assert.StartsWith(Path.Combine(localAppData, "Borea"), provider.GetBoreaSettingsPath());
+    }
+
+    [Fact]
+    public void Constructor_BoreaRoot_RootsBoreaPathsThere()
+    {
+        var provider = new GamePathProvider(null, boreaRoot: @"D:\Portable\Borea");
+
+        Assert.StartsWith(@"D:\Portable\Borea", provider.GetBoreaSettingsPath());
+        Assert.StartsWith(@"D:\Portable\Borea", provider.GetInstancesRoot());
+        Assert.StartsWith(@"D:\Portable\Borea", provider.GetModFavoritesPath());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_WhitespaceBoreaRoot_ThrowsArgumentException(string boreaRoot)
+    {
+        Assert.Throws<ArgumentException>(() => new GamePathProvider(null, boreaRoot: boreaRoot));
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData("   ")]


### PR DESCRIPTION
Closes #64.

Stacked on #58, because the settings shape comes from there.

One new library, `Borea.Composition`, turns the saved settings into every service, once. `BoreaServices.BuildAsync` bootstraps in two steps: a `GamePathProvider` without a game path reads the settings, and the real one is built from them. One `HttpClient` with a `User-Agent` reaches every network class.

`Borea.Core` is untouched.

The App builds the services in `Main` and hands them to `App`. No UI changes. `App.Services` is where the App shell picks them up.

Known, and left for follow-ups:
- A settings file that does not load ends the App before a window shows. Surfacing that is UI and belongs to #50.
- `SpaceDockResolver` maps ids per process, so a fresh process cannot resolve an installed mod's SpaceDock id. It needs persistence next to the installed-mod records, which matters for #65.
- Changed settings need a rebuilt graph. `Main` owns it, so a first run needs a restart after the game folder is picked, until #50 wires a rebuild.
