### PR TITLE
CLI slice 1: settings, game version, instances, enable and disable

### DIFF
--- a/Borea.slnx
+++ b/Borea.slnx
@@ -1,12 +1,14 @@
 <Solution>
   <Folder Name="/src/">
     <Project Path="src/Borea.App/Borea.App.csproj" />
+    <Project Path="src/Borea.Cli/Borea.Cli.csproj" />
     <Project Path="src/Borea.Composition/Borea.Composition.csproj" />
     <Project Path="src/Borea.Core/Borea.Core.csproj" />
     <Project Path="src/Borea.Network/Borea.Network.csproj" />
     <Project Path="src/Borea.Storage/Borea.Storage.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Borea.Cli.Tests/Borea.Cli.Tests.csproj" />
     <Project Path="tests/Borea.Composition.Tests/Borea.Composition.Tests.csproj" />
     <Project Path="tests/Borea.Core.Tests/Borea.Core.Tests.csproj" />
     <Project Path="tests/Borea.Network.Tests/Borea.Network.Tests.csproj" />

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The exit code is 0 when the command completed, 1 when the operation failed and t
 | `borea settings show` | Print where the game and the mod loaders are. |
 | `borea settings set game <directory>` | Point Borea at the game installation. |
 | `borea settings set loader <loader-id> <directory>` | Point Borea at an installed mod loader. |
-| `borea game version` | Print the current public build the master server reports. |
+| `borea game version` | Print the installed build and the current public build the master server reports. |
 | `borea instance list` | Print every instance and mark the active one. |
 | `borea instance create <name>` | Create an empty instance. |
 | `borea instance rename <instance> <new-name>` | Give an instance a new name. |

--- a/README.md
+++ b/README.md
@@ -12,8 +12,27 @@ Borea is a cross-platform complete general content manager for Kitten Space Agen
 | `src\Borea.Core` | Contains all the core information about Borea's mods, mod packs, path providers, and more. Also contains the required interfaces to make a project compatible with Borea. |
 | `src\Borea.Storage` | Contains all the code for storing the data from `Borea.Core` to the disk. |
 | `src\Borea.Network` | Contains all the code for retrieving content from mod/content indexers and saves them to the disk. |
-| `src\Borea.Composition` | The composition root. Builds every service from the saved settings, once, for `Borea.App` and later `Borea.Cli`. |
+| `src\Borea.Composition` | The composition root. Builds every service from the saved settings, once, for `Borea.App` and `Borea.Cli`. |
 | `src\Borea.App` | A desktop level application that the user will interact with. Gets its services from `Borea.Composition`. |
+| `src\Borea.Cli` | The command line interface, `borea`. A thin wrapper over the same services, for scripts and for machines without a desktop. |
+
+# Command line
+`borea` runs Borea's operations from a script. Every read command takes `--json`.
+The exit code is 0 when the command completed, 1 when the operation failed and the reason is on stderr, and 2 when the command line did not parse.
+
+| Command | Does |
+| --- | --- |
+| `borea settings show` | Print where the game and the mod loaders are. |
+| `borea settings set game <directory>` | Point Borea at the game installation. |
+| `borea settings set loader <loader-id> <directory>` | Point Borea at an installed mod loader. |
+| `borea game version` | Print the current public build the master server reports. |
+| `borea instance list` | Print every instance and mark the active one. |
+| `borea instance create <name>` | Create an empty instance. |
+| `borea instance rename <instance> <new-name>` | Give an instance a new name. |
+| `borea instance delete <instance>` | Delete an instance and its folder. |
+| `borea instance activate <instance>` | Make an instance the active one. |
+| `borea enable <mod-id> [--instance <instance>]` | Make the game load a mod. |
+| `borea disable <mod-id> [--instance <instance>]` | Stop the game from loading a mod. |
 
 # Features
 tba

--- a/src/Borea.Cli/Borea.Cli.csproj
+++ b/src/Borea.Cli/Borea.Cli.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>borea</AssemblyName>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.11" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Borea.Composition\Borea.Composition.csproj" />
+    <ProjectReference Include="..\Borea.Core\Borea.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Borea.Cli.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Borea.Cli/BoreaCli.cs
+++ b/src/Borea.Cli/BoreaCli.cs
@@ -1,0 +1,56 @@
+using System.CommandLine;
+using Borea.Cli.Commands;
+
+namespace Borea.Cli;
+
+/// <summary>
+/// Builds the command tree and runs one command line against it.
+/// Every command maps onto one Borea.Core operation and adds no logic of its own.
+/// The exit codes are in <see cref="ExitCodes"/>.
+/// </summary>
+internal static class BoreaCli
+{
+    /// <summary>
+    /// Builds the command tree. The services are built by <paramref name="services"/>.
+    /// </summary>
+    public static RootCommand Build(Func<CancellationToken, Task<CliServices>> services)
+    {
+        if (services is null)
+            throw new ArgumentNullException(nameof(services));
+
+        var root = new RootCommand("Borea, the content manager for Kitten Space Agency.");
+        root.Subcommands.Add(SettingsCommand.Build(services));
+        root.Subcommands.Add(GameCommand.Build(services));
+        root.Subcommands.Add(InstanceCommand.Build(services));
+        root.Subcommands.Add(ModStateCommands.BuildEnable(services));
+        root.Subcommands.Add(ModStateCommands.BuildDisable(services));
+        return root;
+    }
+
+    /// <summary>
+    /// Parses and runs <paramref name="args"/>. A command line that does not parse
+    /// exits with <see cref="ExitCodes.Usage"/> after the parser said why.
+    /// </summary>
+    public static async Task<int> RunAsync(
+        string[] args,
+        Func<CancellationToken, Task<CliServices>> services,
+        TextWriter output,
+        TextWriter error,
+        CancellationToken cancellationToken = default)
+    {
+        if (args is null)
+            throw new ArgumentNullException(nameof(args));
+
+        if (output is null)
+            throw new ArgumentNullException(nameof(output));
+
+        if (error is null)
+            throw new ArgumentNullException(nameof(error));
+
+        var parseResult = Build(services).Parse(args);
+        var configuration = new InvocationConfiguration { Output = output, Error = error };
+        var exitCode = await parseResult.InvokeAsync(configuration, cancellationToken).ConfigureAwait(false);
+
+        return parseResult.Errors.Count > 0 ? ExitCodes.Usage : exitCode;
+    }
+}

--- a/src/Borea.Cli/CliServices.cs
+++ b/src/Borea.Cli/CliServices.cs
@@ -26,6 +26,8 @@ internal sealed class CliServices : IDisposable
 
     public required ILatestVersionPing LatestVersion { get; init; }
 
+    public required IInstalledGameVersionProvider InstalledVersion { get; init; }
+
     /// <summary>
     /// The graph the services came from, disposed with this instance. Null when
     /// nothing needs disposing.
@@ -34,9 +36,10 @@ internal sealed class CliServices : IDisposable
 
     /// <summary>
     /// The graph's services. <paramref name="latestVersion"/> replaces the
-    /// graph's master-server ping, which is what a test needs.
+    /// graph's master-server ping and <paramref name="installedVersion"/> its
+    /// reader of the installed build, which is what a test needs.
     /// </summary>
-    public static CliServices From(BoreaServices services, ILatestVersionPing? latestVersion = null)
+    public static CliServices From(BoreaServices services, ILatestVersionPing? latestVersion = null, IInstalledGameVersionProvider? installedVersion = null)
     {
         if (services is null)
             throw new ArgumentNullException(nameof(services));
@@ -48,6 +51,7 @@ internal sealed class CliServices : IDisposable
             Instances = services.Instances,
             ModState = services.ModState,
             LatestVersion = latestVersion ?? services.LatestVersion,
+            InstalledVersion = installedVersion ?? services.InstalledVersion,
             Graph = services,
         };
     }

--- a/src/Borea.Cli/CliServices.cs
+++ b/src/Borea.Cli/CliServices.cs
@@ -1,0 +1,56 @@
+using Borea.Composition;
+using Borea.Core.Game;
+using Borea.Core.Instances;
+using Borea.Core.Settings;
+using Borea.Core.State;
+
+namespace Borea.Cli;
+
+/// <summary>
+/// The services the commands run against, seen as Borea.Core interfaces.
+/// The program fills it from <see cref="BoreaServices"/>.
+/// </summary>
+internal sealed class CliServices : IDisposable
+{
+    /// <summary>
+    /// The settings the graph was built from. Empty settings when no file was
+    /// saved yet.
+    /// </summary>
+    public required BoreaSettings Settings { get; init; }
+
+    public required IBoreaSettingsRepository SettingsRepository { get; init; }
+
+    public required IInstanceRepository Instances { get; init; }
+
+    public required IModStateRepository ModState { get; init; }
+
+    public required ILatestVersionPing LatestVersion { get; init; }
+
+    /// <summary>
+    /// The graph the services came from, disposed with this instance. Null when
+    /// nothing needs disposing.
+    /// </summary>
+    public IDisposable? Graph { get; init; }
+
+    /// <summary>
+    /// The graph's services. <paramref name="latestVersion"/> replaces the
+    /// graph's master-server ping, which is what a test needs.
+    /// </summary>
+    public static CliServices From(BoreaServices services, ILatestVersionPing? latestVersion = null)
+    {
+        if (services is null)
+            throw new ArgumentNullException(nameof(services));
+
+        return new CliServices
+        {
+            Settings = services.Settings,
+            SettingsRepository = services.SettingsRepository,
+            Instances = services.Instances,
+            ModState = services.ModState,
+            LatestVersion = latestVersion ?? services.LatestVersion,
+            Graph = services,
+        };
+    }
+
+    public void Dispose() => Graph?.Dispose();
+}

--- a/src/Borea.Cli/Commands/ArgumentRules.cs
+++ b/src/Borea.Cli/Commands/ArgumentRules.cs
@@ -1,0 +1,58 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Borea.Core.Mods;
+
+namespace Borea.Cli.Commands;
+
+/// <summary>
+/// Parse-time checks on argument values. A value that fails one is a usage
+/// error, so the command never runs and the process exits with
+/// <see cref="ExitCodes.Usage"/>.
+/// </summary>
+internal static class ArgumentRules
+{
+    /// <summary>A required string that must carry something besides whitespace.</summary>
+    public static Argument<string> Text(string name, string description)
+    {
+        var argument = new Argument<string>(name) { Description = description };
+        argument.Validators.Add(result =>
+        {
+            if (string.IsNullOrWhiteSpace(result.GetValueOrDefault<string>()))
+                result.AddError($"The {name} cannot be empty.");
+        });
+        return argument;
+    }
+
+    /// <summary>A content id, checked against the id rules in <see cref="ModIds"/>.</summary>
+    public static Argument<string> ContentId(string name, string description)
+    {
+        var argument = new Argument<string>(name) { Description = description };
+        argument.Validators.Add(result =>
+        {
+            var value = result.GetValueOrDefault<string>();
+            if (!ModIds.IsValid(value))
+                result.AddError($"'{value}' is not a valid content id.");
+        });
+        return argument;
+    }
+
+    /// <summary>
+    /// The instance a command acts on. Absent means the active instance, present
+    /// and blank is a usage error, like a blank instance argument.
+    /// </summary>
+    public static Option<string?> Instance()
+    {
+        var option = new Option<string?>("--instance")
+        {
+            Description = "The instance to act on, by name or id. The active instance when absent.",
+        };
+        option.Validators.Add(result =>
+        {
+            if (string.IsNullOrWhiteSpace(result.GetValueOrDefault<string?>()))
+                result.AddError("The --instance value cannot be empty.");
+        });
+        return option;
+    }
+
+    public static Option<bool> Json() => new("--json") { Description = "Print the result as JSON, for scripts." };
+}

--- a/src/Borea.Cli/Commands/CommandRunner.cs
+++ b/src/Borea.Cli/Commands/CommandRunner.cs
@@ -1,0 +1,64 @@
+using System.CommandLine;
+
+namespace Borea.Cli.Commands;
+
+/// <summary>
+/// Runs one command body against freshly built services and turns a failed
+/// operation into <see cref="ExitCodes.Failed"/> with the reason on stderr.
+/// </summary>
+internal static class CommandRunner
+{
+    public static async Task<int> RunAsync(
+        ParseResult parseResult,
+        Func<CancellationToken, Task<CliServices>> buildServices,
+        CancellationToken cancellationToken,
+        Func<CliServices, TextWriter, TextWriter, CancellationToken, Task<int>> body)
+    {
+        var output = parseResult.InvocationConfiguration.Output;
+        var error = parseResult.InvocationConfiguration.Error;
+
+        CliServices services;
+        try
+        {
+            services = await buildServices(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            // The settings file is the only thing a build reads, so whatever
+            // stopped it is about that file.
+            error.WriteLine($"error: Borea's settings could not be read. {exception.Message}");
+            return ExitCodes.Failed;
+        }
+
+        using (services)
+        {
+            try
+            {
+                return await body(services, output, error, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                error.WriteLine("error: The command was cancelled.");
+                return ExitCodes.Failed;
+            }
+            catch (Exception exception) when (IsOperationFailure(exception))
+            {
+                error.WriteLine($"error: {exception.Message}");
+                return ExitCodes.Failed;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The exceptions a Core operation, a data file, or a remote host raise when
+    /// the operation itself fails. A cancellation that is not the user's is a
+    /// timeout. Anything else is a defect and keeps its stack trace.
+    /// </summary>
+    private static bool IsOperationFailure(Exception exception) =>
+        exception is InvalidOperationException
+            or FormatException
+            or IOException
+            or UnauthorizedAccessException
+            or HttpRequestException
+            or OperationCanceledException;
+}

--- a/src/Borea.Cli/Commands/GameCommand.cs
+++ b/src/Borea.Cli/Commands/GameCommand.cs
@@ -1,0 +1,69 @@
+using System.CommandLine;
+using Borea.Cli.Output;
+using Borea.Core.Game;
+
+namespace Borea.Cli.Commands;
+
+/// <summary>
+/// <c>borea game</c>: facts about the game installation.
+/// </summary>
+internal static class GameCommand
+{
+    public static Command Build(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var game = new Command("game", "Read facts about the game installation.");
+        game.Subcommands.Add(BuildVersion(services));
+        return game;
+    }
+
+    private static Command BuildVersion(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var json = ArgumentRules.Json();
+        var version = new Command("version", "Print the current public build the master server reports.");
+        version.Options.Add(json);
+
+        version.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, _, ct) =>
+        {
+            var latest = await cli.LatestVersion.PingAsync(ct).ConfigureAwait(false);
+
+            if (string.IsNullOrWhiteSpace(latest.RawVersion))
+                throw new InvalidOperationException("The master server gave no version.");
+
+            var view = LatestVersionView.From(latest);
+
+            if (parseResult.GetValue(json))
+            {
+                JsonOutput.Write(output, new GameVersionView(view));
+                return ExitCodes.Done;
+            }
+
+            output.WriteLine(latest.Version is null
+                ? $"Latest public build: {latest.RawVersion} (this did not parse as a game version)"
+                : $"Latest public build: {latest.Version}");
+
+            if (view.DownloadUrl is not null)
+                output.WriteLine($"Download: {view.DownloadUrl}");
+
+            return ExitCodes.Done;
+        }));
+
+        return version;
+    }
+
+    /// <summary>The JSON shape of <c>game version</c>.</summary>
+    private sealed record GameVersionView(LatestVersionView Latest);
+
+    /// <summary>
+    /// The master server's answer. An answer without a download page carries
+    /// null, not the empty string the ping keeps.
+    /// </summary>
+    private sealed record LatestVersionView(string? Version, int? Revision, string Raw, string? DownloadUrl)
+    {
+        public static LatestVersionView From(LatestVersionInfo latest)
+            => new(
+                latest.Version?.ToString(),
+                latest.Version?.Revision,
+                latest.RawVersion,
+                string.IsNullOrWhiteSpace(latest.DownloadUrl) ? null : latest.DownloadUrl);
+    }
+}

--- a/src/Borea.Cli/Commands/GameCommand.cs
+++ b/src/Borea.Cli/Commands/GameCommand.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using Borea.Cli.Output;
 using Borea.Core.Game;
+using Borea.Core.Settings;
 
 namespace Borea.Cli.Commands;
 
@@ -16,33 +17,53 @@ internal static class GameCommand
         return game;
     }
 
+    /// <summary>
+    /// the installed build comes from disk, the latest from the master server.
+    /// </summary>
     private static Command BuildVersion(Func<CancellationToken, Task<CliServices>> services)
     {
         var json = ArgumentRules.Json();
-        var version = new Command("version", "Print the current public build the master server reports.");
+        var version = new Command("version", "Print the installed build and the current public build the master server reports.");
         version.Options.Add(json);
 
-        version.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, _, ct) =>
+        version.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, error, ct) =>
         {
-            var latest = await cli.LatestVersion.PingAsync(ct).ConfigureAwait(false);
+            var installed = cli.InstalledVersion.GetInstalledVersion();
+            var (latest, latestProblem) = await AskMasterServerAsync(cli.LatestVersion, ct).ConfigureAwait(false);
 
-            if (string.IsNullOrWhiteSpace(latest.RawVersion))
-                throw new InvalidOperationException("The master server gave no version.");
+            if (installed is null && latest is null)
+                throw new InvalidOperationException($"The installed build is unknown: {InstalledUnknownReason(cli.Settings)}. {latestProblem}");
 
-            var view = LatestVersionView.From(latest);
+            if (latestProblem is not null)
+                error.WriteLine($"warning: {latestProblem}");
 
             if (parseResult.GetValue(json))
             {
-                JsonOutput.Write(output, new GameVersionView(view));
+                JsonOutput.Write(output, new GameVersionView(
+                    installed is null ? null : InstalledVersionView.From(installed),
+                    latest is null ? null : LatestVersionView.From(latest)));
                 return ExitCodes.Done;
             }
 
-            output.WriteLine(latest.Version is null
-                ? $"Latest public build: {latest.RawVersion} (this did not parse as a game version)"
-                : $"Latest public build: {latest.Version}");
+            output.WriteLine(installed switch
+            {
+                null => $"Installed build: unknown ({InstalledUnknownReason(cli.Settings)})",
+                { Version: null } => $"Installed build: {installed.RawVersion} (this did not parse as a game version)",
+                _ => $"Installed build: {installed.Version}",
+            });
 
-            if (view.DownloadUrl is not null)
-                output.WriteLine($"Download: {view.DownloadUrl}");
+            if (latest is not null)
+            {
+                output.WriteLine(latest.Version is null
+                    ? $"Latest public build: {latest.RawVersion} (this did not parse as a game version)"
+                    : $"Latest public build: {latest.Version}");
+
+                if (!string.IsNullOrWhiteSpace(latest.DownloadUrl))
+                    output.WriteLine($"Download: {latest.DownloadUrl}");
+            }
+
+            if (installed?.Version is { } have && latest?.Version is { } current)
+                output.WriteLine(have < current ? "A newer build is available." : "The installed build is current.");
 
             return ExitCodes.Done;
         }));
@@ -50,8 +71,43 @@ internal static class GameCommand
         return version;
     }
 
-    /// <summary>The JSON shape of <c>game version</c>.</summary>
-    private sealed record GameVersionView(LatestVersionView Latest);
+    /// <summary>
+    /// The master server's answer.
+    /// </summary>
+    private static async Task<(LatestVersionInfo? Latest, string? Problem)> AskMasterServerAsync(ILatestVersionPing ping, CancellationToken cancellationToken)
+    {
+        LatestVersionInfo answer;
+        try
+        {
+            answer = await ping.PingAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException exception)
+        {
+            return (null, $"The master server could not be reached. {exception.Message}");
+        }
+        catch (OperationCanceledException exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            return (null, $"The master server did not answer in time. {exception.Message}");
+        }
+
+        return string.IsNullOrWhiteSpace(answer.RawVersion)
+            ? (null, "The master server gave no version.")
+            : (answer, null);
+    }
+
+    private static string InstalledUnknownReason(BoreaSettings settings)
+        => settings.GameDirectoryPath is null
+            ? "no game directory is set, run 'borea settings set game'"
+            : $"no KSA.dll with a version was found in {settings.GameDirectoryPath}";
+
+    /// <summary>The JSON shape of <c>game version</c>. A half that is missing is null.</summary>
+    private sealed record GameVersionView(InstalledVersionView? Installed, LatestVersionView? Latest);
+
+    private sealed record InstalledVersionView(string? Version, int? Revision, string Raw)
+    {
+        public static InstalledVersionView From(InstalledGameVersion installed)
+            => new(installed.Version?.ToString(), installed.Version?.Revision, installed.RawVersion);
+    }
 
     /// <summary>
     /// The master server's answer. An answer without a download page carries

--- a/src/Borea.Cli/Commands/InstanceCommand.cs
+++ b/src/Borea.Cli/Commands/InstanceCommand.cs
@@ -1,0 +1,159 @@
+using System.CommandLine;
+using Borea.Cli.Output;
+using Borea.Core.Instances;
+
+namespace Borea.Cli.Commands;
+
+/// <summary>
+/// <c>borea instance</c>: the lifecycle of instances.
+/// </summary>
+internal static class InstanceCommand
+{
+    private const string InstanceArgumentDescription = "The instance's name, or its id when two names differ only in case.";
+
+    public static Command Build(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var instance = new Command("instance", "List, create, rename, delete, and activate instances.");
+        instance.Subcommands.Add(BuildList(services));
+        instance.Subcommands.Add(BuildCreate(services));
+        instance.Subcommands.Add(BuildRename(services));
+        instance.Subcommands.Add(BuildDelete(services));
+        instance.Subcommands.Add(BuildActivate(services));
+        return instance;
+    }
+
+    private static Command BuildList(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var json = ArgumentRules.Json();
+        var list = new Command("list", "Print every instance and mark the active one.");
+        list.Options.Add(json);
+
+        list.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, _, _) =>
+        {
+            var activeId = await cli.Instances.GetActiveInstanceIdAsync().ConfigureAwait(false);
+            var instances = (await cli.Instances.GetAllAsync().ConfigureAwait(false))
+                .OrderBy(instance => instance.Name, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(instance => instance.CreatedAt)
+                .ToList();
+
+            if (parseResult.GetValue(json))
+            {
+                JsonOutput.Write(output, instances.Select(instance => InstanceView.From(instance, instance.InstanceId == activeId)));
+                return ExitCodes.Done;
+            }
+
+            if (instances.Count == 0)
+            {
+                output.WriteLine("No instances.");
+                return ExitCodes.Done;
+            }
+
+            var nameWidth = instances.Max(instance => instance.Name.Length);
+            foreach (var instance in instances)
+            {
+                var marker = instance.InstanceId == activeId ? "*" : " ";
+                output.WriteLine($"{marker} {instance.Name.PadRight(nameWidth)}  {instance.InstanceId}  {Describe(instance.Source)}");
+            }
+
+            return ExitCodes.Done;
+        }));
+
+        return list;
+    }
+
+    private static Command BuildCreate(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var name = ArgumentRules.Text("name", "The display name. Names compare case-insensitively.");
+        var create = new Command("create", "Create an empty instance.");
+        create.Arguments.Add(name);
+
+        create.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, _, _) =>
+        {
+            var created = await cli.Instances.CreateAsync(parseResult.GetRequiredValue(name), InstanceSource.Custom.Value).ConfigureAwait(false);
+
+            output.WriteLine($"Created instance '{created.Name}' ({created.InstanceId}).");
+            return ExitCodes.Done;
+        }));
+
+        return create;
+    }
+
+    private static Command BuildRename(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var instance = ArgumentRules.Text("instance", InstanceArgumentDescription);
+        var newName = ArgumentRules.Text("new-name", "The new display name.");
+        var rename = new Command("rename", "Give an instance a new name.");
+        rename.Arguments.Add(instance);
+        rename.Arguments.Add(newName);
+
+        rename.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, _, _) =>
+        {
+            var target = await InstanceLookup.ResolveAsync(cli.Instances, parseResult.GetRequiredValue(instance)).ConfigureAwait(false);
+            var renamed = parseResult.GetRequiredValue(newName);
+            await cli.Instances.RenameAsync(target.InstanceId, renamed).ConfigureAwait(false);
+
+            output.WriteLine($"Renamed '{target.Name}' to '{renamed}'.");
+            return ExitCodes.Done;
+        }));
+
+        return rename;
+    }
+
+    private static Command BuildDelete(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var instance = ArgumentRules.Text("instance", InstanceArgumentDescription);
+        var delete = new Command("delete", "Delete an instance and everything in its folder.");
+        delete.Arguments.Add(instance);
+
+        delete.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, _, _) =>
+        {
+            var target = await InstanceLookup.ResolveAsync(cli.Instances, parseResult.GetRequiredValue(instance)).ConfigureAwait(false);
+            await cli.Instances.DeleteAsync(target.InstanceId).ConfigureAwait(false);
+
+            output.WriteLine($"Deleted instance '{target.Name}' ({target.InstanceId}).");
+            return ExitCodes.Done;
+        }));
+
+        return delete;
+    }
+
+    private static Command BuildActivate(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var instance = ArgumentRules.Text("instance", InstanceArgumentDescription);
+        var activate = new Command("activate", "Make an instance the active one. It is the instance that launches, and the one 'enable' and 'disable' act on when --instance is absent.");
+        activate.Arguments.Add(instance);
+
+        activate.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, _, _) =>
+        {
+            var target = await InstanceLookup.ResolveAsync(cli.Instances, parseResult.GetRequiredValue(instance)).ConfigureAwait(false);
+            await cli.Instances.SetActiveInstanceAsync(target.InstanceId).ConfigureAwait(false);
+
+            output.WriteLine($"Active instance: '{target.Name}' ({target.InstanceId}).");
+            return ExitCodes.Done;
+        }));
+
+        return activate;
+    }
+
+    private static string Describe(InstanceSource source) => source switch
+    {
+        InstanceSource.FromModPack pack => $"modpack {pack.ModPackId} {pack.Version}",
+        _ => "custom",
+    };
+
+    /// <summary>One entry of <c>instance list --json</c>.</summary>
+    private sealed record InstanceView(Guid Id, string Name, bool Active, InstanceSourceView Source, DateTimeOffset CreatedAt)
+    {
+        public static InstanceView From(Instance instance, bool active)
+            => new(instance.InstanceId, instance.Name, active, InstanceSourceView.From(instance.Source), instance.CreatedAt);
+    }
+
+    private sealed record InstanceSourceView(string Kind, string? ModPackId, string? Version)
+    {
+        public static InstanceSourceView From(InstanceSource source) => source switch
+        {
+            InstanceSource.FromModPack pack => new("modpack", pack.ModPackId, pack.Version.ToString()),
+            _ => new("custom", null, null),
+        };
+    }
+}

--- a/src/Borea.Cli/Commands/InstanceLookup.cs
+++ b/src/Borea.Cli/Commands/InstanceLookup.cs
@@ -1,0 +1,55 @@
+using Borea.Core.Instances;
+
+namespace Borea.Cli.Commands;
+
+/// <summary>
+/// Finds the instance a command line names.
+/// </summary>
+internal static class InstanceLookup
+{
+    /// <summary>
+    /// The instance named by its display name, compared case-insensitively, or by
+    /// its id. When two names differ only in case, only the id names one of them.
+    /// </summary>
+    public static async Task<Instance> ResolveAsync(IInstanceRepository instances, string nameOrId)
+    {
+        var isId = Guid.TryParse(nameOrId, out var instanceId);
+        if (isId)
+        {
+            var byId = await instances.GetByIdAsync(instanceId).ConfigureAwait(false);
+            if (byId is not null)
+                return byId;
+        }
+
+        var all = await instances.GetAllAsync().ConfigureAwait(false);
+        var named = all
+            .Where(instance => string.Equals(instance.Name, nameOrId, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        return named.Count switch
+        {
+            1 => named[0],
+            0 when isId => throw new InvalidOperationException($"No instance has the id '{nameOrId}', and none is named that."),
+            0 => throw new InvalidOperationException($"No instance is named '{nameOrId}'."),
+            _ => throw new InvalidOperationException(
+                $"More than one instance is named '{nameOrId}' when compared case-insensitively. Name it by id: " +
+                string.Join(", ", named.Select(instance => $"{instance.Name} ({instance.InstanceId})")) + "."),
+        };
+    }
+
+    /// <summary>
+    /// The instance a command acts on: the one named, or the active one when
+    /// none was named.
+    /// </summary>
+    public static async Task<Instance> ResolveTargetAsync(IInstanceRepository instances, string? nameOrId)
+    {
+        if (nameOrId is not null)
+            return await ResolveAsync(instances, nameOrId).ConfigureAwait(false);
+
+        var activeId = await instances.GetActiveInstanceIdAsync().ConfigureAwait(false)
+            ?? throw new InvalidOperationException("No instance is active. Pass --instance, or run 'borea instance activate'.");
+
+        return await instances.GetByIdAsync(activeId).ConfigureAwait(false)
+            ?? throw new InvalidOperationException($"The active instance {activeId} does not exist anymore. Activate another one.");
+    }
+}

--- a/src/Borea.Cli/Commands/ModStateCommands.cs
+++ b/src/Borea.Cli/Commands/ModStateCommands.cs
@@ -1,0 +1,59 @@
+using System.CommandLine;
+
+namespace Borea.Cli.Commands;
+
+/// <summary>
+/// <c>borea enable</c> and <c>borea disable</c>: whether the game loads a mod.
+/// The manifest is the game's file, and the game names a mod by its folder, so
+/// the id is any text and not a content id: a folder the user made by hand is
+/// enabled and disabled like an installed one.
+/// </summary>
+internal static class ModStateCommands
+{
+    private const string ModIdDescription = "The mod's id, the name of its folder.";
+
+    public static Command BuildEnable(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var modId = ArgumentRules.Text("mod-id", ModIdDescription);
+        var instance = ArgumentRules.Instance();
+        var enable = new Command("enable", "Make the game load a mod in an instance.");
+        enable.Arguments.Add(modId);
+        enable.Options.Add(instance);
+
+        enable.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, _, ct) =>
+        {
+            var id = parseResult.GetRequiredValue(modId);
+            var target = await InstanceLookup.ResolveTargetAsync(cli.Instances, parseResult.GetValue(instance)).ConfigureAwait(false);
+
+            // The repository does not say whether the entry changed, so the
+            // message states the end state.
+            await cli.ModState.SetActiveAsync(target.InstanceId, id, ct).ConfigureAwait(false);
+
+            output.WriteLine($"Enabled {id} in '{target.Name}'.");
+            return ExitCodes.Done;
+        }));
+
+        return enable;
+    }
+
+    public static Command BuildDisable(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var modId = ArgumentRules.Text("mod-id", ModIdDescription);
+        var instance = ArgumentRules.Instance();
+        var disable = new Command("disable", "Stop the game from loading a mod in an instance. The files stay.");
+        disable.Arguments.Add(modId);
+        disable.Options.Add(instance);
+
+        disable.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, _, ct) =>
+        {
+            var id = parseResult.GetRequiredValue(modId);
+            var target = await InstanceLookup.ResolveTargetAsync(cli.Instances, parseResult.GetValue(instance)).ConfigureAwait(false);
+            await cli.ModState.SetInactiveAsync(target.InstanceId, id, ct).ConfigureAwait(false);
+
+            output.WriteLine($"Disabled {id} in '{target.Name}'.");
+            return ExitCodes.Done;
+        }));
+
+        return disable;
+    }
+}

--- a/src/Borea.Cli/Commands/ModStateCommands.cs
+++ b/src/Borea.Cli/Commands/ModStateCommands.cs
@@ -1,12 +1,13 @@
 using System.CommandLine;
+using Borea.Core.Mods;
+using Borea.Core.State;
 
 namespace Borea.Cli.Commands;
 
 /// <summary>
 /// <c>borea enable</c> and <c>borea disable</c>: whether the game loads a mod.
-/// The manifest is the game's file, and the game names a mod by its folder, so
-/// the id is any text and not a content id: a folder the user made by hand is
-/// enabled and disabled like an installed one.
+/// The manifest is the game's file, and the game names a mod by its folder, so a
+/// folder the user made by hand is enabled and disabled like an installed one.
 /// </summary>
 internal static class ModStateCommands
 {
@@ -25,9 +26,21 @@ internal static class ModStateCommands
             var id = parseResult.GetRequiredValue(modId);
             var target = await InstanceLookup.ResolveTargetAsync(cli.Instances, parseResult.GetValue(instance)).ConfigureAwait(false);
 
-            // The repository does not say whether the entry changed, so the
-            // message states the end state.
-            await cli.ModState.SetActiveAsync(target.InstanceId, id, ct).ConfigureAwait(false);
+            var flipped = await cli.ModState.SetActiveAsync(target.InstanceId, id, ct).ConfigureAwait(false);
+
+            // Nothing flipped means the manifest already lists the mod as enabled,
+            // or does not list it at all. The second case writes an entry, and
+            // it is also the only one that needs the files, so a mod whose folder
+            // the user deleted can still be enabled through its entry.
+            if (!flipped && !await cli.ModState.IsActiveAsync(target.InstanceId, id, ct).ConfigureAwait(false))
+            {
+                if (!ModIds.IsValid(id))
+                    throw new InvalidOperationException($"'{id}' cannot name a mod folder, so no entry can be written for it.");
+
+                var added = await cli.ModState.AddEntryAsync(target.InstanceId, id, enabled: true, ct).ConfigureAwait(false);
+                if (added is ModEntryAddResult.NotOnDisk)
+                    throw new InvalidOperationException($"'{target.Name}' has no mod folder named '{id}'.");
+            }
 
             output.WriteLine($"Enabled {id} in '{target.Name}'.");
             return ExitCodes.Done;

--- a/src/Borea.Cli/Commands/SettingsCommand.cs
+++ b/src/Borea.Cli/Commands/SettingsCommand.cs
@@ -1,0 +1,120 @@
+using System.CommandLine;
+using Borea.Cli.Output;
+using Borea.Core.Mods;
+using Borea.Core.Settings;
+
+namespace Borea.Cli.Commands;
+
+/// <summary>
+/// <c>borea settings</c>: where the game and the mod loaders are.
+/// </summary>
+internal static class SettingsCommand
+{
+    public static Command Build(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var settings = new Command("settings", "Read and write Borea's own settings: where the game and the mod loaders are.");
+        settings.Subcommands.Add(BuildShow(services));
+        settings.Subcommands.Add(BuildSet(services));
+        return settings;
+    }
+
+    private static Command BuildShow(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var json = ArgumentRules.Json();
+        var show = new Command("show", "Print the saved settings.");
+        show.Options.Add(json);
+
+        show.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, (cli, output, _, _) =>
+        {
+            if (parseResult.GetValue(json))
+                JsonOutput.Write(output, SettingsView.From(cli.Settings));
+            else
+                WriteSettings(output, cli.Settings);
+
+            return Task.FromResult(ExitCodes.Done);
+        }));
+
+        return show;
+    }
+
+    private static Command BuildSet(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var set = new Command("set", "Change one setting. The other settings stay as they are.");
+        set.Subcommands.Add(BuildSetGame(services));
+        set.Subcommands.Add(BuildSetLoader(services));
+        return set;
+    }
+
+    private static Command BuildSetGame(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var directory = ArgumentRules.Text("directory", "The folder that holds the game executable.");
+        var game = new Command("game", "Point Borea at the game installation.");
+        game.Arguments.Add(directory);
+
+        game.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, error, ct) =>
+        {
+            var fullPath = Path.GetFullPath(parseResult.GetRequiredValue(directory));
+            await cli.SettingsRepository.SaveAsync(cli.Settings.WithGameDirectory(fullPath), ct).ConfigureAwait(false);
+
+            output.WriteLine($"Game directory: {fullPath}");
+            WarnWhenMissing(error, fullPath);
+            return ExitCodes.Done;
+        }));
+
+        return game;
+    }
+
+    private static Command BuildSetLoader(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var loaderId = ArgumentRules.ContentId("loader-id", "The loader's content id, such as StarMap.");
+        var directory = ArgumentRules.Text("directory", "The folder the loader is installed in.");
+        var loader = new Command("loader", "Point Borea at an installed mod loader.");
+        loader.Arguments.Add(loaderId);
+        loader.Arguments.Add(directory);
+
+        loader.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, error, ct) =>
+        {
+            var id = parseResult.GetRequiredValue(loaderId);
+            var fullPath = Path.GetFullPath(parseResult.GetRequiredValue(directory));
+            await cli.SettingsRepository.SaveAsync(cli.Settings.WithLoaderDirectory(id, fullPath), ct).ConfigureAwait(false);
+
+            output.WriteLine($"Loader {id} directory: {fullPath}");
+            WarnWhenMissing(error, fullPath);
+            return ExitCodes.Done;
+        }));
+
+        return loader;
+    }
+
+    /// <summary>
+    /// The path is saved as given, because Borea can be set up before the game
+    /// is installed. A typo still deserves a word.
+    /// </summary>
+    private static void WarnWhenMissing(TextWriter error, string directory)
+    {
+        if (!Directory.Exists(directory))
+            error.WriteLine($"warning: {directory} does not exist.");
+    }
+
+    private static void WriteSettings(TextWriter output, BoreaSettings settings)
+    {
+        output.WriteLine($"Game directory: {settings.GameDirectoryPath ?? "not set"}");
+
+        if (settings.LoaderDirectoryPaths.Count == 0)
+        {
+            output.WriteLine("Loader directories: none");
+            return;
+        }
+
+        output.WriteLine("Loader directories:");
+        foreach (var (loaderId, path) in settings.LoaderDirectoryPaths.OrderBy(p => p.Key, ModIds.Comparer))
+            output.WriteLine($"  {loaderId}: {path}");
+    }
+
+    /// <summary>The JSON shape of <c>settings show</c>.</summary>
+    private sealed record SettingsView(string? GameDirectory, IReadOnlyDictionary<string, string> LoaderDirectories)
+    {
+        public static SettingsView From(BoreaSettings settings)
+            => new(settings.GameDirectoryPath, settings.LoaderDirectoryPaths);
+    }
+}

--- a/src/Borea.Cli/ExitCodes.cs
+++ b/src/Borea.Cli/ExitCodes.cs
@@ -1,0 +1,13 @@
+namespace Borea.Cli;
+
+internal static class ExitCodes
+{
+    /// <summary>The command completed the operation.</summary>
+    public const int Done = 0;
+
+    /// <summary>The command ran and the operation failed. The reason is on stderr.</summary>
+    public const int Failed = 1;
+
+    /// <summary>The command line did not parse. The parser's message is on stderr.</summary>
+    public const int Usage = 2;
+}

--- a/src/Borea.Cli/Output/JsonOutput.cs
+++ b/src/Borea.Cli/Output/JsonOutput.cs
@@ -1,0 +1,15 @@
+using System.Text.Json;
+
+namespace Borea.Cli.Output;
+
+/// <summary>
+/// Writes a command's result as JSON: camelCase keys, dictionary keys as they
+/// are, indented.
+/// </summary>
+internal static class JsonOutput
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+
+    public static void Write<T>(TextWriter output, T value)
+        => output.WriteLine(JsonSerializer.Serialize(value, Options));
+}

--- a/src/Borea.Cli/Program.cs
+++ b/src/Borea.Cli/Program.cs
@@ -1,0 +1,21 @@
+using System.Text;
+using Borea.Composition;
+
+namespace Borea.Cli;
+
+internal static class Program
+{
+    private static async Task<int> Main(string[] args)
+    {
+        using var output = Console.IsOutputRedirected ? Utf8Writer(Console.OpenStandardOutput()) : null;
+        using var error = Console.IsErrorRedirected ? Utf8Writer(Console.OpenStandardError()) : null;
+
+        return await BoreaCli.RunAsync(args, BuildServicesAsync, output ?? Console.Out, error ?? Console.Error).ConfigureAwait(false);
+    }
+
+    private static async Task<CliServices> BuildServicesAsync(CancellationToken cancellationToken)
+        => CliServices.From(await BoreaServices.BuildAsync(cancellationToken).ConfigureAwait(false));
+
+    private static StreamWriter Utf8Writer(Stream stream)
+        => new(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)) { AutoFlush = true };
+}

--- a/src/Borea.Composition/BoreaServices.cs
+++ b/src/Borea.Composition/BoreaServices.cs
@@ -9,6 +9,7 @@ using Borea.Core.State;
 using Borea.Network.MasterServer;
 using Borea.Network.Sources;
 using Borea.Network.SpaceDock;
+using Borea.Storage.Game;
 using Borea.Storage.Instances;
 using Borea.Storage.ModPacks;
 using Borea.Storage.Mods;
@@ -74,6 +75,8 @@ public sealed class BoreaServices : IDisposable
 
     public required ILatestVersionPing LatestVersion { get; init; }
 
+    public required IInstalledGameVersionProvider InstalledVersion { get; init; }
+
     private BoreaServices(HttpClient http)
     {
         _http = http;
@@ -130,6 +133,7 @@ public sealed class BoreaServices : IDisposable
             Mods = new CompositeModRepository(sources),
             Downloader = new SpaceDockModDownloader(http, resolver),
             LatestVersion = new LatestVersionPing(http),
+            InstalledVersion = new InstalledGameVersionProvider(paths),
         };
     }
 

--- a/src/Borea.Core/Settings/BoreaSettings.cs
+++ b/src/Borea.Core/Settings/BoreaSettings.cs
@@ -24,6 +24,32 @@ public sealed class BoreaSettings
         LoaderDirectoryPaths = Build(loaderDirectoryPaths, nameof(loaderDirectoryPaths));
     }
 
+    /// <summary>
+    /// A copy with the game directory replaced. The loaders stay as they are.
+    /// </summary>
+    public BoreaSettings WithGameDirectory(string? gameDirectoryPath)
+        => new(gameDirectoryPath, LoaderDirectoryPaths);
+
+    /// <summary>
+    /// A copy with one loader's directory set. The id is stored as given here,
+    /// also when the loader was known under another casing.
+    /// </summary>
+    public BoreaSettings WithLoaderDirectory(string loaderId, string directoryPath)
+    {
+        ModIds.Validate(loaderId, nameof(loaderId));
+
+        if (string.IsNullOrWhiteSpace(directoryPath))
+            throw new ArgumentException("Loader directory path cannot be null or whitespace.", nameof(directoryPath));
+
+        // An assignment through the indexer keeps the key that is already
+        // there, so the old casing goes first.
+        var paths = new Dictionary<string, string>(LoaderDirectoryPaths, ModIds.Comparer);
+        paths.Remove(loaderId);
+        paths[loaderId] = directoryPath;
+
+        return new BoreaSettings(GameDirectoryPath, paths);
+    }
+
     private static IReadOnlyDictionary<string, string> Build(IReadOnlyDictionary<string, string>? paths, string paramName)
     {
         var built = new Dictionary<string, string>(ModIds.Comparer);

--- a/src/Borea.Storage/Toml/TomlFileStore.cs
+++ b/src/Borea.Storage/Toml/TomlFileStore.cs
@@ -19,6 +19,8 @@ public static class TomlFileStore
     /// <summary>
     /// Reads and deserializes the TOML file at <paramref name="path"/> into
     /// <typeparamref name="T"/>, or returns null if the file does not exist.
+    /// A file that is not valid TOML throws <see cref="InvalidOperationException"/>
+    /// naming the path, so a caller can show a user which file to repair.
     /// </summary>
     public static async Task<T?> ReadAsync<T>(string path, CancellationToken cancellationToken = default)
         where T : class
@@ -27,7 +29,15 @@ public static class TomlFileStore
             return null;
 
         var text = await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
-        return TomlSerializer.Deserialize<T>(text, Options);
+
+        try
+        {
+            return TomlSerializer.Deserialize<T>(text, Options);
+        }
+        catch (TomlException exception)
+        {
+            throw new InvalidOperationException($"{path} is not valid TOML. {exception.Message}", exception);
+        }
     }
 
     /// <summary>

--- a/tests/Borea.Cli.Tests/Borea.Cli.Tests.csproj
+++ b/tests/Borea.Cli.Tests/Borea.Cli.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Borea.Cli\Borea.Cli.csproj" />
+    <ProjectReference Include="..\..\src\Borea.Composition\Borea.Composition.csproj" />
+    <ProjectReference Include="..\..\src\Borea.Core\Borea.Core.csproj" />
+    <ProjectReference Include="..\..\src\Borea.Storage\Borea.Storage.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Borea.Cli.Tests/BoreaCliTests.cs
+++ b/tests/Borea.Cli.Tests/BoreaCliTests.cs
@@ -1,0 +1,61 @@
+namespace Borea.Cli.Tests;
+
+public sealed class BoreaCliTests : IDisposable
+{
+    private readonly CliHost _host = new();
+
+    [Fact]
+    public async Task Help_ExitsZero_AndListsTheCommands()
+    {
+        var run = await _host.RunAsync("--help");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("settings", run.Output);
+        Assert.Contains("game", run.Output);
+        Assert.Contains("instance", run.Output);
+        Assert.Contains("enable", run.Output);
+        Assert.Contains("disable", run.Output);
+    }
+
+    [Fact]
+    public async Task NoArguments_IsAUsageError()
+    {
+        var run = await _host.RunAsync();
+
+        Assert.Equal(2, run.ExitCode);
+    }
+
+    [Fact]
+    public async Task UnknownCommand_IsAUsageError_ThatNamesTheToken()
+    {
+        var run = await _host.RunAsync("frobnicate");
+
+        Assert.Equal(2, run.ExitCode);
+        Assert.Contains("frobnicate", run.Error);
+    }
+
+    [Fact]
+    public async Task ParseError_BuildsNoServices()
+    {
+        await _host.RunAsync("frobnicate");
+        await _host.RunAsync("--help");
+
+        Assert.Equal(0, _host.Builds);
+    }
+
+    [Fact]
+    public async Task Command_BuildsTheServicesOnce()
+    {
+        await _host.RunAsync("settings", "show");
+
+        Assert.Equal(1, _host.Builds);
+    }
+
+    [Fact]
+    public void Build_NullFactory_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => BoreaCli.Build(null!));
+    }
+
+    public void Dispose() => _host.Dispose();
+}

--- a/tests/Borea.Cli.Tests/CliHost.cs
+++ b/tests/Borea.Cli.Tests/CliHost.cs
@@ -7,13 +7,16 @@ namespace Borea.Cli.Tests;
 /// <summary>
 /// Runs command lines against a temporary Borea root the test owns. The
 /// services come from the real composition root under that root, with the
-/// master server replaced by <see cref="LatestVersion"/>.
+/// master server replaced by <see cref="LatestVersion"/> and, when a test
+/// sets it, the installed build by <see cref="InstalledVersion"/>.
 /// </summary>
 internal sealed class CliHost : IDisposable
 {
     public string Root { get; } = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
 
     public FakeLatestVersionPing LatestVersion { get; } = new();
+
+    public FakeInstalledGameVersionProvider? InstalledVersion { get; set; }
 
     /// <summary>How many times a command built its services.</summary>
     public int Builds { get; private set; }
@@ -33,7 +36,7 @@ internal sealed class CliHost : IDisposable
     private async Task<CliServices> BuildAsync(CancellationToken cancellationToken)
     {
         Builds++;
-        return CliServices.From(await BoreaServices.BuildAsync(Root, cancellationToken), LatestVersion);
+        return CliServices.From(await BoreaServices.BuildAsync(Root, cancellationToken), LatestVersion, InstalledVersion);
     }
 
     public void Dispose()

--- a/tests/Borea.Cli.Tests/CliHost.cs
+++ b/tests/Borea.Cli.Tests/CliHost.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using Borea.Composition;
+using Borea.Storage.Paths;
+
+namespace Borea.Cli.Tests;
+
+/// <summary>
+/// Runs command lines against a temporary Borea root the test owns. The
+/// services come from the real composition root under that root, with the
+/// master server replaced by <see cref="LatestVersion"/>.
+/// </summary>
+internal sealed class CliHost : IDisposable
+{
+    public string Root { get; } = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+
+    public FakeLatestVersionPing LatestVersion { get; } = new();
+
+    /// <summary>How many times a command built its services.</summary>
+    public int Builds { get; private set; }
+
+    public GamePathProvider Paths => new(gameDirectory: null, boreaRoot: Root);
+
+    public async Task<CliRun> RunAsync(params string[] args)
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exitCode = await BoreaCli.RunAsync(args, BuildAsync, output, error);
+
+        return new CliRun(exitCode, output.ToString(), error.ToString());
+    }
+
+    private async Task<CliServices> BuildAsync(CancellationToken cancellationToken)
+    {
+        Builds++;
+        return CliServices.From(await BoreaServices.BuildAsync(Root, cancellationToken), LatestVersion);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(Root))
+            Directory.Delete(Root, recursive: true);
+    }
+}
+
+internal sealed record CliRun(int ExitCode, string Output, string Error)
+{
+    /// <summary>The output parsed as JSON.</summary>
+    public JsonElement Json => JsonDocument.Parse(Output).RootElement;
+}

--- a/tests/Borea.Cli.Tests/CliServicesTests.cs
+++ b/tests/Borea.Cli.Tests/CliServicesTests.cs
@@ -18,18 +18,21 @@ public sealed class CliServicesTests : IDisposable
         Assert.Same(graph.Instances, services.Instances);
         Assert.Same(graph.ModState, services.ModState);
         Assert.Same(graph.LatestVersion, services.LatestVersion);
+        Assert.Same(graph.InstalledVersion, services.InstalledVersion);
         Assert.Same(graph, services.Graph);
     }
 
     [Fact]
-    public async Task From_WithAPing_UsesItInsteadOfTheGraphs()
+    public async Task From_WithReplacements_UsesThemInsteadOfTheGraphs()
     {
         using var graph = await BoreaServices.BuildAsync(_tempRoot);
         var ping = new FakeLatestVersionPing();
+        var installed = new FakeInstalledGameVersionProvider();
 
-        var services = CliServices.From(graph, ping);
+        var services = CliServices.From(graph, ping, installed);
 
         Assert.Same(ping, services.LatestVersion);
+        Assert.Same(installed, services.InstalledVersion);
         Assert.Same(graph.Instances, services.Instances);
     }
 
@@ -45,6 +48,7 @@ public sealed class CliServicesTests : IDisposable
             Instances = graph.Instances,
             ModState = graph.ModState,
             LatestVersion = new FakeLatestVersionPing(),
+            InstalledVersion = new FakeInstalledGameVersionProvider(),
             Graph = owner,
         };
 

--- a/tests/Borea.Cli.Tests/CliServicesTests.cs
+++ b/tests/Borea.Cli.Tests/CliServicesTests.cs
@@ -1,0 +1,74 @@
+using Borea.Composition;
+
+namespace Borea.Cli.Tests;
+
+public sealed class CliServicesTests : IDisposable
+{
+    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+
+    [Fact]
+    public async Task From_CarriesTheGraphsServices_AndKeepsTheGraph()
+    {
+        using var graph = await BoreaServices.BuildAsync(_tempRoot);
+
+        var services = CliServices.From(graph);
+
+        Assert.Same(graph.Settings, services.Settings);
+        Assert.Same(graph.SettingsRepository, services.SettingsRepository);
+        Assert.Same(graph.Instances, services.Instances);
+        Assert.Same(graph.ModState, services.ModState);
+        Assert.Same(graph.LatestVersion, services.LatestVersion);
+        Assert.Same(graph, services.Graph);
+    }
+
+    [Fact]
+    public async Task From_WithAPing_UsesItInsteadOfTheGraphs()
+    {
+        using var graph = await BoreaServices.BuildAsync(_tempRoot);
+        var ping = new FakeLatestVersionPing();
+
+        var services = CliServices.From(graph, ping);
+
+        Assert.Same(ping, services.LatestVersion);
+        Assert.Same(graph.Instances, services.Instances);
+    }
+
+    [Fact]
+    public async Task Dispose_DisposesTheGraph()
+    {
+        using var graph = await BoreaServices.BuildAsync(_tempRoot);
+        var owner = new DisposalProbe();
+        var services = new CliServices
+        {
+            Settings = graph.Settings,
+            SettingsRepository = graph.SettingsRepository,
+            Instances = graph.Instances,
+            ModState = graph.ModState,
+            LatestVersion = new FakeLatestVersionPing(),
+            Graph = owner,
+        };
+
+        services.Dispose();
+
+        Assert.True(owner.Disposed);
+    }
+
+    [Fact]
+    public void From_Null_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => CliServices.From(null!));
+    }
+
+    private sealed class DisposalProbe : IDisposable
+    {
+        public bool Disposed { get; private set; }
+
+        public void Dispose() => Disposed = true;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+}

--- a/tests/Borea.Cli.Tests/FakeInstalledGameVersionProvider.cs
+++ b/tests/Borea.Cli.Tests/FakeInstalledGameVersionProvider.cs
@@ -1,0 +1,13 @@
+using Borea.Core.Game;
+
+namespace Borea.Cli.Tests;
+
+/// <summary>
+/// Answers in place of the version resource of KSA.dll.
+/// </summary>
+internal sealed class FakeInstalledGameVersionProvider : IInstalledGameVersionProvider
+{
+    public InstalledGameVersion? Installed { get; set; }
+
+    public InstalledGameVersion? GetInstalledVersion() => Installed;
+}

--- a/tests/Borea.Cli.Tests/FakeLatestVersionPing.cs
+++ b/tests/Borea.Cli.Tests/FakeLatestVersionPing.cs
@@ -1,0 +1,19 @@
+using Borea.Core.Game;
+
+namespace Borea.Cli.Tests;
+
+/// <summary>
+/// Answers in place of the master server.
+/// </summary>
+internal sealed class FakeLatestVersionPing : ILatestVersionPing
+{
+    public const string DownloadUrl = "https://example.test/ksa";
+
+    public LatestVersionInfo Answer { get; set; } = new(GameVersion.Parse("2026.9.7.5402"), "2026.9.7.5402", DownloadUrl);
+
+    /// <summary>Thrown instead of answering when set.</summary>
+    public Exception? Failure { get; set; }
+
+    public Task<LatestVersionInfo> PingAsync(CancellationToken cancellationToken = default)
+        => Failure is null ? Task.FromResult(Answer) : Task.FromException<LatestVersionInfo>(Failure);
+}

--- a/tests/Borea.Cli.Tests/GameCommandTests.cs
+++ b/tests/Borea.Cli.Tests/GameCommandTests.cs
@@ -8,26 +8,93 @@ public sealed class GameCommandTests : IDisposable
     private readonly CliHost _host = new();
 
     [Fact]
-    public async Task Version_PrintsTheMasterServerAnswer()
+    public async Task Version_NoGameDirectory_SaysUnknown_AndPrintsTheLatest()
     {
         var run = await _host.RunAsync("game", "version");
 
         Assert.Equal(0, run.ExitCode);
+        Assert.Contains("Installed build: unknown (no game directory is set", run.Output);
         Assert.Contains("Latest public build: 2026.9.7.5402", run.Output);
         Assert.Contains(FakeLatestVersionPing.DownloadUrl, run.Output);
+        Assert.Equal(string.Empty, run.Error);
     }
 
     [Fact]
-    public async Task Version_Json_CarriesTheVersionItsRevisionAndTheUrl()
+    public async Task Version_GameDirectoryWithoutTheAssembly_SaysUnknown_NamingTheDirectory()
     {
+        await _host.RunAsync("settings", "set", "game", _host.Root);
+
+        var run = await _host.RunAsync("game", "version");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains($"Installed build: unknown (no KSA.dll with a version was found in {_host.Root})", run.Output);
+    }
+
+    [Fact]
+    public async Task Version_PrintsBothBuilds_AndSaysANewerOneIsAvailable()
+    {
+        _host.InstalledVersion = new FakeInstalledGameVersionProvider { Installed = new InstalledGameVersion(GameVersion.Parse("2026.8.22.5348"), "2026.8.22.5348") };
+
+        var run = await _host.RunAsync("game", "version");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("Installed build: 2026.8.22.5348", run.Output);
+        Assert.Contains("Latest public build: 2026.9.7.5402", run.Output);
+        Assert.Contains("A newer build is available.", run.Output);
+    }
+
+    [Fact]
+    public async Task Version_InstalledIsTheLatest_SaysItIsCurrent()
+    {
+        _host.InstalledVersion = new FakeInstalledGameVersionProvider { Installed = new InstalledGameVersion(GameVersion.Parse("2026.9.7.5402"), "2026.9.7.5402") };
+
+        var run = await _host.RunAsync("game", "version");
+
+        Assert.Contains("The installed build is current.", run.Output);
+    }
+
+    [Fact]
+    public async Task Version_Json_CarriesBothHalves()
+    {
+        _host.InstalledVersion = new FakeInstalledGameVersionProvider { Installed = new InstalledGameVersion(GameVersion.Parse("2026.8.22.5348"), "2026.8.22.5348") };
+
         var run = await _host.RunAsync("game", "version", "--json");
 
         Assert.Equal(0, run.ExitCode);
+        var installed = run.Json.GetProperty("installed");
+        Assert.Equal("2026.8.22.5348", installed.GetProperty("version").GetString());
+        Assert.Equal(5348, installed.GetProperty("revision").GetInt32());
+        Assert.Equal("2026.8.22.5348", installed.GetProperty("raw").GetString());
         var latest = run.Json.GetProperty("latest");
         Assert.Equal("2026.9.7.5402", latest.GetProperty("version").GetString());
         Assert.Equal(5402, latest.GetProperty("revision").GetInt32());
         Assert.Equal("2026.9.7.5402", latest.GetProperty("raw").GetString());
         Assert.Equal(FakeLatestVersionPing.DownloadUrl, latest.GetProperty("downloadUrl").GetString());
+    }
+
+    [Fact]
+    public async Task Version_Json_NoGameDirectory_HasNullInstalled()
+    {
+        var run = await _host.RunAsync("game", "version", "--json");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Equal(JsonValueKind.Null, run.Json.GetProperty("installed").ValueKind);
+        Assert.Equal("2026.9.7.5402", run.Json.GetProperty("latest").GetProperty("version").GetString());
+    }
+
+    [Fact]
+    public async Task Version_InstalledThatDoesNotParse_KeepsTheRawString()
+    {
+        _host.InstalledVersion = new FakeInstalledGameVersionProvider { Installed = new InstalledGameVersion(null, "1.0.0.0") };
+
+        var human = await _host.RunAsync("game", "version");
+        var json = await _host.RunAsync("game", "version", "--json");
+
+        Assert.Contains("Installed build: 1.0.0.0 (this did not parse as a game version)", human.Output);
+        Assert.DoesNotContain("newer build", human.Output);
+        var installed = json.Json.GetProperty("installed");
+        Assert.Equal(JsonValueKind.Null, installed.GetProperty("version").ValueKind);
+        Assert.Equal("1.0.0.0", installed.GetProperty("raw").GetString());
     }
 
     [Fact]
@@ -39,8 +106,7 @@ public sealed class GameCommandTests : IDisposable
         var json = await _host.RunAsync("game", "version", "--json");
 
         Assert.Equal(0, human.ExitCode);
-        Assert.Contains("weird", human.Output);
-        Assert.Contains("did not parse", human.Output);
+        Assert.Contains("Latest public build: weird (this did not parse as a game version)", human.Output);
         var latest = json.Json.GetProperty("latest");
         Assert.Equal(JsonValueKind.Null, latest.GetProperty("version").ValueKind);
         Assert.Equal(JsonValueKind.Null, latest.GetProperty("revision").ValueKind);
@@ -61,24 +127,32 @@ public sealed class GameCommandTests : IDisposable
     }
 
     [Fact]
-    public async Task Version_NoAnswer_Fails()
+    public async Task Version_HostUnreachable_WithAnInstalledBuild_WarnsAndStillAnswers()
     {
-        _host.LatestVersion.Answer = new LatestVersionInfo(null, string.Empty, string.Empty);
+        _host.InstalledVersion = new FakeInstalledGameVersionProvider { Installed = new InstalledGameVersion(GameVersion.Parse("2026.9.7.5402"), "2026.9.7.5402") };
+        _host.LatestVersion.Failure = new HttpRequestException("No such host is known.");
 
-        var run = await _host.RunAsync("game", "version");
+        var human = await _host.RunAsync("game", "version");
+        var json = await _host.RunAsync("game", "version", "--json");
 
-        Assert.Equal(1, run.ExitCode);
-        Assert.Contains("no version", run.Error);
+        Assert.Equal(0, human.ExitCode);
+        Assert.Contains("Installed build: 2026.9.7.5402", human.Output);
+        Assert.DoesNotContain("Latest public build", human.Output);
+        Assert.Contains("warning: The master server could not be reached. No such host is known.", human.Error);
+        Assert.Equal(0, json.ExitCode);
+        Assert.Equal(JsonValueKind.Null, json.Json.GetProperty("latest").ValueKind);
+        Assert.Equal("2026.9.7.5402", json.Json.GetProperty("installed").GetProperty("version").GetString());
     }
 
     [Fact]
-    public async Task Version_HostUnreachable_Fails_WithTheReason()
+    public async Task Version_HostUnreachable_NoInstalledBuild_Fails_WithBothReasons()
     {
         _host.LatestVersion.Failure = new HttpRequestException("No such host is known.");
 
         var run = await _host.RunAsync("game", "version");
 
         Assert.Equal(1, run.ExitCode);
+        Assert.Contains("no game directory is set", run.Error);
         Assert.Contains("No such host is known.", run.Error);
     }
 
@@ -94,7 +168,18 @@ public sealed class GameCommandTests : IDisposable
     }
 
     [Fact]
-    public async Task Version_Timeout_Fails_WithTheReason()
+    public async Task Version_NoAnswer_NoInstalledBuild_Fails()
+    {
+        _host.LatestVersion.Answer = new LatestVersionInfo(null, string.Empty, string.Empty);
+
+        var run = await _host.RunAsync("game", "version");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("The master server gave no version.", run.Error);
+    }
+
+    [Fact]
+    public async Task Version_Timeout_NoInstalledBuild_Fails_WithTheReason()
     {
         // HttpClient reports its own timeout as a cancellation the caller did not ask for.
         _host.LatestVersion.Failure = new TaskCanceledException("The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.");
@@ -102,6 +187,7 @@ public sealed class GameCommandTests : IDisposable
         var run = await _host.RunAsync("game", "version");
 
         Assert.Equal(1, run.ExitCode);
+        Assert.Contains("did not answer in time", run.Error);
         Assert.Contains("HttpClient.Timeout", run.Error);
     }
 

--- a/tests/Borea.Cli.Tests/GameCommandTests.cs
+++ b/tests/Borea.Cli.Tests/GameCommandTests.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+using Borea.Core.Game;
+
+namespace Borea.Cli.Tests;
+
+public sealed class GameCommandTests : IDisposable
+{
+    private readonly CliHost _host = new();
+
+    [Fact]
+    public async Task Version_PrintsTheMasterServerAnswer()
+    {
+        var run = await _host.RunAsync("game", "version");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("Latest public build: 2026.9.7.5402", run.Output);
+        Assert.Contains(FakeLatestVersionPing.DownloadUrl, run.Output);
+    }
+
+    [Fact]
+    public async Task Version_Json_CarriesTheVersionItsRevisionAndTheUrl()
+    {
+        var run = await _host.RunAsync("game", "version", "--json");
+
+        Assert.Equal(0, run.ExitCode);
+        var latest = run.Json.GetProperty("latest");
+        Assert.Equal("2026.9.7.5402", latest.GetProperty("version").GetString());
+        Assert.Equal(5402, latest.GetProperty("revision").GetInt32());
+        Assert.Equal("2026.9.7.5402", latest.GetProperty("raw").GetString());
+        Assert.Equal(FakeLatestVersionPing.DownloadUrl, latest.GetProperty("downloadUrl").GetString());
+    }
+
+    [Fact]
+    public async Task Version_AnswerThatDoesNotParse_KeepsTheRawString()
+    {
+        _host.LatestVersion.Answer = new LatestVersionInfo(null, "weird", FakeLatestVersionPing.DownloadUrl);
+
+        var human = await _host.RunAsync("game", "version");
+        var json = await _host.RunAsync("game", "version", "--json");
+
+        Assert.Equal(0, human.ExitCode);
+        Assert.Contains("weird", human.Output);
+        Assert.Contains("did not parse", human.Output);
+        var latest = json.Json.GetProperty("latest");
+        Assert.Equal(JsonValueKind.Null, latest.GetProperty("version").ValueKind);
+        Assert.Equal(JsonValueKind.Null, latest.GetProperty("revision").ValueKind);
+        Assert.Equal("weird", latest.GetProperty("raw").GetString());
+    }
+
+    [Fact]
+    public async Task Version_AnswerWithoutADownloadPage_LeavesItOut()
+    {
+        _host.LatestVersion.Answer = new LatestVersionInfo(GameVersion.Parse("2026.9.7.5402"), "2026.9.7.5402", string.Empty);
+
+        var human = await _host.RunAsync("game", "version");
+        var json = await _host.RunAsync("game", "version", "--json");
+
+        Assert.Equal(0, human.ExitCode);
+        Assert.DoesNotContain("Download:", human.Output);
+        Assert.Equal(JsonValueKind.Null, json.Json.GetProperty("latest").GetProperty("downloadUrl").ValueKind);
+    }
+
+    [Fact]
+    public async Task Version_NoAnswer_Fails()
+    {
+        _host.LatestVersion.Answer = new LatestVersionInfo(null, string.Empty, string.Empty);
+
+        var run = await _host.RunAsync("game", "version");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("no version", run.Error);
+    }
+
+    [Fact]
+    public async Task Version_HostUnreachable_Fails_WithTheReason()
+    {
+        _host.LatestVersion.Failure = new HttpRequestException("No such host is known.");
+
+        var run = await _host.RunAsync("game", "version");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("No such host is known.", run.Error);
+    }
+
+    [Fact]
+    public async Task Version_HostUnreachable_Json_LeavesStdoutEmpty()
+    {
+        _host.LatestVersion.Failure = new HttpRequestException("No such host is known.");
+
+        var run = await _host.RunAsync("game", "version", "--json");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Equal(string.Empty, run.Output);
+    }
+
+    [Fact]
+    public async Task Version_Timeout_Fails_WithTheReason()
+    {
+        // HttpClient reports its own timeout as a cancellation the caller did not ask for.
+        _host.LatestVersion.Failure = new TaskCanceledException("The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.");
+
+        var run = await _host.RunAsync("game", "version");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("HttpClient.Timeout", run.Error);
+    }
+
+    public void Dispose() => _host.Dispose();
+}

--- a/tests/Borea.Cli.Tests/InstanceCommandTests.cs
+++ b/tests/Borea.Cli.Tests/InstanceCommandTests.cs
@@ -1,0 +1,207 @@
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+using Borea.Storage.Instances;
+
+namespace Borea.Cli.Tests;
+
+public sealed class InstanceCommandTests : IDisposable
+{
+    private readonly CliHost _host = new();
+
+    [Fact]
+    public async Task List_NoInstances_SaysSo()
+    {
+        var human = await _host.RunAsync("instance", "list");
+        var json = await _host.RunAsync("instance", "list", "--json");
+
+        Assert.Equal(0, human.ExitCode);
+        Assert.Contains("No instances.", human.Output);
+        Assert.Equal(0, json.ExitCode);
+        Assert.Empty(json.Json.EnumerateArray());
+    }
+
+    [Fact]
+    public async Task Create_ThenList_ShowsItInactive()
+    {
+        var create = await _host.RunAsync("instance", "create", "Alpha");
+        var list = await _host.RunAsync("instance", "list", "--json");
+
+        Assert.Equal(0, create.ExitCode);
+        Assert.Contains("Alpha", create.Output);
+        var entry = Assert.Single(list.Json.EnumerateArray());
+        Assert.Equal("Alpha", entry.GetProperty("name").GetString());
+        Assert.False(entry.GetProperty("active").GetBoolean());
+        Assert.Equal("custom", entry.GetProperty("source").GetProperty("kind").GetString());
+        Assert.True(Guid.TryParse(entry.GetProperty("id").GetString(), out _));
+    }
+
+    [Fact]
+    public async Task List_InstanceFromAModPack_NamesThePackAndItsVersion()
+    {
+        var packed = Instance.FromExisting(Guid.NewGuid(), "Packed", new InstanceSource.FromModPack("SomePack", ModVersion.Parse("1.2.0")),
+            DateTimeOffset.UtcNow, Array.Empty<InstalledMod>(), isFavorite: false);
+        await new FileInstanceRepository(_host.Paths).SaveAsync(packed);
+
+        var human = await _host.RunAsync("instance", "list");
+        var json = await _host.RunAsync("instance", "list", "--json");
+
+        Assert.Contains("modpack SomePack 1.2.0", human.Output);
+        var source = Assert.Single(json.Json.EnumerateArray()).GetProperty("source");
+        Assert.Equal("modpack", source.GetProperty("kind").GetString());
+        Assert.Equal("SomePack", source.GetProperty("modPackId").GetString());
+        Assert.Equal("1.2.0", source.GetProperty("version").GetString());
+    }
+
+    [Fact]
+    public async Task Create_NameTakenInAnotherCase_Fails()
+    {
+        await _host.RunAsync("instance", "create", "Alpha");
+
+        var run = await _host.RunAsync("instance", "create", "alpha");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("already in use", run.Error);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task Create_BlankName_IsAUsageError(string name)
+    {
+        var run = await _host.RunAsync("instance", "create", name);
+
+        Assert.Equal(2, run.ExitCode);
+    }
+
+    [Fact]
+    public async Task Activate_ByNameInAnotherCase_MarksItInTheList()
+    {
+        await _host.RunAsync("instance", "create", "Alpha");
+        await _host.RunAsync("instance", "create", "Beta");
+
+        var activate = await _host.RunAsync("instance", "activate", "alpha");
+        var human = await _host.RunAsync("instance", "list");
+        var json = await _host.RunAsync("instance", "list", "--json");
+
+        Assert.Equal(0, activate.ExitCode);
+        Assert.Contains("* Alpha", human.Output);
+        Assert.Contains("  Beta", human.Output);
+        var entries = json.Json.EnumerateArray().ToDictionary(e => e.GetProperty("name").GetString()!, e => e.GetProperty("active").GetBoolean());
+        Assert.True(entries["Alpha"]);
+        Assert.False(entries["Beta"]);
+    }
+
+    [Fact]
+    public async Task Activate_ById_SetsTheActivePointer()
+    {
+        await _host.RunAsync("instance", "create", "Alpha");
+        var list = await _host.RunAsync("instance", "list", "--json");
+        var id = Guid.Parse(Assert.Single(list.Json.EnumerateArray()).GetProperty("id").GetString()!);
+
+        var activate = await _host.RunAsync("instance", "activate", id.ToString());
+
+        Assert.Equal(0, activate.ExitCode);
+        Assert.Equal(id, await new FileInstanceRepository(_host.Paths).GetActiveInstanceIdAsync());
+    }
+
+    [Fact]
+    public async Task Rename_ChangesTheName()
+    {
+        await _host.RunAsync("instance", "create", "Alpha");
+
+        var rename = await _host.RunAsync("instance", "rename", "Alpha", "Beta");
+        var list = await _host.RunAsync("instance", "list", "--json");
+
+        Assert.Equal(0, rename.ExitCode);
+        var entry = Assert.Single(list.Json.EnumerateArray());
+        Assert.Equal("Beta", entry.GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task Rename_ToATakenName_Fails()
+    {
+        await _host.RunAsync("instance", "create", "Alpha");
+        await _host.RunAsync("instance", "create", "Beta");
+
+        var run = await _host.RunAsync("instance", "rename", "Alpha", "beta");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("already in use", run.Error);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesTheInstanceAndItsFolder()
+    {
+        await _host.RunAsync("instance", "create", "Alpha");
+        var before = await _host.RunAsync("instance", "list", "--json");
+        var id = Guid.Parse(Assert.Single(before.Json.EnumerateArray()).GetProperty("id").GetString()!);
+
+        var delete = await _host.RunAsync("instance", "delete", "Alpha");
+        var after = await _host.RunAsync("instance", "list", "--json");
+
+        Assert.Equal(0, delete.ExitCode);
+        Assert.Empty(after.Json.EnumerateArray());
+        Assert.False(Directory.Exists(_host.Paths.GetInstanceRoot(id)));
+    }
+
+    [Theory]
+    [InlineData("activate")]
+    [InlineData("delete")]
+    public async Task UnknownInstance_Fails(string command)
+    {
+        await _host.RunAsync("instance", "create", "Alpha");
+
+        var run = await _host.RunAsync("instance", command, "Nope");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("No instance is named 'Nope'.", run.Error);
+    }
+
+    [Fact]
+    public async Task UnknownId_Fails_SayingTheIdMatchedNothing()
+    {
+        var id = Guid.NewGuid().ToString();
+
+        var run = await _host.RunAsync("instance", "activate", id);
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains($"No instance has the id '{id}'", run.Error);
+    }
+
+    [Fact]
+    public async Task NamesThatDifferOnlyInCase_NeedTheId()
+    {
+        // The repository refuses to create such a pair, so the files are written directly.
+        var repository = new FileInstanceRepository(_host.Paths);
+        var upper = Instance.FromExisting(Guid.NewGuid(), "Alpha", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, Array.Empty<InstalledMod>(), isFavorite: false);
+        var lower = Instance.FromExisting(Guid.NewGuid(), "alpha", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, Array.Empty<InstalledMod>(), isFavorite: false);
+        await repository.SaveAsync(upper);
+        await repository.SaveAsync(lower);
+
+        var byName = await _host.RunAsync("instance", "activate", "Alpha");
+        var byId = await _host.RunAsync("instance", "activate", lower.InstanceId.ToString());
+
+        Assert.Equal(1, byName.ExitCode);
+        Assert.Contains(upper.InstanceId.ToString(), byName.Error);
+        Assert.Contains(lower.InstanceId.ToString(), byName.Error);
+        Assert.Equal(0, byId.ExitCode);
+        Assert.Equal(lower.InstanceId, await repository.GetActiveInstanceIdAsync());
+    }
+
+    [Fact]
+    public async Task List_ActivePointerThatIsNotToml_Fails_NamingTheFile()
+    {
+        var pointer = _host.Paths.GetActiveInstancePointerPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(pointer)!);
+        await File.WriteAllTextAsync(pointer, "ActiveInstanceId = \n");
+
+        var run = await _host.RunAsync("instance", "list");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains(pointer, run.Error);
+        Assert.DoesNotContain("Unhandled exception", run.Error);
+        Assert.Equal(string.Empty, run.Output);
+    }
+
+    public void Dispose() => _host.Dispose();
+}

--- a/tests/Borea.Cli.Tests/ModStateCommandsTests.cs
+++ b/tests/Borea.Cli.Tests/ModStateCommandsTests.cs
@@ -1,0 +1,152 @@
+using Borea.Storage.Instances;
+using Borea.Storage.State;
+
+namespace Borea.Cli.Tests;
+
+public sealed class ModStateCommandsTests : IDisposable
+{
+    private readonly CliHost _host = new();
+
+    [Fact]
+    public async Task Enable_WithInstance_MakesTheModActive()
+    {
+        var instanceId = await CreateAsync("Alpha");
+
+        var run = await _host.RunAsync("enable", "SomeMod", "--instance", "Alpha");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("Enabled SomeMod in 'Alpha'.", run.Output);
+        Assert.True(await ModState.IsActiveAsync(instanceId, "SomeMod"));
+    }
+
+    [Fact]
+    public async Task Enable_WithoutInstance_UsesTheActiveOne()
+    {
+        await CreateAsync("Other");
+        var alpha = await CreateAsync("Alpha");
+        await _host.RunAsync("instance", "activate", "Alpha");
+
+        var run = await _host.RunAsync("enable", "SomeMod");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("'Alpha'", run.Output);
+        Assert.True(await ModState.IsActiveAsync(alpha, "SomeMod"));
+    }
+
+    [Fact]
+    public async Task Enable_NoActiveInstance_Fails()
+    {
+        await CreateAsync("Alpha");
+
+        var run = await _host.RunAsync("enable", "SomeMod");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("No instance is active", run.Error);
+    }
+
+    [Fact]
+    public async Task Enable_ActiveInstanceDeleted_Fails()
+    {
+        await CreateAsync("Alpha");
+        await _host.RunAsync("instance", "activate", "Alpha");
+        await _host.RunAsync("instance", "delete", "Alpha");
+
+        var run = await _host.RunAsync("enable", "SomeMod");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("does not exist anymore", run.Error);
+    }
+
+    [Fact]
+    public async Task Enable_UnknownInstance_Fails()
+    {
+        var run = await _host.RunAsync("enable", "SomeMod", "--instance", "Nope");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("No instance is named 'Nope'.", run.Error);
+    }
+
+    [Fact]
+    public async Task Enable_KeepsAnotherDisabledModDisabled()
+    {
+        var instanceId = await CreateAsync("Alpha");
+        await _host.RunAsync("instance", "activate", "Alpha");
+        await ModState.SetActiveAsync(instanceId, "ModA");
+        await ModState.SetActiveAsync(instanceId, "ModB");
+        await ModState.SetInactiveAsync(instanceId, "ModB");
+
+        var run = await _host.RunAsync("enable", "ModC");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.True(await ModState.IsActiveAsync(instanceId, "ModA"));
+        Assert.False(await ModState.IsActiveAsync(instanceId, "ModB"));
+        Assert.True(await ModState.IsActiveAsync(instanceId, "ModC"));
+    }
+
+    [Fact]
+    public async Task Disable_MakesTheModInactive()
+    {
+        var instanceId = await CreateAsync("Alpha");
+        await _host.RunAsync("enable", "SomeMod", "--instance", "Alpha");
+
+        var run = await _host.RunAsync("disable", "somemod", "--instance", "alpha");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("Disabled somemod in 'Alpha'.", run.Output);
+        Assert.False(await ModState.IsActiveAsync(instanceId, "SomeMod"));
+    }
+
+    [Fact]
+    public async Task Disable_ModTheGameNamedByItsFolder_Works()
+    {
+        // The game writes the folder name as the id, and a folder name is not bound by the content id rules.
+        var instanceId = await CreateAsync("Alpha");
+        var manifest = _host.Paths.GetInstanceManifestPath(instanceId);
+        await File.WriteAllTextAsync(manifest, """
+            [[mods]]
+            id="my mod"
+            enabled = true
+            """);
+
+        var run = await _host.RunAsync("disable", "my mod", "--instance", "Alpha");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.False(await ModState.IsActiveAsync(instanceId, "my mod"));
+    }
+
+    [Theory]
+    [InlineData("enable")]
+    [InlineData("disable")]
+    public async Task BlankModId_IsAUsageError(string command)
+    {
+        await CreateAsync("Alpha");
+
+        var run = await _host.RunAsync(command, " ", "--instance", "Alpha");
+
+        Assert.Equal(2, run.ExitCode);
+    }
+
+    [Theory]
+    [InlineData("enable")]
+    [InlineData("disable")]
+    public async Task BlankInstanceOption_IsAUsageError(string command)
+    {
+        await CreateAsync("Alpha");
+
+        var run = await _host.RunAsync(command, "SomeMod", "--instance", "");
+
+        Assert.Equal(2, run.ExitCode);
+        Assert.Contains("--instance", run.Error);
+    }
+
+    private FileModStateRepository ModState => new(_host.Paths);
+
+    private async Task<Guid> CreateAsync(string name)
+    {
+        await _host.RunAsync("instance", "create", name);
+        var instances = await new FileInstanceRepository(_host.Paths).GetAllAsync();
+        return instances.Single(instance => instance.Name == name).InstanceId;
+    }
+
+    public void Dispose() => _host.Dispose();
+}

--- a/tests/Borea.Cli.Tests/ModStateCommandsTests.cs
+++ b/tests/Borea.Cli.Tests/ModStateCommandsTests.cs
@@ -11,6 +11,7 @@ public sealed class ModStateCommandsTests : IDisposable
     public async Task Enable_WithInstance_MakesTheModActive()
     {
         var instanceId = await CreateAsync("Alpha");
+        CreateModFolder(instanceId, "SomeMod");
 
         var run = await _host.RunAsync("enable", "SomeMod", "--instance", "Alpha");
 
@@ -24,6 +25,7 @@ public sealed class ModStateCommandsTests : IDisposable
     {
         await CreateAsync("Other");
         var alpha = await CreateAsync("Alpha");
+        CreateModFolder(alpha, "SomeMod");
         await _host.RunAsync("instance", "activate", "Alpha");
 
         var run = await _host.RunAsync("enable", "SomeMod");
@@ -31,6 +33,48 @@ public sealed class ModStateCommandsTests : IDisposable
         Assert.Equal(0, run.ExitCode);
         Assert.Contains("'Alpha'", run.Output);
         Assert.True(await ModState.IsActiveAsync(alpha, "SomeMod"));
+    }
+
+    [Fact]
+    public async Task Enable_ModThatIsNotInstalled_Fails()
+    {
+        await CreateAsync("Alpha");
+
+        var run = await _host.RunAsync("enable", "SomeMod", "--instance", "Alpha");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("no mod folder named 'SomeMod'", run.Error);
+    }
+
+    [Fact]
+    public async Task Enable_ModWhoseFolderIsGone_StillFlipsItsEntry()
+    {
+        var instanceId = await CreateAsync("Alpha");
+        var manifest = _host.Paths.GetInstanceManifestPath(instanceId);
+        await File.WriteAllTextAsync(manifest, """
+            [[mods]]
+            id="SomeMod"
+            enabled = false
+            """);
+
+        var run = await _host.RunAsync("enable", "SomeMod", "--instance", "Alpha");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.True(await ModState.IsActiveAsync(instanceId, "SomeMod"));
+    }
+
+    [Fact]
+    public async Task Enable_AlreadyEnabled_SaysSoAndChangesNothing()
+    {
+        var instanceId = await CreateAsync("Alpha");
+        CreateModFolder(instanceId, "SomeMod");
+        await _host.RunAsync("enable", "SomeMod", "--instance", "Alpha");
+
+        var run = await _host.RunAsync("enable", "SomeMod", "--instance", "Alpha");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("Enabled SomeMod in 'Alpha'.", run.Output);
+        Assert.Single(await ModState.GetEntriesAsync(instanceId));
     }
 
     [Fact]
@@ -71,9 +115,11 @@ public sealed class ModStateCommandsTests : IDisposable
     {
         var instanceId = await CreateAsync("Alpha");
         await _host.RunAsync("instance", "activate", "Alpha");
-        await ModState.SetActiveAsync(instanceId, "ModA");
-        await ModState.SetActiveAsync(instanceId, "ModB");
-        await ModState.SetInactiveAsync(instanceId, "ModB");
+        CreateModFolder(instanceId, "ModA");
+        CreateModFolder(instanceId, "ModB");
+        CreateModFolder(instanceId, "ModC");
+        await ModState.AddEntryAsync(instanceId, "ModA", enabled: true);
+        await ModState.AddEntryAsync(instanceId, "ModB", enabled: false);
 
         var run = await _host.RunAsync("enable", "ModC");
 
@@ -87,6 +133,7 @@ public sealed class ModStateCommandsTests : IDisposable
     public async Task Disable_MakesTheModInactive()
     {
         var instanceId = await CreateAsync("Alpha");
+        CreateModFolder(instanceId, "SomeMod");
         await _host.RunAsync("enable", "SomeMod", "--instance", "Alpha");
 
         var run = await _host.RunAsync("disable", "somemod", "--instance", "alpha");
@@ -137,6 +184,13 @@ public sealed class ModStateCommandsTests : IDisposable
 
         Assert.Equal(2, run.ExitCode);
         Assert.Contains("--instance", run.Error);
+    }
+
+    private void CreateModFolder(Guid instanceId, string folderName)
+    {
+        var modFolder = Path.Combine(_host.Paths.GetInstanceModsFolder(instanceId), folderName);
+        Directory.CreateDirectory(modFolder);
+        File.WriteAllText(Path.Combine(modFolder, "mod.toml"), $"name = \"{folderName}\"\n");
     }
 
     private FileModStateRepository ModState => new(_host.Paths);

--- a/tests/Borea.Cli.Tests/SettingsCommandTests.cs
+++ b/tests/Borea.Cli.Tests/SettingsCommandTests.cs
@@ -1,0 +1,172 @@
+using System.Text.Json;
+
+namespace Borea.Cli.Tests;
+
+public sealed class SettingsCommandTests : IDisposable
+{
+    private readonly CliHost _host = new();
+
+    [Fact]
+    public async Task Show_NoSettingsFile_ReportsNothingSet()
+    {
+        var run = await _host.RunAsync("settings", "show");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("Game directory: not set", run.Output);
+        Assert.Contains("Loader directories: none", run.Output);
+    }
+
+    [Fact]
+    public async Task Show_NoSettingsFile_JsonHasNullGameAndNoLoaders()
+    {
+        var run = await _host.RunAsync("settings", "show", "--json");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Equal(JsonValueKind.Null, run.Json.GetProperty("gameDirectory").ValueKind);
+        Assert.Empty(run.Json.GetProperty("loaderDirectories").EnumerateObject());
+    }
+
+    [Fact]
+    public async Task SetGame_SavesTheDirectory_AndShowReadsItBack()
+    {
+        var game = Directory.CreateDirectory(Path.Combine(_host.Root, "Game")).FullName;
+
+        var set = await _host.RunAsync("settings", "set", "game", game);
+        var show = await _host.RunAsync("settings", "show", "--json");
+
+        Assert.Equal(0, set.ExitCode);
+        Assert.Contains(game, set.Output);
+        Assert.Equal(string.Empty, set.Error);
+        Assert.Equal(game, show.Json.GetProperty("gameDirectory").GetString());
+    }
+
+    [Fact]
+    public async Task SetGame_DirectoryThatDoesNotExist_SavesItAndWarns()
+    {
+        var game = Path.Combine(_host.Root, "Missing");
+
+        var set = await _host.RunAsync("settings", "set", "game", game);
+        var show = await _host.RunAsync("settings", "show", "--json");
+
+        Assert.Equal(0, set.ExitCode);
+        Assert.Contains("warning:", set.Error);
+        Assert.Contains(game, set.Error);
+        Assert.Equal(game, show.Json.GetProperty("gameDirectory").GetString());
+    }
+
+    [Fact]
+    public async Task SetGame_RelativePath_IsStoredAbsolute()
+    {
+        var set = await _host.RunAsync("settings", "set", "game", "Game");
+        var show = await _host.RunAsync("settings", "show", "--json");
+
+        Assert.Equal(0, set.ExitCode);
+        var stored = show.Json.GetProperty("gameDirectory").GetString()!;
+        Assert.True(Path.IsPathRooted(stored));
+        Assert.EndsWith("Game", stored);
+    }
+
+    [Fact]
+    public async Task SetLoader_AddsTheLoader_AndKeepsTheRest()
+    {
+        var game = Path.Combine(_host.Root, "Game");
+        var starMap = Path.Combine(_host.Root, "StarMap");
+        var other = Path.Combine(_host.Root, "Other");
+
+        await _host.RunAsync("settings", "set", "game", game);
+        var first = await _host.RunAsync("settings", "set", "loader", "StarMap", starMap);
+        var second = await _host.RunAsync("settings", "set", "loader", "Other-Loader", other);
+        var show = await _host.RunAsync("settings", "show", "--json");
+
+        Assert.Equal(0, first.ExitCode);
+        Assert.Equal(0, second.ExitCode);
+        Assert.Equal(game, show.Json.GetProperty("gameDirectory").GetString());
+        var loaders = show.Json.GetProperty("loaderDirectories");
+        Assert.Equal(starMap, loaders.GetProperty("StarMap").GetString());
+        Assert.Equal(other, loaders.GetProperty("Other-Loader").GetString());
+    }
+
+    [Fact]
+    public async Task SetLoader_SameIdInAnotherCase_ReplacesTheEntry()
+    {
+        var first = Path.Combine(_host.Root, "First");
+        var second = Path.Combine(_host.Root, "Second");
+
+        await _host.RunAsync("settings", "set", "loader", "StarMap", first);
+        await _host.RunAsync("settings", "set", "loader", "starmap", second);
+        var show = await _host.RunAsync("settings", "show", "--json");
+
+        var loaders = show.Json.GetProperty("loaderDirectories").EnumerateObject().ToList();
+        var loader = Assert.Single(loaders);
+        Assert.Equal("starmap", loader.Name);
+        Assert.Equal(second, loader.Value.GetString());
+    }
+
+    [Fact]
+    public async Task Show_ListsTheLoaders()
+    {
+        var starMap = Path.Combine(_host.Root, "StarMap");
+
+        await _host.RunAsync("settings", "set", "loader", "StarMap", starMap);
+        var show = await _host.RunAsync("settings", "show");
+
+        Assert.Contains("Loader directories:", show.Output);
+        Assert.Contains($"StarMap: {starMap}", show.Output);
+    }
+
+    [Theory]
+    [InlineData("bad id")]
+    [InlineData("CON")]
+    [InlineData("-leading-dash")]
+    public async Task SetLoader_InvalidId_IsAUsageError_ThatWritesNothing(string loaderId)
+    {
+        var run = await _host.RunAsync("settings", "set", "loader", loaderId, _host.Root);
+
+        Assert.Equal(2, run.ExitCode);
+        Assert.Contains("not a valid content id", run.Error);
+        Assert.False(File.Exists(_host.Paths.GetBoreaSettingsPath()));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SetGame_BlankDirectory_IsAUsageError(string directory)
+    {
+        var run = await _host.RunAsync("settings", "set", "game", directory);
+
+        Assert.Equal(2, run.ExitCode);
+        Assert.False(File.Exists(_host.Paths.GetBoreaSettingsPath()));
+    }
+
+    [Fact]
+    public async Task AnyCommand_SettingsFileThatDoesNotLoad_Fails()
+    {
+        // Loader ids that collide by case are rejected when the settings load.
+        Directory.CreateDirectory(_host.Root);
+        await File.WriteAllTextAsync(_host.Paths.GetBoreaSettingsPath(), """
+            [LoaderDirectoryPaths]
+            StarMap = 'C:\Games\StarMap'
+            starmap = 'C:\Games\Other'
+            """);
+
+        var run = await _host.RunAsync("settings", "show");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("settings could not be read", run.Error);
+    }
+
+    [Fact]
+    public async Task AnyCommand_SettingsFileThatIsNotToml_Fails_NamingTheFile()
+    {
+        Directory.CreateDirectory(_host.Root);
+        await File.WriteAllTextAsync(_host.Paths.GetBoreaSettingsPath(), "GameDirectoryPath = \n");
+
+        var run = await _host.RunAsync("settings", "show");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains(_host.Paths.GetBoreaSettingsPath(), run.Error);
+        Assert.DoesNotContain("Unhandled exception", run.Error);
+    }
+
+    public void Dispose() => _host.Dispose();
+}

--- a/tests/Borea.Composition.Tests/BoreaServicesTests.cs
+++ b/tests/Borea.Composition.Tests/BoreaServicesTests.cs
@@ -1,6 +1,7 @@
 using Borea.Core.Mods;
 using Borea.Core.Settings;
 using Borea.Network.Sources;
+using Borea.Storage.Game;
 using Borea.Storage.Paths;
 using Borea.Storage.Settings;
 
@@ -108,6 +109,16 @@ public sealed class BoreaServicesTests : IDisposable
         using var services = await BoreaServices.BuildAsync(_tempRoot);
 
         Assert.IsType<CompositeModRepository>(services.Mods);
+    }
+
+    [Fact]
+    public async Task InstalledVersion_ReadsTheGameDirectoryTheSettingsName()
+    {
+        using var services = await BoreaServices.BuildAsync(_tempRoot);
+
+        Assert.IsType<InstalledGameVersionProvider>(services.InstalledVersion);
+        // No game directory is set, so there is nothing to read.
+        Assert.Null(services.InstalledVersion.GetInstalledVersion());
     }
 
     [Fact]

--- a/tests/Borea.Core.Tests/Settings/BoreaSettingsTests.cs
+++ b/tests/Borea.Core.Tests/Settings/BoreaSettingsTests.cs
@@ -109,4 +109,59 @@ public sealed class BoreaSettingsTests
 
         Assert.Equal(@"C:\Games\StarMap", settings.LoaderDirectoryPaths["StarMap"]);
     }
+
+    [Fact]
+    public void WithGameDirectory_ReplacesTheGame_AndKeepsTheLoaders()
+    {
+        var settings = new BoreaSettings(@"C:\Games\KSA", StarMapAt());
+
+        var changed = settings.WithGameDirectory(@"D:\KSA");
+
+        Assert.Equal(@"D:\KSA", changed.GameDirectoryPath);
+        Assert.Equal(@"C:\Games\StarMap", changed.LoaderDirectoryPaths["StarMap"]);
+        Assert.Equal(@"C:\Games\KSA", settings.GameDirectoryPath);
+    }
+
+    [Fact]
+    public void WithLoaderDirectory_AddsALoader_AndKeepsTheRest()
+    {
+        var settings = new BoreaSettings(@"C:\Games\KSA", StarMapAt());
+
+        var changed = settings.WithLoaderDirectory("Cheese-Loader", @"C:\Games\Cheese");
+
+        Assert.Equal(@"C:\Games\KSA", changed.GameDirectoryPath);
+        Assert.Equal(@"C:\Games\StarMap", changed.LoaderDirectoryPaths["StarMap"]);
+        Assert.Equal(@"C:\Games\Cheese", changed.LoaderDirectoryPaths["Cheese-Loader"]);
+        Assert.Single(settings.LoaderDirectoryPaths);
+    }
+
+    [Fact]
+    public void WithLoaderDirectory_SameIdInAnotherCase_ReplacesTheEntryAndItsCasing()
+    {
+        var settings = new BoreaSettings(null, StarMapAt());
+
+        var changed = settings.WithLoaderDirectory("starmap", @"C:\Games\Other");
+
+        var loader = Assert.Single(changed.LoaderDirectoryPaths);
+        Assert.Equal("starmap", loader.Key);
+        Assert.Equal(@"C:\Games\Other", loader.Value);
+    }
+
+    [Theory]
+    [InlineData("not a valid id")]
+    [InlineData("")]
+    public void WithLoaderDirectory_InvalidId_ThrowsArgumentException(string loaderId)
+    {
+        var settings = new BoreaSettings(null);
+
+        Assert.Throws<ArgumentException>(() => settings.WithLoaderDirectory(loaderId, @"C:\Games\Loader"));
+    }
+
+    [Fact]
+    public void WithLoaderDirectory_WhitespacePath_ThrowsArgumentException()
+    {
+        var settings = new BoreaSettings(null);
+
+        Assert.Throws<ArgumentException>(() => settings.WithLoaderDirectory("StarMap", "   "));
+    }
 }

--- a/tests/Borea.Storage.Tests/Toml/TomlFileStoreTests.cs
+++ b/tests/Borea.Storage.Tests/Toml/TomlFileStoreTests.cs
@@ -28,6 +28,19 @@ public sealed class TomlFileStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task ReadAsync_FileThatIsNotToml_ThrowsNamingThePath()
+    {
+        var path = Path.Combine(_tempRoot, "broken.toml");
+        Directory.CreateDirectory(_tempRoot);
+        await File.WriteAllTextAsync(path, "Name = \n");
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => TomlFileStore.ReadAsync<SampleDto>(path));
+
+        Assert.Contains(path, exception.Message);
+        Assert.NotNull(exception.InnerException);
+    }
+
+    [Fact]
     public async Task WriteAsync_CreatesContainingDirectory()
     {
         var path = Path.Combine(_tempRoot, "nested", "deeper", "file.toml");


### PR DESCRIPTION
Part of #66, stacked on #70.

**A second program next to the desktop app.** `src/Borea.Cli` builds an executable named `borea` on System.CommandLine 2.0.11.

It gets its services from `BoreaServices`, the composition root of #70, so the app and the command line always do the same thing.

Every command calls one operation that Borea.Core already offers.

**The commands in this slice.**
- `settings show`, `settings set game <dir>`, `settings set loader <id> <dir>`: where the game and the mod loaders are.
- `game version`: the current public build the master server reports.
- `instance list`, `create`, `rename`, `delete`, `activate`: the lifecycle of instances.
- `enable <mod-id>` and `disable <mod-id>`, with `--instance <name>` or the active instance when the option is absent.

**Two output modes.** Text for a person by default. `--json` on the three read commands for scripts.

**exit codes:** 0 when the command completed. 1 when the operation failed, with the reason on stderr. 2 when the command line did not parse, for example a missing argument or an invalid loader id.

**Not in this slice**, because their operations are not on the base branch yet: `index refresh` (#60) and `instance mods` (#62).

**To try it** after `dotnet build Borea.slnx`, with `borea` standing for `dotnet src/Borea.Cli/bin/Debug/net10.0/borea.dll`:
- `borea --help`
- `borea instance create Test`
- `borea enable SomeMod --instance Test`
- `borea instance list --json`
- `borea justSomeNonsense`, which exits 2

The executable uses `%LocalAppData%\Borea`, the same folder as the app.

LLM usage disclosure: Claude Fable 5.1 (and Opus 5 for an code review workflow) was used collaborativly with me to create large parts of this code. I read, reviewed and tested all of it myself and like it.

