### PR TITLE
Tidy the index fetcher

### DIFF
--- a/src/Borea.Core/Index/SnapshotVersions.cs
+++ b/src/Borea.Core/Index/SnapshotVersions.cs
@@ -1,0 +1,15 @@
+namespace Borea.Core.Index;
+
+public static class SnapshotVersions
+{
+    /// <summary>
+    /// The highest snapshot version this build reads.
+    /// </summary>
+    public const int Highest = 1;
+
+    /// <summary>
+    /// Whether the snapshot is from a newer format than this build implements.
+    /// Such a snapshot is refused whole and the cached copy is kept.
+    /// </summary>
+    public static bool IsAboveHighest(int snapshotVersion) => snapshotVersion > Highest;
+}

--- a/src/Borea.Network/Index/ContentIndexFetcher.cs
+++ b/src/Borea.Network/Index/ContentIndexFetcher.cs
@@ -64,7 +64,7 @@ public sealed class ContentIndexFetcher : IContentIndexFetcher
         // Read the content as a byte array to then write to disk.
         byte[] body = await response.Content.ReadAsByteArrayAsync(ct);
 
-        await BasicIndexFormatCheckAsync(body, response, ct);
+        BasicIndexFormatCheck(body, response);
 
         Directory.CreateDirectory(Path.GetDirectoryName(destinationPath)!);
 
@@ -97,11 +97,12 @@ public sealed class ContentIndexFetcher : IContentIndexFetcher
 
     /// <summary>
     /// Checks if the index is JSON or plain text, if it can be parsed as JSON, and if it has 4 required properties:
-    /// 'snapshot_version', 'listings', 'packs', and 'game_versions'. The actual values of the properties (excluding 'snapshot_version') are not
-    /// validated, only their existence is checked.
+    /// 'snapshot_version', 'listings', 'packs', and 'game_versions'. Only 'snapshot_version'
+    /// has its value read. For the other three, presence is all this checks. A full
+    /// validation of the document belongs to whatever reads it.
     /// </summary>
     /// <exception cref="HttpRequestException"></exception>
-    private static async Task BasicIndexFormatCheckAsync(byte[] body, HttpResponseMessage response, CancellationToken ct)
+    private static void BasicIndexFormatCheck(byte[] body, HttpResponseMessage response)
     {
         // Make sure index is JSON or plain text
         if (response.Content.Headers.ContentType?.MediaType != "application/json" && response.Content.Headers.ContentType?.MediaType != "text/plain")
@@ -112,7 +113,7 @@ public sealed class ContentIndexFetcher : IContentIndexFetcher
         JsonDocument document;
         try
         {
-            document = await JsonDocument.ParseAsync(new MemoryStream(body), cancellationToken: ct);
+            document = JsonDocument.Parse(body);
         }
         catch (JsonException ex)
         {
@@ -128,49 +129,36 @@ public sealed class ContentIndexFetcher : IContentIndexFetcher
                 throw new HttpRequestException("The index is not a JSON object.");
             }
 
-            if (!root.TryGetProperty("snapshot_version", out var versionElement))
+            if (!root.TryGetProperty("snapshot_version", out var versionElement) ||
+                versionElement.ValueKind != JsonValueKind.Number ||
+                !versionElement.TryGetInt32(out int snapshotVersion) ||
+                snapshotVersion < 1)
             {
                 throw new HttpRequestException("The index has no usable 'snapshot_version'.");
             }
 
-            int snapshotVersion;
-
-            try
+            // A newer envelope is refused whole and the cached copy is kept.
+            if (SnapshotVersions.IsAboveHighest(snapshotVersion))
             {
-                // Uses a unsigned integer to auto-rejct negative values
-                if (!versionElement.TryGetUInt32(out uint SnapshotVersion))
-                {
-                    throw new HttpRequestException("The index has an invalid 'snapshot_version'.");
-                }
-                snapshotVersion = (int)SnapshotVersion;
-            }
-            catch (InvalidOperationException ex)
-            {
-                throw new HttpRequestException("The index has an invalid 'snapshot_version'.", ex);
-            }
-
-            // Change 1 to SnapshotVersions.Highest once implemented
-            if (snapshotVersion > 1)
-            {
-                throw new HttpRequestException(                                     // Same here
-                    $"The index is snapshot version {snapshotVersion} and this build reads {1}.");
+                throw new HttpRequestException(
+                    $"The index is snapshot version {snapshotVersion} and this build reads {SnapshotVersions.Highest}.");
             }
 
             // Not checking for 'sources' since it is optional
             // For these three properties, we don't care about the value since they are arrays or objects.
             // Only checking for their existence for now. Reading the index client side can do a full validation.
             // This can be changed later if a IndexValidator class or similar is implemented to validate the index fully.
-            if (!root.TryGetProperty("listings", out var listingsElement))
+            if (!root.TryGetProperty("listings", out _))
             {
                 throw new HttpRequestException("The index has no usable 'listings'.");
             }
 
-            if (!root.TryGetProperty("packs", out var packsElement))
+            if (!root.TryGetProperty("packs", out _))
             {
                 throw new HttpRequestException("The index has no usable 'packs'.");
             }
 
-            if (!root.TryGetProperty("game_versions", out var gameVersionsElement))
+            if (!root.TryGetProperty("game_versions", out _))
             {
                 throw new HttpRequestException("The index has no usable 'game_versions'.");
             }

--- a/tests/Borea.Core.Tests/Index/SnapshotVersionsTests.cs
+++ b/tests/Borea.Core.Tests/Index/SnapshotVersionsTests.cs
@@ -1,0 +1,29 @@
+using Borea.Core.Index;
+
+namespace Borea.Core.Tests.Index;
+
+public sealed class SnapshotVersionsTests
+{
+    [Fact]
+    public void Highest_IsTheVersionTheSpecDefines()
+    {
+        Assert.Equal(1, SnapshotVersions.Highest);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void IsAboveHighest_IsFalseAtOrBelowTheCeiling(int snapshotVersion)
+    {
+        Assert.False(SnapshotVersions.IsAboveHighest(snapshotVersion));
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(999)]
+    [InlineData(int.MaxValue)]
+    public void IsAboveHighest_IsTrueAboveTheCeiling(int snapshotVersion)
+    {
+        Assert.True(SnapshotVersions.IsAboveHighest(snapshotVersion));
+    }
+}

--- a/tests/Borea.Network.Tests/Index/ContentIndexFetcherTests.cs
+++ b/tests/Borea.Network.Tests/Index/ContentIndexFetcherTests.cs
@@ -426,6 +426,9 @@ namespace Borea.Network.Tests.Index
         [InlineData("")]
         [InlineData("""{ "snapshot_version": 999, "listings": {}, "packs": {}, "game_versions": []}""")]
         [InlineData("""{ "snapshot_version": -1, "listings": {}, "packs": {}, "game_versions": []}""")]
+        [InlineData("""{ "snapshot_version": 3000000000, "listings": {}, "packs": {}, "game_versions": []}""")]
+        [InlineData("""{ "snapshot_version": 4294967295, "listings": {}, "packs": {}, "game_versions": []}""")]
+        [InlineData("""{ "snapshot_version": 1.5, "listings": {}, "packs": {}, "game_versions": []}""")]
         public async Task FetchAsync_RejectsInvalidIndexes_ThrowsAndLeavesCacheUntouched(string invalidJson)
         {
             await File.WriteAllTextAsync(_destinationPath, SampleIndexBody);

--- a/tests/Borea.Storage.Tests/Borea.Storage.Tests.csproj
+++ b/tests/Borea.Storage.Tests/Borea.Storage.Tests.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`snapshot_version` was read as a `uint` to keep negatives out and then cast back to `int`, and the cast wraps for anything above `int.MaxValue`, so the value came out negative and passed the ceiling:

```text
snapshot_version = 3000000000  ->  (int) = -1294967296  ->  accepted, cached copy replaced
snapshot_version = 4294967295  ->  (int) =          -1  ->  accepted, cached copy replaced
```

The rest:

- `SnapshotVersions.Highest` replaces the hardcoded `1` and its two "change this later" comments. Useful for #44
- The body is already in memory, so it is parsed directly instead of through an undisposed `MemoryStream`, which also lets the check stop being `async`.
- `out _` for the three properties that are only checked for presence.
- `<GenerateAssemblyInfo>false</GenerateAssemblyInfo>` comes back out of `Borea.Storage.Tests`. The duplicate attributes it was aimed at come from the fixture projects sitting inside the test project folder, and the `Compile Remove` on `Fixtures\**` from #57 already answers that. I removed the flag with both fixture `obj/**/*.AssemblyInfo.cs` files on disk.