### PR TITLE
Launch an instance through the mod loader

### DIFF
--- a/src/Borea.Core/Launch/ILauncher.cs
+++ b/src/Borea.Core/Launch/ILauncher.cs
@@ -1,0 +1,19 @@
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+
+namespace Borea.Core.Launch;
+
+/// <summary>
+/// Starts the game for one instance through its mod loader.
+/// </summary>
+public interface ILauncher
+{
+    LaunchResult Launch(Instance instance, ModMetadata? loader);
+
+    /// <summary>
+    /// Whether a launch this launcher started for the instance is still
+    /// running. A launch from an earlier session, a game started by hand, and
+    /// the new process a loader starts when it restarts itself are not seen.
+    /// </summary>
+    bool IsRunning(Guid instanceId);
+}

--- a/src/Borea.Core/Launch/InstanceHandover.cs
+++ b/src/Borea.Core/Launch/InstanceHandover.cs
@@ -1,0 +1,47 @@
+using Borea.Core.Mods;
+
+namespace Borea.Core.Launch;
+
+/// <summary>
+/// How a loader is told which instance to run: a flag that takes the instance
+/// root as the next argument, a variable that carries it, or both.
+/// </summary>
+public sealed class InstanceHandover
+{
+    // StarMap reads the flag first and the variable when the flag is absent.
+    // Its own restart passes only --restarted, so the variable is what keeps
+    // the instance across it.
+    private static readonly Dictionary<string, InstanceHandover> KnownHandovers = new(ModIds.Comparer)
+    {
+        ["StarMap"] = new InstanceHandover("-InstancePath", "STARMAP_INSTANCE_PATH"),
+    };
+
+    /// <summary>The argument that precedes the instance root. Null when the loader takes no flag.</summary>
+    public string? Flag { get; }
+
+    /// <summary>The environment variable that carries the instance root. Null when the loader reads none.</summary>
+    public string? Variable { get; }
+
+    public InstanceHandover(string? flag, string? variable)
+    {
+        if (flag is not null && string.IsNullOrWhiteSpace(flag))
+            throw new ArgumentException("A flag, if provided, cannot be whitespace.", nameof(flag));
+
+        if (variable is not null && string.IsNullOrWhiteSpace(variable))
+            throw new ArgumentException("A variable, if provided, cannot be whitespace.", nameof(variable));
+
+        if (flag is null && variable is null)
+            throw new ArgumentException("A handover needs a flag or a variable.", nameof(flag));
+
+        Flag = flag;
+        Variable = variable;
+    }
+
+    /// <summary>The handover Borea knows for the loader, or null.</summary>
+    public static InstanceHandover? Known(string loaderId)
+    {
+        ModIds.Validate(loaderId, nameof(loaderId));
+
+        return KnownHandovers.TryGetValue(loaderId, out var handover) ? handover : null;
+    }
+}

--- a/src/Borea.Core/Launch/LaunchOutcome.cs
+++ b/src/Borea.Core/Launch/LaunchOutcome.cs
@@ -1,0 +1,28 @@
+namespace Borea.Core.Launch;
+
+public enum LaunchOutcome
+{
+    /// <summary>The loader process is running.</summary>
+    Started = 0,
+
+    /// <summary>No loader was given, and the game cannot be started for an instance without one.</summary>
+    NoLoader = 1,
+
+    /// <summary>The loader's listing does not name what to run.</summary>
+    NoLaunchTarget = 2,
+
+    /// <summary>Borea does not know how the loader takes an instance.</summary>
+    NoInstanceHandover = 3,
+
+    /// <summary>No directory is configured for the loader.</summary>
+    NoLoaderDirectory = 4,
+
+    /// <summary>The executable the listing names is not in the loader directory.</summary>
+    LaunchTargetMissing = 5,
+
+    /// <summary>A launch this launcher started for the instance is still running.</summary>
+    AlreadyRunning = 6,
+
+    /// <summary>The operating system refused to start the process.</summary>
+    StartFailed = 7,
+}

--- a/src/Borea.Core/Launch/LaunchPlan.cs
+++ b/src/Borea.Core/Launch/LaunchPlan.cs
@@ -1,0 +1,91 @@
+using System.Collections.ObjectModel;
+using Borea.Core.Mods;
+
+namespace Borea.Core.Launch;
+
+/// <summary>
+/// What a launch runs: the executable, its arguments, the working directory,
+/// and the environment variables added to Borea's own.
+/// </summary>
+public sealed class LaunchPlan
+{
+    public string Executable { get; }
+
+    /// <summary>One entry per argument, never a joined command line.</summary>
+    public IReadOnlyList<string> Arguments { get; }
+
+    public string WorkingDirectory { get; }
+
+    public IReadOnlyDictionary<string, string> EnvironmentVariables { get; }
+
+    public LaunchPlan(
+        string executable,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        IReadOnlyDictionary<string, string> environmentVariables)
+    {
+        Executable = Absolute(executable, nameof(executable));
+        WorkingDirectory = Absolute(workingDirectory, nameof(workingDirectory));
+
+        if (arguments is null)
+            throw new ArgumentNullException(nameof(arguments));
+
+        var copied = arguments.ToArray();
+        if (copied.Any(argument => argument is null))
+            throw new ArgumentException("An argument cannot be null.", nameof(arguments));
+
+        if (environmentVariables is null)
+            throw new ArgumentNullException(nameof(environmentVariables));
+
+        var variables = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (name, value) in environmentVariables)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("An environment variable needs a name.", nameof(environmentVariables));
+
+            if (value is null)
+                throw new ArgumentException($"The environment variable '{name}' cannot be null.", nameof(environmentVariables));
+
+            variables[name] = value;
+        }
+
+        Arguments = new ReadOnlyCollection<string>(copied);
+        EnvironmentVariables = new ReadOnlyDictionary<string, string>(variables);
+    }
+
+    /// <summary>
+    /// The launch target under the loader directory with the separator
+    /// translated (RFC 0035 rule 2), started in that directory (rule 5), with
+    /// the instance root handed over the way the loader takes it.
+    /// </summary>
+    public static LaunchPlan ForLoader(string loaderDirectory, string launch, InstanceHandover handover, string instanceRoot)
+    {
+        if (handover is null)
+            throw new ArgumentNullException(nameof(handover));
+
+        var directory = Absolute(loaderDirectory, nameof(loaderDirectory));
+        var root = Absolute(instanceRoot, nameof(instanceRoot));
+        var target = RelativePaths.Contained(launch, nameof(launch))
+            ?? throw new ArgumentException("The launch target is required.", nameof(launch));
+
+        var executable = Path.Combine(directory, target.Replace('/', Path.DirectorySeparatorChar));
+        var arguments = handover.Flag is null ? Array.Empty<string>() : new[] { handover.Flag, root };
+        var variables = new Dictionary<string, string>();
+        if (handover.Variable is not null)
+            variables[handover.Variable] = root;
+
+        return new LaunchPlan(executable, arguments, directory, variables);
+    }
+
+    private static string Absolute(string path, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("A path is required.", paramName);
+
+        // Fully qualified, because a rooted path can still lack its drive on Windows.
+        if (!Path.IsPathFullyQualified(path))
+            throw new ArgumentException("The path must be absolute, because the loader resolves it in its own working directory.", paramName);
+
+        return path;
+    }
+}

--- a/src/Borea.Core/Launch/LaunchResult.cs
+++ b/src/Borea.Core/Launch/LaunchResult.cs
@@ -1,0 +1,44 @@
+namespace Borea.Core.Launch;
+
+public sealed class LaunchResult
+{
+    public LaunchOutcome Outcome { get; }
+
+    /// <summary>What happened and what to do about it, for the user.</summary>
+    public string Message { get; }
+
+    /// <summary>What was run, or would have been run. Null when no plan was built.</summary>
+    public LaunchPlan? Plan { get; }
+
+    /// <summary>Null unless the launch started.</summary>
+    public int? ProcessId { get; }
+
+    public bool Started => Outcome == LaunchOutcome.Started;
+
+    private LaunchResult(LaunchOutcome outcome, string message, LaunchPlan? plan, int? processId)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            throw new ArgumentException("A launch result needs a message for the user.", nameof(message));
+
+        Outcome = outcome;
+        Message = message;
+        Plan = plan;
+        ProcessId = processId;
+    }
+
+    public static LaunchResult Success(LaunchPlan plan, int processId, string message)
+    {
+        if (plan is null)
+            throw new ArgumentNullException(nameof(plan));
+
+        return new LaunchResult(LaunchOutcome.Started, message, plan, processId);
+    }
+
+    public static LaunchResult Failed(LaunchOutcome outcome, string message, LaunchPlan? plan = null)
+    {
+        if (outcome == LaunchOutcome.Started)
+            throw new ArgumentException("A started launch is a success, not a failure.", nameof(outcome));
+
+        return new LaunchResult(outcome, message, plan, processId: null);
+    }
+}

--- a/src/Borea.Storage/Launch/IProcessStarter.cs
+++ b/src/Borea.Storage/Launch/IProcessStarter.cs
@@ -1,0 +1,9 @@
+using Borea.Core.Launch;
+
+namespace Borea.Storage.Launch;
+
+public interface IProcessStarter
+{
+    /// <summary>Throws the operating system's error when the process does not start.</summary>
+    IStartedProcess Start(LaunchPlan plan);
+}

--- a/src/Borea.Storage/Launch/IStartedProcess.cs
+++ b/src/Borea.Storage/Launch/IStartedProcess.cs
@@ -1,0 +1,12 @@
+namespace Borea.Storage.Launch;
+
+/// <summary>
+/// A process a starter started. Disposing releases the handle, the process
+/// keeps running.
+/// </summary>
+public interface IStartedProcess : IDisposable
+{
+    int Id { get; }
+
+    bool HasExited { get; }
+}

--- a/src/Borea.Storage/Launch/LoaderLauncher.cs
+++ b/src/Borea.Storage/Launch/LoaderLauncher.cs
@@ -1,0 +1,143 @@
+using System.ComponentModel;
+using Borea.Core.Instances;
+using Borea.Core.Launch;
+using Borea.Core.Mods;
+using Borea.Core.Paths;
+
+namespace Borea.Storage.Launch;
+
+/// <summary>
+/// ILauncher over the configured loader directories and a process starter.
+/// It remembers every launch per instance until the process exits, so a
+/// second launch of a running instance is refused.
+/// </summary>
+public sealed class LoaderLauncher : ILauncher, IDisposable
+{
+    private readonly IGamePathProvider _pathProvider;
+    private readonly IProcessStarter _starter;
+    private readonly object _gate = new();
+    private readonly Dictionary<Guid, IStartedProcess> _running = new();
+
+    public LoaderLauncher(IGamePathProvider pathProvider, IProcessStarter starter)
+    {
+        _pathProvider = pathProvider ?? throw new ArgumentNullException(nameof(pathProvider));
+        _starter = starter ?? throw new ArgumentNullException(nameof(starter));
+    }
+
+    public LaunchResult Launch(Instance instance, ModMetadata? loader)
+    {
+        if (instance is null)
+            throw new ArgumentNullException(nameof(instance));
+
+        if (loader is null)
+        {
+            return LaunchResult.Failed(
+                LaunchOutcome.NoLoader,
+                "No mod loader is set for this launch. The game reads no instance path on its own, so install a loader first.");
+        }
+
+        if (loader.Type != ContentType.ModLoader)
+            throw new ArgumentException("Only a mod loader can start the game.", nameof(loader));
+
+        lock (_gate)
+        {
+            Forget(exited: true);
+
+            if (_running.ContainsKey(instance.InstanceId))
+            {
+                return LaunchResult.Failed(
+                    LaunchOutcome.AlreadyRunning,
+                    $"Instance '{instance.Name}' is already running from a launch Borea started. Close the game first.");
+            }
+
+            var launch = loader.Provides?.Launch;
+            if (launch is null)
+            {
+                return LaunchResult.Failed(
+                    LaunchOutcome.NoLaunchTarget,
+                    $"The listing of {loader.Name} does not say what to run, so Borea cannot start it.");
+            }
+
+            var handover = InstanceHandover.Known(loader.ModId);
+            if (handover is null)
+            {
+                return LaunchResult.Failed(
+                    LaunchOutcome.NoInstanceHandover,
+                    $"Borea does not know how {loader.Name} takes an instance, so it cannot start one with it.");
+            }
+
+            var loaderDirectory = _pathProvider.GetLoaderDirectoryPath(loader.ModId);
+            if (loaderDirectory is null)
+            {
+                return LaunchResult.Failed(
+                    LaunchOutcome.NoLoaderDirectory,
+                    $"Borea does not know where {loader.Name} is installed. Set its directory in the settings.");
+            }
+
+            var plan = LaunchPlan.ForLoader(
+                Path.GetFullPath(loaderDirectory),
+                launch,
+                handover,
+                Path.GetFullPath(_pathProvider.GetInstanceRoot(instance.InstanceId)));
+
+            if (!File.Exists(plan.Executable))
+            {
+                return LaunchResult.Failed(
+                    LaunchOutcome.LaunchTargetMissing,
+                    $"'{plan.Executable}' is not there. Reinstall {loader.Name} or correct its directory in the settings.",
+                    plan);
+            }
+
+            IStartedProcess process;
+            try
+            {
+                process = _starter.Start(plan);
+            }
+            catch (Win32Exception exception)
+            {
+                return LaunchResult.Failed(
+                    LaunchOutcome.StartFailed,
+                    $"The system did not start '{plan.Executable}': {exception.Message}",
+                    plan);
+            }
+
+            _running[instance.InstanceId] = process;
+
+            return LaunchResult.Success(
+                plan,
+                process.Id,
+                $"Started {loader.Name} for instance '{instance.Name}'.");
+        }
+    }
+
+    public bool IsRunning(Guid instanceId)
+    {
+        lock (_gate)
+        {
+            Forget(exited: true);
+            return _running.ContainsKey(instanceId);
+        }
+    }
+
+    /// <summary>Releases the handles. The processes keep running.</summary>
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            Forget(exited: false);
+        }
+    }
+
+    /// <summary>Drops the exited launches, or every launch, and releases their handles.</summary>
+    private void Forget(bool exited)
+    {
+        foreach (var (instanceId, process) in _running.ToArray())
+        {
+            if (exited && !process.HasExited)
+                continue;
+
+            _running.Remove(instanceId);
+            process.Dispose();
+        }
+    }
+}

--- a/src/Borea.Storage/Launch/ProcessStarter.cs
+++ b/src/Borea.Storage/Launch/ProcessStarter.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics;
+using Borea.Core.Launch;
+
+namespace Borea.Storage.Launch;
+
+/// <summary>
+/// Starts a plan as an operating system process. The process inherits Borea's
+/// environment plus the plan's variables and keeps Borea's console.
+/// </summary>
+public sealed class ProcessStarter : IProcessStarter
+{
+    public IStartedProcess Start(LaunchPlan plan)
+    {
+        if (plan is null)
+            throw new ArgumentNullException(nameof(plan));
+
+        // UseShellExecute off, so the environment and the argument list reach the process.
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = plan.Executable,
+            WorkingDirectory = plan.WorkingDirectory,
+            UseShellExecute = false,
+        };
+
+        foreach (var argument in plan.Arguments)
+            startInfo.ArgumentList.Add(argument);
+
+        foreach (var (name, value) in plan.EnvironmentVariables)
+            startInfo.Environment[name] = value;
+
+        var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"No process was started for '{plan.Executable}'.");
+
+        return new StartedProcess(process);
+    }
+
+    private sealed class StartedProcess : IStartedProcess
+    {
+        private readonly Process _process;
+
+        public StartedProcess(Process process)
+        {
+            _process = process;
+        }
+
+        public int Id => _process.Id;
+
+        public bool HasExited => _process.HasExited;
+
+        public void Dispose() => _process.Dispose();
+    }
+}

--- a/tests/Borea.Core.Tests/Launch/InstanceHandoverTests.cs
+++ b/tests/Borea.Core.Tests/Launch/InstanceHandoverTests.cs
@@ -1,0 +1,71 @@
+using Borea.Core.Launch;
+
+namespace Borea.Core.Tests.Launch;
+
+public sealed class InstanceHandoverTests
+{
+    [Fact]
+    public void Known_StarMap_TakesTheFlagAndTheVariable()
+    {
+        var handover = InstanceHandover.Known("StarMap");
+
+        Assert.NotNull(handover);
+        Assert.Equal("-InstancePath", handover!.Flag);
+        Assert.Equal("STARMAP_INSTANCE_PATH", handover.Variable);
+    }
+
+    [Fact]
+    public void Known_IdDifferingOnlyInCase_IsTheSameLoader()
+    {
+        Assert.Same(InstanceHandover.Known("StarMap"), InstanceHandover.Known("starmap"));
+    }
+
+    [Fact]
+    public void Known_OtherLoader_IsNull()
+    {
+        Assert.Null(InstanceHandover.Known("OtherLoader"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not a valid id!")]
+    public void Known_InvalidId_ThrowsArgumentException(string? loaderId)
+    {
+        Assert.Throws<ArgumentException>(() => InstanceHandover.Known(loaderId!));
+    }
+
+    [Fact]
+    public void Constructor_FlagOnly_IsAccepted()
+    {
+        var handover = new InstanceHandover("-Instance", null);
+
+        Assert.Equal("-Instance", handover.Flag);
+        Assert.Null(handover.Variable);
+    }
+
+    [Fact]
+    public void Constructor_VariableOnly_IsAccepted()
+    {
+        var handover = new InstanceHandover(null, "LOADER_INSTANCE");
+
+        Assert.Null(handover.Flag);
+        Assert.Equal("LOADER_INSTANCE", handover.Variable);
+    }
+
+    [Fact]
+    public void Constructor_Neither_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => new InstanceHandover(null, null));
+    }
+
+    [Theory]
+    [InlineData("", "VAR")]
+    [InlineData("   ", "VAR")]
+    [InlineData("-Flag", "")]
+    [InlineData("-Flag", "   ")]
+    public void Constructor_Whitespace_ThrowsArgumentException(string flag, string variable)
+    {
+        Assert.Throws<ArgumentException>(() => new InstanceHandover(flag, variable));
+    }
+}

--- a/tests/Borea.Core.Tests/Launch/LaunchPlanTests.cs
+++ b/tests/Borea.Core.Tests/Launch/LaunchPlanTests.cs
@@ -1,0 +1,147 @@
+using Borea.Core.Launch;
+
+namespace Borea.Core.Tests.Launch;
+
+public sealed class LaunchPlanTests
+{
+    private static readonly string LoaderDirectory = Path.Combine(Path.GetTempPath(), "BoreaTest", "StarMap");
+    private static readonly string InstanceRoot = Path.Combine(Path.GetTempPath(), "BoreaTest", "Instances", "one");
+    private static readonly InstanceHandover Handover = new("-InstancePath", "LOADER_INSTANCE_PATH");
+
+    [Fact]
+    public void ForLoader_PassesTheInstanceRootAsFlagAndVariable()
+    {
+        var plan = LaunchPlan.ForLoader(LoaderDirectory, "StarMap.exe", Handover, InstanceRoot);
+
+        Assert.Equal(Path.Combine(LoaderDirectory, "StarMap.exe"), plan.Executable);
+        Assert.Equal(new[] { "-InstancePath", InstanceRoot }, plan.Arguments);
+        Assert.Equal(InstanceRoot, plan.EnvironmentVariables["LOADER_INSTANCE_PATH"]);
+        Assert.Single(plan.EnvironmentVariables);
+    }
+
+    [Fact]
+    public void ForLoader_StartsTheProcessInTheLoaderDirectory()
+    {
+        var plan = LaunchPlan.ForLoader(LoaderDirectory, "StarMap.exe", Handover, InstanceRoot);
+
+        Assert.Equal(LoaderDirectory, plan.WorkingDirectory);
+    }
+
+    [Fact]
+    public void ForLoader_FlagOnlyHandover_SetsNoVariable()
+    {
+        var plan = LaunchPlan.ForLoader(LoaderDirectory, "StarMap.exe", new InstanceHandover("-Instance", null), InstanceRoot);
+
+        Assert.Equal(new[] { "-Instance", InstanceRoot }, plan.Arguments);
+        Assert.Empty(plan.EnvironmentVariables);
+    }
+
+    [Fact]
+    public void ForLoader_VariableOnlyHandover_PassesNoArguments()
+    {
+        var plan = LaunchPlan.ForLoader(LoaderDirectory, "StarMap.exe", new InstanceHandover(null, "LOADER_INSTANCE"), InstanceRoot);
+
+        Assert.Empty(plan.Arguments);
+        Assert.Equal(InstanceRoot, plan.EnvironmentVariables["LOADER_INSTANCE"]);
+    }
+
+    [Fact]
+    public void ForLoader_NestedLaunchTarget_TranslatesTheSeparator()
+    {
+        var plan = LaunchPlan.ForLoader(LoaderDirectory, "bin/StarMap", Handover, InstanceRoot);
+
+        Assert.Equal(Path.Combine(LoaderDirectory, "bin", "StarMap"), plan.Executable);
+    }
+
+    [Theory]
+    [InlineData("../StarMap.exe")]
+    [InlineData("/StarMap.exe")]
+    [InlineData("bin/../../StarMap.exe")]
+    public void ForLoader_LaunchTargetLeavingTheLoaderDirectory_ThrowsArgumentException(string launch)
+    {
+        Assert.Throws<ArgumentException>(() => LaunchPlan.ForLoader(LoaderDirectory, launch, Handover, InstanceRoot));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ForLoader_NoLaunchTarget_ThrowsArgumentException(string? launch)
+    {
+        Assert.Throws<ArgumentException>(() => LaunchPlan.ForLoader(LoaderDirectory, launch!, Handover, InstanceRoot));
+    }
+
+    [Fact]
+    public void ForLoader_NoHandover_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => LaunchPlan.ForLoader(LoaderDirectory, "StarMap.exe", null!, InstanceRoot));
+    }
+
+    [Fact]
+    public void ForLoader_RelativeLoaderDirectory_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => LaunchPlan.ForLoader("StarMap", "StarMap.exe", Handover, InstanceRoot));
+    }
+
+    [Fact]
+    public void ForLoader_RelativeInstanceRoot_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => LaunchPlan.ForLoader(LoaderDirectory, "StarMap.exe", Handover, "Instances/one"));
+    }
+
+    [Fact]
+    public void Constructor_CopiesTheArgumentsAndVariables()
+    {
+        var arguments = new List<string> { "-InstancePath", InstanceRoot };
+        var variables = new Dictionary<string, string> { ["LOADER_INSTANCE_PATH"] = InstanceRoot };
+
+        var plan = new LaunchPlan(Path.Combine(LoaderDirectory, "StarMap.exe"), arguments, LoaderDirectory, variables);
+        arguments.Add("--extra");
+        variables["OTHER"] = "value";
+
+        Assert.Equal(2, plan.Arguments.Count);
+        Assert.Single(plan.EnvironmentVariables);
+    }
+
+    [Fact]
+    public void Constructor_NullArgument_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => new LaunchPlan(
+            Path.Combine(LoaderDirectory, "StarMap.exe"),
+            new string?[] { "-InstancePath", null }!,
+            LoaderDirectory,
+            new Dictionary<string, string>()));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_BlankVariableName_ThrowsArgumentException(string name)
+    {
+        Assert.Throws<ArgumentException>(() => new LaunchPlan(
+            Path.Combine(LoaderDirectory, "StarMap.exe"),
+            Array.Empty<string>(),
+            LoaderDirectory,
+            new Dictionary<string, string> { [name] = "value" }));
+    }
+
+    [Fact]
+    public void Constructor_NullVariableValue_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => new LaunchPlan(
+            Path.Combine(LoaderDirectory, "StarMap.exe"),
+            Array.Empty<string>(),
+            LoaderDirectory,
+            new Dictionary<string, string?> { ["LOADER_INSTANCE_PATH"] = null }!));
+    }
+
+    [Fact]
+    public void Constructor_RelativeExecutable_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => new LaunchPlan(
+            "StarMap.exe",
+            Array.Empty<string>(),
+            LoaderDirectory,
+            new Dictionary<string, string>()));
+    }
+}

--- a/tests/Borea.Core.Tests/Launch/LaunchResultTests.cs
+++ b/tests/Borea.Core.Tests/Launch/LaunchResultTests.cs
@@ -1,0 +1,70 @@
+using Borea.Core.Launch;
+
+namespace Borea.Core.Tests.Launch;
+
+public sealed class LaunchResultTests
+{
+    private static LaunchPlan SamplePlan() => LaunchPlan.ForLoader(
+        Path.Combine(Path.GetTempPath(), "BoreaTest", "StarMap"),
+        "StarMap.exe",
+        InstanceHandover.Known("StarMap")!,
+        Path.Combine(Path.GetTempPath(), "BoreaTest", "Instances", "one"));
+
+    [Fact]
+    public void Success_CarriesThePlanAndTheProcessId()
+    {
+        var plan = SamplePlan();
+
+        var result = LaunchResult.Success(plan, 4242, "Started StarMap for instance 'Test'.");
+
+        Assert.True(result.Started);
+        Assert.Equal(LaunchOutcome.Started, result.Outcome);
+        Assert.Same(plan, result.Plan);
+        Assert.Equal(4242, result.ProcessId);
+        Assert.Equal("Started StarMap for instance 'Test'.", result.Message);
+    }
+
+    [Fact]
+    public void Failed_HasNoPlanAndNoProcess()
+    {
+        var result = LaunchResult.Failed(LaunchOutcome.NoLoaderDirectory, "Borea does not know where StarMap is installed.");
+
+        Assert.False(result.Started);
+        Assert.Equal(LaunchOutcome.NoLoaderDirectory, result.Outcome);
+        Assert.Null(result.Plan);
+        Assert.Null(result.ProcessId);
+    }
+
+    [Fact]
+    public void Failed_AfterThePlanWasBuilt_KeepsIt()
+    {
+        var plan = SamplePlan();
+
+        var result = LaunchResult.Failed(LaunchOutcome.LaunchTargetMissing, "StarMap.exe is not there.", plan);
+
+        Assert.False(result.Started);
+        Assert.Same(plan, result.Plan);
+        Assert.Null(result.ProcessId);
+    }
+
+    [Fact]
+    public void Failed_WithTheStartedOutcome_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => LaunchResult.Failed(LaunchOutcome.Started, "Contradiction."));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Failed_WithoutMessage_ThrowsArgumentException(string? message)
+    {
+        Assert.Throws<ArgumentException>(() => LaunchResult.Failed(LaunchOutcome.NoLoader, message!));
+    }
+
+    [Fact]
+    public void Success_WithoutPlan_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => LaunchResult.Success(null!, 1, "Started."));
+    }
+}

--- a/tests/Borea.Storage.Tests/Launch/FakeProcessStarter.cs
+++ b/tests/Borea.Storage.Tests/Launch/FakeProcessStarter.cs
@@ -1,0 +1,47 @@
+using Borea.Core.Launch;
+using Borea.Storage.Launch;
+
+namespace Borea.Storage.Tests.Launch;
+
+/// <summary>
+/// Records every plan and hands out processes whose exit a test controls.
+/// </summary>
+internal sealed class FakeProcessStarter : IProcessStarter
+{
+    private int _nextId = 1000;
+
+    public List<LaunchPlan> Plans { get; } = new();
+
+    public List<FakeStartedProcess> Processes { get; } = new();
+
+    /// <summary>Thrown by the next start when set.</summary>
+    public Exception? Failure { get; set; }
+
+    public IStartedProcess Start(LaunchPlan plan)
+    {
+        Plans.Add(plan);
+
+        if (Failure is not null)
+            throw Failure;
+
+        var process = new FakeStartedProcess(_nextId++);
+        Processes.Add(process);
+        return process;
+    }
+}
+
+internal sealed class FakeStartedProcess : IStartedProcess
+{
+    public FakeStartedProcess(int id)
+    {
+        Id = id;
+    }
+
+    public int Id { get; }
+
+    public bool HasExited { get; set; }
+
+    public bool Disposed { get; private set; }
+
+    public void Dispose() => Disposed = true;
+}

--- a/tests/Borea.Storage.Tests/Launch/LoaderLauncherTests.cs
+++ b/tests/Borea.Storage.Tests/Launch/LoaderLauncherTests.cs
@@ -1,0 +1,273 @@
+using System.ComponentModel;
+using Borea.Core.Instances;
+using Borea.Core.Launch;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+using Borea.Storage.Launch;
+using Borea.Storage.Paths;
+using Borea.Storage.Tests.Mods;
+using Borea.Storage.Tests.Paths;
+
+namespace Borea.Storage.Tests.Launch;
+
+public sealed class LoaderLauncherTests : IDisposable
+{
+    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+    private readonly TestGamePathProvider _paths;
+    private readonly FakeProcessStarter _starter = new();
+    private readonly LoaderLauncher _launcher;
+    private readonly Instance _instance = new("Test", InstanceSource.Custom.Value);
+
+    public LoaderLauncherTests()
+    {
+        _paths = new TestGamePathProvider(_tempRoot);
+        _launcher = new LoaderLauncher(_paths, _starter);
+    }
+
+    private string StarMapDirectory => Path.Combine(_tempRoot, "StarMap");
+
+    /// <summary>Puts an empty file where the loader's executable would be.</summary>
+    private string PlaceStarMap(string launch = "StarMap.exe")
+    {
+        var executable = Path.Combine(StarMapDirectory, launch.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(executable)!);
+        File.WriteAllBytes(executable, Array.Empty<byte>());
+        return executable;
+    }
+
+    private static ModMetadata LoaderListing(string modId = "StarMap", LoaderProvides? provides = null, bool standalone = true) => new(
+        specVersion: 1,
+        modId: modId,
+        source: "TestSource",
+        name: "StarMap",
+        authors: new[] { "KlaasWhite" },
+        abstractText: "The loader.",
+        license: "MIT",
+        links: MetadataFixtures.SampleLinks(),
+        gameMin: "2026.8.3.5117",
+        type: ContentType.ModLoader,
+        install: standalone ? new InstallDescriptor(target: InstallAnchor.Standalone) : null,
+        provides: provides);
+
+    private static LoaderProvides StarMapProvides(string launch = "StarMap.exe") => new(
+        launch: launch,
+        contentDir: InstallAnchor.Mods,
+        configure: new LoaderConfigure("StarMapConfig.json", ConfigureFormat.Json, "GameLocation"));
+
+    [Fact]
+    public void Launch_KnownLoader_StartsItInItsDirectoryWithTheInstanceRoot()
+    {
+        var executable = PlaceStarMap();
+        var instanceRoot = Path.GetFullPath(_paths.GetInstanceRoot(_instance.InstanceId));
+
+        var result = _launcher.Launch(_instance, LoaderListing(provides: StarMapProvides()));
+
+        Assert.True(result.Started);
+        Assert.Equal(LaunchOutcome.Started, result.Outcome);
+        Assert.Equal(Assert.Single(_starter.Processes).Id, result.ProcessId);
+        Assert.Contains("StarMap", result.Message);
+
+        var plan = Assert.Single(_starter.Plans);
+        Assert.Same(plan, result.Plan);
+        Assert.Equal(executable, plan.Executable);
+        Assert.Equal(new[] { "-InstancePath", instanceRoot }, plan.Arguments);
+        Assert.Equal(instanceRoot, plan.EnvironmentVariables["STARMAP_INSTANCE_PATH"]);
+        Assert.Equal(Path.GetFullPath(StarMapDirectory), plan.WorkingDirectory);
+        Assert.True(_launcher.IsRunning(_instance.InstanceId));
+    }
+
+    [Fact]
+    public void Launch_NestedLaunchTarget_ResolvesUnderTheLoaderDirectory()
+    {
+        var executable = PlaceStarMap("bin/StarMap.exe");
+
+        var result = _launcher.Launch(_instance, LoaderListing(provides: StarMapProvides("bin/StarMap.exe")));
+
+        Assert.True(result.Started);
+        Assert.Equal(executable, result.Plan!.Executable);
+    }
+
+    [Fact]
+    public void Launch_NoLoader_ReportsInsteadOfStartingTheGame()
+    {
+        var result = _launcher.Launch(_instance, loader: null);
+
+        Assert.Equal(LaunchOutcome.NoLoader, result.Outcome);
+        Assert.False(result.Started);
+        Assert.Empty(_starter.Plans);
+        Assert.False(_launcher.IsRunning(_instance.InstanceId));
+    }
+
+    [Fact]
+    public void Launch_ListingWithoutLaunchTarget_ReportsIt()
+    {
+        PlaceStarMap();
+
+        var result = _launcher.Launch(_instance, LoaderListing(provides: new LoaderProvides(contentDir: InstallAnchor.Mods), standalone: false));
+
+        Assert.Equal(LaunchOutcome.NoLaunchTarget, result.Outcome);
+        Assert.Contains("StarMap", result.Message);
+        Assert.Empty(_starter.Plans);
+    }
+
+    [Fact]
+    public void Launch_ListingWithoutProvides_ReportsNoLaunchTarget()
+    {
+        PlaceStarMap();
+
+        var result = _launcher.Launch(_instance, LoaderListing(provides: null, standalone: false));
+
+        Assert.Equal(LaunchOutcome.NoLaunchTarget, result.Outcome);
+        Assert.Empty(_starter.Plans);
+    }
+
+    [Fact]
+    public void Launch_LoaderWhoseHandoverIsUnknown_ReportsInsteadOfGuessing()
+    {
+        var result = _launcher.Launch(_instance, LoaderListing(modId: "OtherLoader", provides: StarMapProvides()));
+
+        Assert.Equal(LaunchOutcome.NoInstanceHandover, result.Outcome);
+        Assert.Contains("StarMap", result.Message);
+        Assert.Empty(_starter.Plans);
+    }
+
+    [Fact]
+    public void Launch_NoLoaderDirectoryConfigured_ReportsIt()
+    {
+        // The real provider with no loader directories, so StarMap is known but not located.
+        using var launcher = new LoaderLauncher(new GamePathProvider(gameDirectory: null), _starter);
+
+        var result = launcher.Launch(_instance, LoaderListing(provides: StarMapProvides()));
+
+        Assert.Equal(LaunchOutcome.NoLoaderDirectory, result.Outcome);
+        Assert.Contains("StarMap", result.Message);
+        Assert.Empty(_starter.Plans);
+    }
+
+    [Fact]
+    public void Launch_ExecutableMissing_ReportsIt()
+    {
+        Directory.CreateDirectory(StarMapDirectory);
+
+        var result = _launcher.Launch(_instance, LoaderListing(provides: StarMapProvides()));
+
+        Assert.Equal(LaunchOutcome.LaunchTargetMissing, result.Outcome);
+        Assert.Contains(Path.Combine(StarMapDirectory, "StarMap.exe"), result.Message);
+        Assert.Equal(Path.Combine(Path.GetFullPath(StarMapDirectory), "StarMap.exe"), result.Plan!.Executable);
+        Assert.Empty(_starter.Plans);
+        Assert.False(_launcher.IsRunning(_instance.InstanceId));
+    }
+
+    [Fact]
+    public void Launch_SecondLaunchWhileTheFirstRuns_IsRefused()
+    {
+        PlaceStarMap();
+        var listing = LoaderListing(provides: StarMapProvides());
+        _launcher.Launch(_instance, listing);
+
+        var second = _launcher.Launch(_instance, listing);
+
+        Assert.Equal(LaunchOutcome.AlreadyRunning, second.Outcome);
+        Assert.Contains("Test", second.Message);
+        Assert.Single(_starter.Plans);
+        Assert.True(_launcher.IsRunning(_instance.InstanceId));
+    }
+
+    [Fact]
+    public void Launch_AfterTheProcessExited_StartsAgainAndReleasesTheOldHandle()
+    {
+        PlaceStarMap();
+        var listing = LoaderListing(provides: StarMapProvides());
+        _launcher.Launch(_instance, listing);
+        var first = Assert.Single(_starter.Processes);
+
+        first.HasExited = true;
+
+        Assert.False(_launcher.IsRunning(_instance.InstanceId));
+        Assert.True(first.Disposed);
+
+        var second = _launcher.Launch(_instance, listing);
+
+        Assert.True(second.Started);
+        Assert.Equal(_starter.Processes[^1].Id, second.ProcessId);
+        Assert.NotEqual(first.Id, second.ProcessId);
+        Assert.True(_launcher.IsRunning(_instance.InstanceId));
+    }
+
+    [Fact]
+    public void Launch_TwoInstances_BothRun()
+    {
+        PlaceStarMap();
+        var listing = LoaderListing(provides: StarMapProvides());
+        var other = new Instance("Other", InstanceSource.Custom.Value);
+
+        var first = _launcher.Launch(_instance, listing);
+        var second = _launcher.Launch(other, listing);
+
+        Assert.True(first.Started);
+        Assert.True(second.Started);
+        Assert.True(_launcher.IsRunning(_instance.InstanceId));
+        Assert.True(_launcher.IsRunning(other.InstanceId));
+        Assert.NotEqual(first.Plan!.Arguments[1], second.Plan!.Arguments[1]);
+    }
+
+    [Fact]
+    public void Launch_SystemRefusesToStart_ReportsStartFailed()
+    {
+        PlaceStarMap();
+        _starter.Failure = new Win32Exception("Access is denied.");
+
+        var result = _launcher.Launch(_instance, LoaderListing(provides: StarMapProvides()));
+
+        Assert.Equal(LaunchOutcome.StartFailed, result.Outcome);
+        Assert.Contains("Access is denied.", result.Message);
+        Assert.Same(Assert.Single(_starter.Plans), result.Plan);
+        Assert.False(_launcher.IsRunning(_instance.InstanceId));
+    }
+
+    [Fact]
+    public void Launch_AModInsteadOfALoader_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => _launcher.Launch(_instance, MetadataFixtures.MinimalMetadata()));
+    }
+
+    [Fact]
+    public void Launch_NullInstance_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => _launcher.Launch(null!, LoaderListing(provides: StarMapProvides())));
+    }
+
+    [Fact]
+    public void IsRunning_UnknownInstance_IsFalse()
+    {
+        Assert.False(_launcher.IsRunning(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Dispose_ReleasesTheHandlesAndForgetsTheLaunches()
+    {
+        PlaceStarMap();
+        _launcher.Launch(_instance, LoaderListing(provides: StarMapProvides()));
+        var process = Assert.Single(_starter.Processes);
+
+        _launcher.Dispose();
+
+        Assert.True(process.Disposed);
+        Assert.False(_launcher.IsRunning(_instance.InstanceId));
+    }
+
+    [Fact]
+    public void Constructor_NullDependency_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new LoaderLauncher(null!, _starter));
+        Assert.Throws<ArgumentNullException>(() => new LoaderLauncher(_paths, null!));
+    }
+
+    public void Dispose()
+    {
+        _launcher.Dispose();
+
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+}

--- a/tests/Borea.Storage.Tests/Launch/ProcessStarterTests.cs
+++ b/tests/Borea.Storage.Tests/Launch/ProcessStarterTests.cs
@@ -1,0 +1,89 @@
+using System.ComponentModel;
+using Borea.Core.Launch;
+using Borea.Storage.Launch;
+
+namespace Borea.Storage.Tests.Launch;
+
+public sealed class ProcessStarterTests : IDisposable
+{
+    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest " + Guid.NewGuid());
+    private readonly ProcessStarter _starter = new();
+
+    public ProcessStarterTests()
+    {
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    /// <summary>
+    /// A script that writes the plan's variable and an inherited one into
+    /// files next to it, so the files prove the directory and both variables.
+    /// </summary>
+    private LaunchPlan ProbePlan()
+    {
+        var variables = new Dictionary<string, string> { ["BOREA_PROBE"] = "probe-value" };
+
+        if (OperatingSystem.IsWindows())
+        {
+            var script = Path.Combine(_tempRoot, "probe.cmd");
+            File.WriteAllText(script, "@echo off\r\necho %BOREA_PROBE%> env.txt\r\necho %PATH%> inherited.txt\r\n");
+            return new LaunchPlan(Path.Combine(Environment.SystemDirectory, "cmd.exe"), new[] { "/c", script }, _tempRoot, variables);
+        }
+
+        var shellScript = Path.Combine(_tempRoot, "probe.sh");
+        File.WriteAllText(shellScript, "printf '%s' \"$BOREA_PROBE\" > env.txt\nprintf '%s' \"$PATH\" > inherited.txt\n");
+        return new LaunchPlan("/bin/sh", new[] { shellScript }, _tempRoot, variables);
+    }
+
+    private static void WaitForExit(IStartedProcess process)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        while (!process.HasExited && DateTime.UtcNow < deadline)
+            Thread.Sleep(50);
+    }
+
+    [Fact]
+    public void Start_RunsTheExecutableInTheWorkingDirectoryWithTheVariables()
+    {
+        using var process = _starter.Start(ProbePlan());
+
+        Assert.True(process.Id > 0);
+        WaitForExit(process);
+        Assert.True(process.HasExited);
+
+        var written = Path.Combine(_tempRoot, "env.txt");
+        Assert.True(File.Exists(written), "The script did not run in the plan's working directory.");
+        Assert.Equal("probe-value", File.ReadAllText(written).Trim());
+        Assert.NotEqual(string.Empty, File.ReadAllText(Path.Combine(_tempRoot, "inherited.txt")).Trim());
+    }
+
+    [Fact]
+    public void Start_MissingExecutable_ThrowsWin32Exception()
+    {
+        var plan = new LaunchPlan(
+            Path.Combine(_tempRoot, "missing.exe"),
+            Array.Empty<string>(),
+            _tempRoot,
+            new Dictionary<string, string>());
+
+        Assert.Throws<Win32Exception>(() => _starter.Start(plan));
+    }
+
+    [Fact]
+    public void Start_NullPlan_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => _starter.Start(null!));
+    }
+
+    public void Dispose()
+    {
+        // A child that outlived the wait still holds the directory
+        try
+        {
+            if (Directory.Exists(_tempRoot))
+                Directory.Delete(_tempRoot, recursive: true);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Closes #69.

**Borea can start the game for an instance now.** A launch runs like this:

1. The caller says: start instance X with the loader StarMap.
2. Borea looks up in the settings where StarMap is installed.
3. Borea reads from the live StarMap listing which file to run. That is `[provides].launch`, so `StarMap.exe`.
4. Borea starts that file inside the StarMap folder, so StarMap finds its `StarMapConfig.json`, and hands over the instance folder the way the loader takes it. For StarMap that is the argument `-InstancePath <path>` and the environment variable `STARMAP_INSTANCE_PATH`.
5. StarMap points the game's Documents path at that folder. Mods, `manifest.toml`, saves, settings and logs all come from the instance.
6. Borea remembers that the instance is running. A second launch of the same instance is refused until the process ends.

**When something is missing** there is one sentence for the user: no loader chosen, no folder in the settings, a listing without `launch`, the executable is not there, or the system refused to start it. Without a loader nothing is started, because the game alone reads no instance path and would land in the shared profile.

**The one thing the format does not say yet** is how a loader takes an instance. RFC 0035 leaves that to discussion #20 and `[provides]` has no field for it. So Borea keeps a small table of what it knows, and that is StarMap only: the flag, plus the variable, because StarMap's own restart passes only `--restarted` and keeps the environment. Any other loader is refused with a message instead of started with a guess. Once the format gains a field for it, the table goes away and the listing says it.

**Tested against the real game.** StarMap printed the instance path, and settings, manifest, mods, saves and logs all landed in the instance folder. The Documents profile stayed untouched.

**Not in this pull request:** the one line in `BoreaServices` (#70), the installer and the manifest writer asking `IsRunning` before they write (after #72), a CLI `launch` command, detecting a StarMap the user started by hand, and the format field for the handover, which is a design repo question.

LLM usage disclosure: Claude Fable 5.1 (and Opus 5 for an code review workflow) was used collaborativly with me to create parts of this code. I read, reviewed and tested all of it myself and like it.
