### PR TITLE
Install a mod loader per RFC 0035

### DIFF
--- a/src/Borea.Core/ModLoaders/ILoaderConfigurator.cs
+++ b/src/Borea.Core/ModLoaders/ILoaderConfigurator.cs
@@ -1,0 +1,27 @@
+using Borea.Core.Mods;
+
+namespace Borea.Core.ModLoaders;
+
+/// <summary>
+/// Writes the loader's own configuration file per <c>[provides.configure]</c>
+/// of RFC 0035.
+/// </summary>
+public interface ILoaderConfigurator
+{
+    /// <summary>
+    /// Writes the absolute game directory to the key <c>game-path</c> names, in
+    /// the file below <paramref name="loaderDirectory"/>, and returns the
+    /// file's absolute path, or null when the listing names no key.
+    /// </summary>
+    /// <exception cref="ArgumentException">The listing is not a mod loader, or a directory is not absolute.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The file cannot be read as its stated format, holds a key twice, or a
+    /// value sits where the key path expects a table.
+    /// </exception>
+    /// <exception cref="NotSupportedException">The listing names a format this configurator cannot write.</exception>
+    Task<string?> ConfigureAsync(
+        ModMetadata loader,
+        string loaderDirectory,
+        string gameDirectory,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Borea.Core/ModLoaders/ILoaderInstaller.cs
+++ b/src/Borea.Core/ModLoaders/ILoaderInstaller.cs
@@ -1,0 +1,55 @@
+using Borea.Core.Mods;
+
+namespace Borea.Core.ModLoaders;
+
+/// <summary>
+/// Installs one release of a mod loader per RFC 0035 and records its
+/// directory in the settings. Starting it is the launcher's job.
+/// </summary>
+public interface ILoaderInstaller
+{
+    /// <summary>
+    /// The stamped install decides where the loader goes; the live listing
+    /// decides what to launch and what to configure, because RFC 0035 never
+    /// stamps <c>[provides]</c>. A recorded loader is replaced in place and
+    /// keeps its configuration file. A failed first install removes what it
+    /// wrote.
+    /// </summary>
+    /// <param name="directory">
+    /// Where a standalone loader goes. Null means the recorded directory, or
+    /// Borea's own choice for a first install. Invalid for any other anchor.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// The listing is not a mod loader, the release does not belong to it, or
+    /// the directory does not fit the anchor.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// The destination holds foreign files, the loader is recorded elsewhere,
+    /// the game directory is not set, the archive is empty where the release
+    /// says, or the launch target is missing.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// The release is not a mod loader, or names an anchor, path, archive
+    /// format or configuration format this installer cannot perform.
+    /// </exception>
+    /// <exception cref="DownloadFailedException">No source served the archive.</exception>
+    Task<LoaderInstallResult> InstallAsync(
+        ModMetadata loader,
+        ModVersionMetadata release,
+        string? directory = null,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// What a loader install left behind.
+/// </summary>
+/// <param name="ConfigurationFile">The file that received the game path, or null.</param>
+/// <param name="Replaced">Whether a recorded install was replaced in place.</param>
+public sealed record LoaderInstallResult(
+    string LoaderId,
+    ModVersion Version,
+    string Directory,
+    DownloadResult Download,
+    string? ConfigurationFile,
+    bool Replaced);

--- a/src/Borea.Core/ModLoaders/ILoaderInstaller.cs
+++ b/src/Borea.Core/ModLoaders/ILoaderInstaller.cs
@@ -11,9 +11,9 @@ public interface ILoaderInstaller
     /// <summary>
     /// The stamped install decides where the loader goes; the live listing
     /// decides what to launch and what to configure, because RFC 0035 never
-    /// stamps <c>[provides]</c>. A recorded loader is replaced in place and
-    /// keeps its configuration file. A failed first install removes what it
-    /// wrote.
+    /// stamps <c>[provides]</c>. A recorded loader keeps its configuration
+    /// file, and its old directory is restored when replacement fails. A
+    /// failed first install removes what it wrote.
     /// </summary>
     /// <param name="directory">
     /// Where a standalone loader goes. Null means the recorded directory, or

--- a/src/Borea.Core/ModLoaders/LoaderConfigure.cs
+++ b/src/Borea.Core/ModLoaders/LoaderConfigure.cs
@@ -22,8 +22,8 @@ public sealed class LoaderConfigure
         if (string.IsNullOrWhiteSpace(file))
             throw new ArgumentException("The configuration file is required.", nameof(file));
 
-        if (gamePath is not null && string.IsNullOrWhiteSpace(gamePath))
-            throw new ArgumentException("The game path key, if provided, cannot be whitespace.", nameof(gamePath));
+        if (gamePath is not null && gamePath.Split('.').Any(string.IsNullOrWhiteSpace))
+            throw new ArgumentException("The game path key, if provided, is dot-separated segments, and none of them can be empty.", nameof(gamePath));
 
         File = RelativePaths.Contained(file, nameof(file))!;
         Format = format;

--- a/src/Borea.Core/Paths/IGamePathProvider.cs
+++ b/src/Borea.Core/Paths/IGamePathProvider.cs
@@ -17,6 +17,11 @@ public interface IGamePathProvider
     string GetInstancesRoot();
 
     /// <summary>
+    /// Root for loaders installed standalone (RFC 0035), one folder per loader id.
+    /// </summary>
+    string GetLoadersRoot();
+
+    /// <summary>
     /// Path to the file tracking which instance is currently selected for
     /// launch.
     /// </summary>

--- a/src/Borea.Storage/Files/AtomicFile.cs
+++ b/src/Borea.Storage/Files/AtomicFile.cs
@@ -1,0 +1,52 @@
+namespace Borea.Storage.Files;
+
+/// <summary>
+/// Writes a whole text file so a reader sees the old content or the new one,
+/// never a truncated file.
+/// </summary>
+internal static class AtomicFile
+{
+    /// <summary>
+    /// Writes UTF-8 without a byte order mark, creating the directory if
+    /// needed. Replaces an existing file, and leaves it untouched when the
+    /// write does not finish.
+    /// </summary>
+    /// <remarks>Not safe against a second writer of the same path.</remarks>
+    public static async Task WriteAllTextAsync(string path, string text, CancellationToken cancellationToken = default)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+
+        // Written beside the file and moved onto it: the move is atomic in one
+        // directory, and the unique name keeps a second writer off this file.
+        var tempPath = $"{path}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            await File.WriteAllTextAsync(tempPath, text, cancellationToken).ConfigureAwait(false);
+            File.Move(tempPath, path, overwrite: true);
+        }
+        finally
+        {
+            TryDeleteLeftover(tempPath);
+        }
+    }
+
+    /// <summary>
+    /// Clears the temporary file without replacing the error that caused it.
+    /// </summary>
+    private static void TryDeleteLeftover(string tempPath)
+    {
+        try
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/src/Borea.Storage/ModLoaders/FileLoaderInstaller.cs
+++ b/src/Borea.Storage/ModLoaders/FileLoaderInstaller.cs
@@ -1,0 +1,287 @@
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+using Borea.Core.Paths;
+using Borea.Core.Settings;
+using Borea.Storage.Mods;
+
+namespace Borea.Storage.ModLoaders;
+
+/// <summary>
+/// File-backed <see cref="ILoaderInstaller"/>.
+/// </summary>
+public sealed class FileLoaderInstaller : ILoaderInstaller
+{
+    private readonly IGamePathProvider _pathProvider;
+    private readonly IModDownloader _downloader;
+    private readonly IBoreaSettingsRepository _settings;
+    private readonly ILoaderConfigurator _configurator;
+
+    public FileLoaderInstaller(
+        IGamePathProvider pathProvider,
+        IModDownloader downloader,
+        IBoreaSettingsRepository settings,
+        ILoaderConfigurator configurator)
+    {
+        _pathProvider = pathProvider ?? throw new ArgumentNullException(nameof(pathProvider));
+        _downloader = downloader ?? throw new ArgumentNullException(nameof(downloader));
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _configurator = configurator ?? throw new ArgumentNullException(nameof(configurator));
+    }
+
+    public async Task<LoaderInstallResult> InstallAsync(
+        ModMetadata loader,
+        ModVersionMetadata release,
+        string? directory = null,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(loader);
+        ArgumentNullException.ThrowIfNull(release);
+        RequireInstallable(loader, release);
+
+        var settings = await _settings.GetAsync(cancellationToken).ConfigureAwait(false) ?? new BoreaSettings(null);
+        var recorded = settings.LoaderDirectoryPaths.TryGetValue(loader.ModId, out var known) ? Path.GetFullPath(known) : null;
+
+        var (target, path, root) = Describe(loader, release);
+        var destination = Resolve(loader, target, path, directory, recorded, settings.GameDirectoryPath);
+
+        var replacing = recorded is not null;
+        if (replacing && !SamePath(recorded!, destination))
+        {
+            throw new InvalidOperationException(
+                $"{loader.Name} is already installed at '{recorded}'. Install into that directory to replace it, remove it first, or correct its directory in the settings.");
+        }
+
+        if (!replacing && Directory.Exists(destination) && Directory.EnumerateFileSystemEntries(destination).Any())
+            throw new InvalidOperationException($"'{destination}' already holds files that Borea did not install.");
+
+        var configure = loader.Provides?.Configure;
+        var gameDirectory = settings.GameDirectoryPath;
+        if (configure?.GamePath is not null && gameDirectory is null)
+            throw new InvalidOperationException($"Borea does not know where the game is installed, so it cannot configure {loader.Name}. Set the game directory first.");
+
+        var configurationPath = configure is null
+            ? null
+            : Path.GetFullPath(Path.Combine(destination, configure.File.Replace('/', Path.DirectorySeparatorChar)));
+        var archivePath = Path.Combine(Path.GetTempPath(), $"borea-download-{Guid.NewGuid():N}.zip");
+        var created = !Directory.Exists(destination);
+
+        try
+        {
+            var download = await _downloader.DownloadAsync(release, archivePath, progress, cancellationToken).ConfigureAwait(false);
+
+            var kept = replacing && configurationPath is not null && File.Exists(configurationPath)
+                ? await File.ReadAllBytesAsync(configurationPath, cancellationToken).ConfigureAwait(false)
+                : null;
+
+            Unpack(archivePath, root, destination, release);
+            if (kept is not null)
+                await File.WriteAllBytesAsync(configurationPath!, kept, cancellationToken).ConfigureAwait(false);
+
+            RequireLaunchTarget(loader, release, destination);
+
+            var configurationFile = configure?.GamePath is null
+                ? null
+                : await _configurator.ConfigureAsync(loader, destination, gameDirectory!, cancellationToken).ConfigureAwait(false);
+
+            var paths = settings.LoaderDirectoryPaths.ToDictionary(p => p.Key, p => p.Value, ModIds.Comparer);
+            paths[loader.ModId] = destination;
+            await _settings.SaveAsync(new BoreaSettings(settings.GameDirectoryPath, paths), cancellationToken).ConfigureAwait(false);
+
+            return new LoaderInstallResult(loader.ModId, release.Version, destination, download, configurationFile, replacing);
+        }
+        catch
+        {
+            // A first install is taken back; a replacement is left as far as it got.
+            if (created)
+                TryDeleteDirectory(destination);
+            else if (!replacing)
+                TryClearDirectory(destination);
+
+            throw;
+        }
+        finally
+        {
+            TryDeleteFile(archivePath);
+        }
+    }
+
+    private static void RequireInstallable(ModMetadata loader, ModVersionMetadata release)
+    {
+        if (loader.Type != ContentType.ModLoader)
+            throw new ArgumentException($"'{loader.ModId}' is a {loader.Type}, and only a mod loader installs this way.", nameof(loader));
+
+        if (release.Type != ContentType.ModLoader)
+            throw new NotSupportedException($"'{release.ModId}' is a {release.Type}, and only a mod loader installs by its own descriptor.");
+
+        if (!ModIds.Equals(loader.ModId, release.ModId))
+            throw new ArgumentException($"The release belongs to '{release.ModId}' and not to '{loader.ModId}'.", nameof(release));
+
+        if (!ModArchive.IsZip(release.Download.ContentType))
+            throw new NotSupportedException($"'{release.ModId}' is served as '{release.Download.ContentType}', and only a zip archive can be unpacked.");
+
+        if (loader.Provides?.Configure is { Format: not (ConfigureFormat.Json or ConfigureFormat.Toml) })
+            throw new NotSupportedException($"The listing of {loader.Name} keeps its configuration in a format this version of Borea cannot write.");
+    }
+
+    private static (InstallAnchor? Target, string? Path, string? Root) Describe(ModMetadata loader, ModVersionMetadata release)
+    {
+        if (release.Install is { } stamped)
+            return (stamped.Target, stamped.Path, stamped.Root);
+
+        if (loader.Install is { } authored)
+            return (authored.Target, authored.Path, authored.Root);
+
+        return (null, null, null);
+    }
+
+    private string Resolve(ModMetadata loader, InstallAnchor? target, string? path, string? directory, string? recorded, string? gameDirectory)
+    {
+        switch (target)
+        {
+            case null:
+                throw new NotSupportedException($"The listing of {loader.Name} does not say where the loader goes, so Borea cannot install it and can only show its links.");
+
+            case InstallAnchor.Standalone:
+                if (directory is null && recorded is not null)
+                    return recorded;
+
+                var chosen = directory is null
+                    ? Path.Combine(_pathProvider.GetLoadersRoot(), loader.ModId)
+                    : Absolute(directory, nameof(directory));
+                return Below(chosen, path);
+
+            case InstallAnchor.GameRoot:
+                if (directory is not null)
+                    throw new ArgumentException($"Only a standalone loader lets Borea choose the directory; {loader.Name} goes below the game folder.", nameof(directory));
+
+                if (gameDirectory is null)
+                    throw new InvalidOperationException($"Borea does not know where the game is installed, so it cannot place {loader.Name}. Set the game directory first.");
+
+                var gameRoot = Absolute(gameDirectory, nameof(gameDirectory));
+                var placed = Below(gameRoot, path);
+                if (SamePath(placed, gameRoot))
+                    throw new NotSupportedException($"{loader.Name} installs into the game folder itself, which Borea cannot take back out again.");
+
+                return placed;
+
+            case InstallAnchor.Mods:
+            case InstallAnchor.UserData:
+                throw new NotSupportedException($"{loader.Name} installs into the {Anchor(target.Value)} of an instance, and Borea records a loader once and not per instance.");
+
+            default:
+                throw new NotSupportedException($"The listing of {loader.Name} names an install target this version of Borea does not know, so it must not guess.");
+        }
+    }
+
+    private static string Below(string anchor, string? path) =>
+        Path.TrimEndingDirectorySeparator(path is null
+            ? Path.GetFullPath(anchor)
+            : Path.GetFullPath(Path.Combine(anchor, path.Replace('/', Path.DirectorySeparatorChar))));
+
+    private static string Anchor(InstallAnchor anchor) => anchor == InstallAnchor.Mods ? "mods folder" : "user data root";
+
+    /// <summary>
+    /// No derived root for a loader (RFC 0035 rule 9).
+    /// </summary>
+    private static void Unpack(string archivePath, string? root, string destination, ModVersionMetadata release)
+    {
+        var files = ModArchive.Extract(archivePath, root, destination);
+        if (files == 0)
+        {
+            throw new InvalidOperationException(root is null
+                ? $"The archive of '{release.ModId}' {release.Version} holds no files."
+                : $"The archive of '{release.ModId}' {release.Version} holds nothing under '{root}'.");
+        }
+    }
+
+    /// <summary>
+    /// RFC 0035 rule 3: the launch target must be in the release.
+    /// </summary>
+    private static void RequireLaunchTarget(ModMetadata loader, ModVersionMetadata release, string destination)
+    {
+        var launch = loader.Provides?.Launch;
+        if (launch is null)
+            return;
+
+        var executable = Path.Combine(destination, launch.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(executable))
+        {
+            throw new InvalidOperationException(
+                $"The archive of '{release.ModId}' {release.Version} has no '{launch}' at its install root, so nothing could start {loader.Name}.");
+        }
+    }
+
+    private static string Absolute(string path, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("A directory is required.", paramName);
+
+        if (!Path.IsPathFullyQualified(path))
+            throw new ArgumentException("The directory must be absolute, because the loader resolves its own files against it.", paramName);
+
+        return Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+    }
+
+    private static bool SamePath(string left, string right)
+    {
+        var comparison = OperatingSystem.IsLinux() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+        return string.Equals(
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(left)),
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(right)),
+            comparison);
+    }
+
+    /// <summary>
+    /// Cleanup must not replace the error that caused it, here and below.
+    /// </summary>
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static void TryClearDirectory(string path)
+    {
+        try
+        {
+            foreach (var entry in Directory.EnumerateFileSystemEntries(path))
+            {
+                if (Directory.Exists(entry))
+                    Directory.Delete(entry, recursive: true);
+                else
+                    File.Delete(entry);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/src/Borea.Storage/ModLoaders/FileLoaderInstaller.cs
+++ b/src/Borea.Storage/ModLoaders/FileLoaderInstaller.cs
@@ -65,6 +65,10 @@ public sealed class FileLoaderInstaller : ILoaderInstaller
             : Path.GetFullPath(Path.Combine(destination, configure.File.Replace('/', Path.DirectorySeparatorChar)));
         var archivePath = Path.Combine(Path.GetTempPath(), $"borea-download-{Guid.NewGuid():N}.zip");
         var created = !Directory.Exists(destination);
+        var stagingDirectory = replacing ? TransactionPath(destination, "staging") : destination;
+        var backupDirectory = replacing ? TransactionPath(destination, "backup") : null;
+        var replacementActivated = false;
+        var replacementBackedUp = false;
 
         try
         {
@@ -74,26 +78,44 @@ public sealed class FileLoaderInstaller : ILoaderInstaller
                 ? await File.ReadAllBytesAsync(configurationPath, cancellationToken).ConfigureAwait(false)
                 : null;
 
-            Unpack(archivePath, root, destination, release);
+            Unpack(archivePath, root, stagingDirectory, release);
             if (kept is not null)
-                await File.WriteAllBytesAsync(configurationPath!, kept, cancellationToken).ConfigureAwait(false);
+            {
+                var stagedConfigurationPath = Path.GetFullPath(Path.Combine(stagingDirectory, configure!.File.Replace('/', Path.DirectorySeparatorChar)));
+                Directory.CreateDirectory(Path.GetDirectoryName(stagedConfigurationPath)!);
+                await File.WriteAllBytesAsync(stagedConfigurationPath, kept, cancellationToken).ConfigureAwait(false);
+            }
 
-            RequireLaunchTarget(loader, release, destination);
+            RequireLaunchTarget(loader, release, stagingDirectory);
 
-            var configurationFile = configure?.GamePath is null
+            var stagedConfigurationFile = configure?.GamePath is null
                 ? null
-                : await _configurator.ConfigureAsync(loader, destination, gameDirectory!, cancellationToken).ConfigureAwait(false);
+                : await _configurator.ConfigureAsync(loader, stagingDirectory, gameDirectory!, cancellationToken).ConfigureAwait(false);
+
+            var configurationFile = stagedConfigurationFile is null
+                ? null
+                : Path.GetFullPath(Path.Combine(destination, Path.GetRelativePath(stagingDirectory, stagedConfigurationFile)));
+
+            if (replacing)
+            {
+                replacementBackedUp = ActivateReplacement(destination, stagingDirectory, backupDirectory!);
+                replacementActivated = true;
+            }
 
             var paths = settings.LoaderDirectoryPaths.ToDictionary(p => p.Key, p => p.Value, ModIds.Comparer);
             paths[loader.ModId] = destination;
             await _settings.SaveAsync(new BoreaSettings(settings.GameDirectoryPath, paths), cancellationToken).ConfigureAwait(false);
 
+            if (replacementBackedUp)
+                TryDeleteDirectory(backupDirectory!);
+
             return new LoaderInstallResult(loader.ModId, release.Version, destination, download, configurationFile, replacing);
         }
-        catch
+        catch (Exception installError)
         {
-            // A first install is taken back; a replacement is left as far as it got.
-            if (created)
+            if (replacementActivated)
+                RestoreReplacement(destination, backupDirectory!, replacementBackedUp, installError);
+            else if (created && !replacing)
                 TryDeleteDirectory(destination);
             else if (!replacing)
                 TryClearDirectory(destination);
@@ -103,6 +125,72 @@ public sealed class FileLoaderInstaller : ILoaderInstaller
         finally
         {
             TryDeleteFile(archivePath);
+            if (replacing)
+                TryDeleteDirectory(stagingDirectory);
+        }
+    }
+
+    private static string TransactionPath(string destination, string purpose)
+    {
+        var parent = Path.GetDirectoryName(destination);
+        var name = Path.GetFileName(destination);
+        if (string.IsNullOrEmpty(parent) || string.IsNullOrEmpty(name))
+            throw new NotSupportedException("A loader installed at a file-system root cannot be replaced safely.");
+
+        return Path.Combine(parent, $".{name}.borea-{purpose}-{Guid.NewGuid():N}");
+    }
+
+    private static bool ActivateReplacement(string destination, string stagingDirectory, string backupDirectory)
+    {
+        var backedUp = Directory.Exists(destination);
+        if (backedUp)
+            Directory.Move(destination, backupDirectory);
+
+        try
+        {
+            Directory.Move(stagingDirectory, destination);
+            return backedUp;
+        }
+        catch (Exception activationError)
+        {
+            if (!backedUp)
+                throw;
+
+            try
+            {
+                Directory.Move(backupDirectory, destination);
+            }
+            catch (Exception rollbackError)
+            {
+                throw new AggregateException(
+                    "The loader replacement could not be activated, and Borea could not restore the previous directory.",
+                    activationError,
+                    rollbackError);
+            }
+
+            throw;
+        }
+    }
+
+    private static void RestoreReplacement(string destination, string backupDirectory, bool backedUp, Exception installError)
+    {
+        var failedDirectory = TransactionPath(destination, "failed");
+        try
+        {
+            if (Directory.Exists(destination))
+                Directory.Move(destination, failedDirectory);
+
+            if (backedUp)
+                Directory.Move(backupDirectory, destination);
+
+            TryDeleteDirectory(failedDirectory);
+        }
+        catch (Exception rollbackError)
+        {
+            throw new AggregateException(
+                "The loader replacement failed, and Borea could not restore the previous directory.",
+                installError,
+                rollbackError);
         }
     }
 

--- a/src/Borea.Storage/ModLoaders/LoaderConfigurator.cs
+++ b/src/Borea.Storage/ModLoaders/LoaderConfigurator.cs
@@ -1,0 +1,196 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+using Borea.Storage.Files;
+using Tomlyn;
+using Tomlyn.Model;
+using Tomlyn.Parsing;
+using Tomlyn.Serialization;
+
+namespace Borea.Storage.ModLoaders;
+
+/// <summary>
+/// The file is read as a tree, the one key is set, and the tree is written
+/// back, so every other key survives.
+/// </summary>
+public sealed class LoaderConfigurator : ILoaderConfigurator
+{
+    private static readonly JsonDocumentOptions JsonReadOptions = new()
+    {
+        CommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+        // Refused at the parse, where the error names the file.
+        AllowDuplicateProperties = false,
+    };
+
+    private static readonly JsonSerializerOptions JsonWriteOptions = new() { WriteIndented = true };
+
+    public async Task<string?> ConfigureAsync(
+        ModMetadata loader,
+        string loaderDirectory,
+        string gameDirectory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(loader);
+
+        if (loader.Type != ContentType.ModLoader)
+            throw new ArgumentException("Only a mod loader has a configuration file to write.", nameof(loader));
+
+        var directory = Absolute(loaderDirectory, nameof(loaderDirectory));
+        var game = Path.TrimEndingDirectorySeparator(Absolute(gameDirectory, nameof(gameDirectory)));
+
+        var configure = loader.Provides?.Configure;
+        if (configure?.GamePath is null)
+            return null;
+
+        if (configure.Format is not (ConfigureFormat.Json or ConfigureFormat.Toml))
+            throw new NotSupportedException($"The listing of {loader.Name} keeps its configuration in a format this version of Borea cannot write.");
+
+        var keys = configure.GamePath.Split('.');
+        var file = Path.GetFullPath(Path.Combine(directory, configure.File.Replace('/', Path.DirectorySeparatorChar)));
+        var text = File.Exists(file)
+            ? await File.ReadAllTextAsync(file, cancellationToken).ConfigureAwait(false)
+            : null;
+
+        var written = configure.Format == ConfigureFormat.Json
+            ? SetJson(text, keys, game, file, loader)
+            : SetToml(text, keys, game, file, loader);
+
+        await AtomicFile.WriteAllTextAsync(file, written, cancellationToken).ConfigureAwait(false);
+        return file;
+    }
+
+    private static string SetJson(string? text, string[] keys, string value, string file, ModMetadata loader)
+    {
+        JsonObject root;
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            root = new JsonObject();
+        }
+        else
+        {
+            JsonNode? node;
+            try
+            {
+                node = JsonNode.Parse(text, documentOptions: JsonReadOptions);
+            }
+            catch (JsonException exception)
+            {
+                throw new InvalidOperationException($"'{file}' is not valid JSON, so Borea cannot configure {loader.Name} without destroying it. {exception.Message}", exception);
+            }
+
+            root = node as JsonObject
+                ?? throw new InvalidOperationException($"'{file}' does not hold a JSON object at its root, so there is nowhere to put the game path.");
+        }
+
+        var table = root;
+        for (var i = 0; i < keys.Length - 1; i++)
+        {
+            switch (table[keys[i]])
+            {
+                case JsonObject child:
+                    table = child;
+                    break;
+                case null:
+                    var created = new JsonObject();
+                    table[keys[i]] = created;
+                    table = created;
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"'{file}' holds a value at '{string.Join('.', keys.Take(i + 1))}' where the listing of {loader.Name} expects an object.");
+            }
+        }
+
+        table[keys[^1]] = value;
+        return root.ToJsonString(JsonWriteOptions) + Environment.NewLine;
+    }
+
+    private static string SetToml(string? text, string[] keys, string value, string file, ModMetadata loader)
+    {
+        // One store for read and write keeps the comments of the file.
+        var options = new TomlSerializerOptions { MetadataStore = new TomlMetadataStore() };
+
+        TomlTable root;
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            root = new TomlTable();
+        }
+        else
+        {
+            try
+            {
+                // The table model keeps the last value of a repeated key.
+                if (DuplicateKey(text, options) is { } duplicate)
+                    throw new InvalidOperationException($"'{file}' holds the key '{duplicate}' twice, so Borea cannot configure {loader.Name} without dropping one of them.");
+
+                root = TomlSerializer.Deserialize<TomlTable>(text, options) ?? new TomlTable();
+            }
+            catch (TomlException exception)
+            {
+                throw new InvalidOperationException($"'{file}' is not valid TOML, so Borea cannot configure {loader.Name} without destroying it. {exception.Message}", exception);
+            }
+        }
+
+        var table = root;
+        for (var i = 0; i < keys.Length - 1; i++)
+        {
+            if (table.TryGetValue(keys[i], out var existing))
+            {
+                table = existing as TomlTable
+                    ?? throw new InvalidOperationException(
+                        $"'{file}' holds a value at '{string.Join('.', keys.Take(i + 1))}' where the listing of {loader.Name} expects a table.");
+            }
+            else
+            {
+                var created = new TomlTable();
+                table[keys[i]] = created;
+                table = created;
+            }
+        }
+
+        table[keys[^1]] = value;
+        return TomlSerializer.Serialize(root, options);
+    }
+
+    /// <summary>
+    /// The parser merges dotted keys and repeated headers into one table, and
+    /// each table array member is a table of its own.
+    /// </summary>
+    private static string? DuplicateKey(string text, TomlSerializerOptions options)
+    {
+        var parser = TomlParser.Create(text, options);
+        var scopes = new Stack<HashSet<string>>();
+        while (parser.MoveNext())
+        {
+            switch (parser.Current.Kind)
+            {
+                case TomlParseEventKind.StartTable:
+                    scopes.Push(new HashSet<string>(StringComparer.Ordinal));
+                    break;
+                case TomlParseEventKind.EndTable:
+                    scopes.Pop();
+                    break;
+                case TomlParseEventKind.PropertyName:
+                    var name = parser.GetPropertyName();
+                    if (!scopes.Peek().Add(name))
+                        return name;
+                    break;
+            }
+        }
+
+        return null;
+    }
+
+    private static string Absolute(string path, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("A path is required.", paramName);
+
+        if (!Path.IsPathFullyQualified(path))
+            throw new ArgumentException("The path must be absolute, because the loader resolves it in its own working directory.", paramName);
+
+        return Path.GetFullPath(path);
+    }
+}

--- a/src/Borea.Storage/Mods/FileModInstaller.cs
+++ b/src/Borea.Storage/Mods/FileModInstaller.cs
@@ -12,8 +12,6 @@ namespace Borea.Storage.Mods;
 /// </summary>
 public sealed class FileModInstaller : IModInstaller
 {
-    private static readonly string[] ZipContentTypes = { "application/zip", "application/x-zip-compressed" };
-
     private readonly IGamePathProvider _pathProvider;
     private readonly IModDownloader _downloader;
     private readonly IInstanceRepository _instances;
@@ -115,7 +113,7 @@ public sealed class FileModInstaller : IModInstaller
                 throw new NotSupportedException($"'{release.ModId}' installs below '{install.Path}', where the game does not look for a mod.");
         }
 
-        if (!ZipContentTypes.Contains(release.Download.ContentType, StringComparer.OrdinalIgnoreCase))
+        if (!ModArchive.IsZip(release.Download.ContentType))
             throw new NotSupportedException($"'{release.ModId}' is served as '{release.Download.ContentType}', and only a zip archive can be unpacked.");
     }
 

--- a/src/Borea.Storage/Mods/ModArchive.cs
+++ b/src/Borea.Storage/Mods/ModArchive.cs
@@ -7,6 +7,13 @@ namespace Borea.Storage.Mods;
 /// </summary>
 internal static class ModArchive
 {
+    private static readonly string[] ZipContentTypes = { "application/zip", "application/x-zip-compressed" };
+
+    /// <summary>
+    /// The second media type is what some hosts send for the same bytes.
+    /// </summary>
+    public static bool IsZip(string contentType) => ZipContentTypes.Contains(contentType, StringComparer.OrdinalIgnoreCase);
+
     /// <summary>
     /// The root RFC 0035 rule 9 derives for a mod whose release states none:
     /// the one top-level directory that holds a mod.toml. Any other layout,
@@ -70,7 +77,7 @@ internal static class ModArchive
 
             var target = Path.GetFullPath(Path.Combine(destinationRoot, relative));
             if (!target.StartsWith(inside, StringComparison.Ordinal))
-                throw new InvalidOperationException($"The archive entry '{entry.FullName}' would land outside the mod folder.");
+                throw new InvalidOperationException($"The archive entry '{entry.FullName}' would land outside the install folder.");
 
             if (relative.EndsWith('/'))
             {

--- a/src/Borea.Storage/Paths/GamePathProvider.cs
+++ b/src/Borea.Storage/Paths/GamePathProvider.cs
@@ -42,6 +42,7 @@ public sealed class GamePathProvider : IGamePathProvider
 
     public string GetIndexPath() => Path.Combine(_boreaRoot, "index.json");
     public string GetInstancesRoot() => Path.Combine(_boreaRoot, "Instances");
+    public string GetLoadersRoot() => Path.Combine(_boreaRoot, "Loaders");
     public string GetInstanceRoot(Guid instanceId) => Path.Combine(GetInstancesRoot(), instanceId.ToString());
     public string GetInstanceModsFolder(Guid instanceId) => Path.Combine(GetInstanceRoot(instanceId), "mods");
     public string GetInstanceSavesFolder(Guid instanceId) => Path.Combine(GetInstanceRoot(instanceId), "saves");

--- a/src/Borea.Storage/Toml/TomlFileStore.cs
+++ b/src/Borea.Storage/Toml/TomlFileStore.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using Borea.Storage.Files;
 using Tomlyn;
 using Tomlyn.Serialization;
 
@@ -44,7 +45,8 @@ public static class TomlFileStore
     /// Serializes <paramref name="value"/> to TOML and writes it to
     /// <paramref name="path"/>, creating the containing directory if needed.
     /// Replaces any existing file, and leaves it untouched when the write does
-    /// not finish.
+    /// not finish; the game reads manifest.toml in ModLibrary with no error
+    /// handling.
     /// </summary>
     /// <remarks>Not safe against a second writer of the same path.</remarks>
     public static async Task WriteAsync<T>(string path, T value, CancellationToken cancellationToken = default)
@@ -53,45 +55,8 @@ public static class TomlFileStore
         if (value is null)
             throw new ArgumentNullException(nameof(value));
 
-        var directory = Path.GetDirectoryName(path);
-        if (!string.IsNullOrEmpty(directory))
-            Directory.CreateDirectory(directory);
-
         var text = TomlSerializer.Serialize(value, Options);
-
-        // Written beside the file and moved onto it, because writing in place
-        // truncates first and the game parses manifest.toml with no error
-        // handling. Same directory, so the move is atomic. The name is unique per
-        // write, so a second writer cannot delete this one's temporary file.
-        var tempPath = $"{path}.{Guid.NewGuid():N}.tmp";
-        try
-        {
-            await File.WriteAllTextAsync(tempPath, text, cancellationToken).ConfigureAwait(false);
-            File.Move(tempPath, path, overwrite: true);
-        }
-        finally
-        {
-            TryDeleteLeftover(tempPath);
-        }
-    }
-
-    /// <summary>
-    /// Clears the temporary file when the write did not reach the move, without
-    /// replacing the error that caused it.
-    /// </summary>
-    private static void TryDeleteLeftover(string tempPath)
-    {
-        try
-        {
-            if (File.Exists(tempPath))
-                File.Delete(tempPath);
-        }
-        catch (IOException)
-        {
-        }
-        catch (UnauthorizedAccessException)
-        {
-        }
+        await AtomicFile.WriteAllTextAsync(path, text, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/tests/Borea.Core.Tests/ModLoaders/LoaderProvidesTests.cs
+++ b/tests/Borea.Core.Tests/ModLoaders/LoaderProvidesTests.cs
@@ -74,6 +74,17 @@ public sealed class LoaderProvidesTests
         Assert.Throws<ArgumentException>(() => new LoaderConfigure("../StarMapConfig.json", ConfigureFormat.Json));
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("a..b")]
+    [InlineData("a.")]
+    [InlineData(".a")]
+    public void Configure_GamePathKeyWithAnEmptySegment_ThrowsArgumentException(string gamePath)
+    {
+        Assert.Throws<ArgumentException>(() => new LoaderConfigure("Config.json", ConfigureFormat.Json, gamePath));
+    }
+
     [Fact]
     public void Configure_NestedGamePathKey_IsAccepted()
     {

--- a/tests/Borea.Storage.Tests/ModLoaders/FileLoaderInstallerTests.cs
+++ b/tests/Borea.Storage.Tests/ModLoaders/FileLoaderInstallerTests.cs
@@ -1,0 +1,755 @@
+using System.Security.Cryptography;
+using System.Text.Json.Nodes;
+using Borea.Core.Dependencies;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+using Borea.Core.Settings;
+using Borea.Storage.ModLoaders;
+using Borea.Storage.Settings;
+using Borea.Storage.Tests.Mods;
+using Borea.Storage.Tests.Paths;
+
+namespace Borea.Storage.Tests.ModLoaders;
+
+public sealed class FileLoaderInstallerTests : IDisposable
+{
+    private const string LoaderId = "StarMap";
+
+    private static readonly IReadOnlyDictionary<string, string> Links = new Dictionary<string, string>
+    {
+        ["forums"] = "https://forums.ahwoo.com/threads/starmap-mod-loader.384/",
+        ["repository"] = "https://github.com/StarMapLoader/StarMap",
+        ["bugtracker"] = "https://github.com/StarMapLoader/StarMap/issues",
+    };
+
+    private static readonly LoaderConfigure StarMapConfigure = new("StarMapConfig.json", ConfigureFormat.Json, "GameLocation");
+
+    private static readonly InstallInfo StandaloneStamp = new(null, derived: true, target: InstallAnchor.Standalone);
+
+    private readonly string _tempRoot;
+    private readonly string _gameDirectory;
+    private readonly TestGamePathProvider _pathProvider;
+    private readonly FileBoreaSettingsRepository _settings;
+    private readonly FakeModDownloader _downloader = new();
+    private readonly FileLoaderInstaller _installer;
+
+    public FileLoaderInstallerTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+        _gameDirectory = Path.Combine(_tempRoot, "Game");
+        _pathProvider = new TestGamePathProvider(_tempRoot);
+        _settings = new FileBoreaSettingsRepository(_pathProvider);
+        _installer = new FileLoaderInstaller(_pathProvider, _downloader, _settings, new LoaderConfigurator());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+
+    private string DefaultDirectory => Path.Combine(_pathProvider.GetLoadersRoot(), LoaderId);
+
+    private static string ConfigPath(string directory) => Path.Combine(directory, "StarMapConfig.json");
+
+    /// <summary>The live StarMap listing of the index, as of 2026-09-04.</summary>
+    private static ModMetadata StarMap() => Listing(Standalone(), Provides(StarMapConfigure));
+
+    private static ModMetadata Listing(
+        InstallDescriptor? install,
+        LoaderProvides? provides,
+        ContentType type = ContentType.ModLoader,
+        string id = LoaderId) => new(
+        specVersion: 1,
+        modId: id,
+        source: "index",
+        name: "StarMap",
+        authors: new[] { "KlaasWhite" },
+        abstractText: "Mod loader that runs code mods for Kitten Space Agency.",
+        license: "MIT",
+        links: Links,
+        gameMin: "2026.8.3.5117",
+        type: type,
+        tags: new[] { "library" },
+        install: install,
+        provides: provides);
+
+    private static InstallDescriptor Standalone() => new(
+        target: InstallAnchor.Standalone,
+        uninstall: new[] { "Delete the StarMap directory. The game runs unmodded again with no further cleanup." });
+
+    private static LoaderProvides Provides(LoaderConfigure? configure, string? launch = "StarMap.exe") =>
+        new(launch, InstallAnchor.Mods, configure: configure);
+
+    /// <summary>StarMap 0.4.6 as stamped in the index.</summary>
+    private static ModVersionMetadata Release(
+        InstallInfo? install,
+        string version = "0.4.6",
+        ContentType type = ContentType.ModLoader,
+        string contentType = "application/zip",
+        string id = LoaderId) => new(
+        specVersion: 1,
+        modId: id,
+        version: ModVersion.Parse(version),
+        releaseStatus: ReleaseStatus.Stable,
+        releaseDate: new DateTimeOffset(2026, 8, 2, 16, 47, 50, TimeSpan.Zero),
+        gameMin: "2026.8.3.5117",
+        gameMinRevision: 5117,
+        download: new DownloadInfo(
+            $"https://github.com/StarMapLoader/StarMap/releases/download/{version}/StarMap-{version}.zip",
+            "BC9510994DAF56FD826B734EF0F2704C8E4D1B91BCF010C76733E168CC23604A",
+            891020,
+            contentType),
+        installSizeBytes: 2549644,
+        dependencies: Array.Empty<ModDependency>(),
+        type: type,
+        install: install,
+        changelog: $"https://github.com/StarMapLoader/StarMap/releases/tag/{version}");
+
+    private static ModVersionMetadata StarMapRelease(string version = "0.4.6") => Release(StandaloneStamp, version);
+
+    /// <summary>The flat layout of the StarMap release archive.</summary>
+    private static byte[] StarMapZip(string exe = "exe", params (string Path, string Content)[] extra) =>
+        TestArchives.Build(new[]
+        {
+            ("StarMap.exe", exe),
+            ("StarMap.dll", "dll"),
+            ("0Harmony.dll", "harmony"),
+            ("StarMap.runtimeconfig.json", "{}"),
+        }.Concat(extra).ToArray());
+
+    private Task SaveSettingsAsync(string? gameDirectory, IReadOnlyDictionary<string, string>? loaders = null) =>
+        _settings.SaveAsync(new BoreaSettings(gameDirectory, loaders));
+
+    private Task SaveGameDirectoryAsync() => SaveSettingsAsync(_gameDirectory);
+
+    private Task<LoaderInstallResult> InstallAsync(ModMetadata? loader = null, ModVersionMetadata? release = null, string? directory = null) =>
+        _installer.InstallAsync(loader ?? StarMap(), release ?? StarMapRelease(), directory);
+
+    private async Task<string?> RecordedDirectoryAsync()
+    {
+        var settings = await _settings.GetAsync();
+        return settings is not null && settings.LoaderDirectoryPaths.TryGetValue(LoaderId, out var path) ? path : null;
+    }
+
+    private static async Task<JsonObject> ReadConfigAsync(string directory) =>
+        (JsonObject)JsonNode.Parse(await File.ReadAllTextAsync(ConfigPath(directory)))!;
+
+    private async Task AssertNothingInstalledAsync()
+    {
+        Assert.False(Directory.Exists(DefaultDirectory));
+        Assert.Null(await RecordedDirectoryAsync());
+        Assert.All(_downloader.ArchivePaths, path => Assert.False(File.Exists(path)));
+    }
+
+    #region The real listing
+
+    [Fact]
+    public async Task InstallAsync_StarMap_UnpacksBelowTheLoadersRootAndRecordsIt()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = StarMapZip();
+
+        var result = await InstallAsync();
+
+        Assert.Equal(DefaultDirectory, result.Directory);
+        Assert.Equal(
+            new[] { "0Harmony.dll", "StarMap.dll", "StarMap.exe", "StarMap.runtimeconfig.json", "StarMapConfig.json" },
+            Directory.EnumerateFileSystemEntries(DefaultDirectory).Select(entry => Path.GetFileName(entry)).Order(StringComparer.Ordinal));
+        Assert.Equal(DefaultDirectory, await RecordedDirectoryAsync());
+        Assert.Equal(LoaderId, result.LoaderId);
+        Assert.Equal(ModVersion.Parse("0.4.6"), result.Version);
+        Assert.False(result.Replaced);
+        Assert.Equal(StarMapRelease().Download.Url, result.Download.Url);
+        Assert.Equal(Convert.ToHexString(SHA256.HashData(_downloader.Bytes)), result.Download.Sha256);
+        Assert.Single(_downloader.ArchivePaths);
+    }
+
+    [Fact]
+    public async Task InstallAsync_StarMap_WritesTheGameLocation()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = StarMapZip();
+
+        var result = await InstallAsync();
+
+        Assert.Equal(ConfigPath(DefaultDirectory), result.ConfigurationFile);
+        var config = await ReadConfigAsync(DefaultDirectory);
+        Assert.Equal(_gameDirectory, (string?)config["GameLocation"]);
+    }
+
+    [Fact]
+    public async Task InstallAsync_ArchiveShipsAConfiguration_ItsOtherKeysSurvive()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = StarMapZip(extra: ("StarMapConfig.json", """
+            {
+              "GameLocation": "",
+              "RepositoryLocation": "",
+              "GameArguments": []
+            }
+            """));
+
+        await InstallAsync();
+
+        var config = await ReadConfigAsync(DefaultDirectory);
+        Assert.Equal(_gameDirectory, (string?)config["GameLocation"]);
+        Assert.Equal(string.Empty, (string?)config["RepositoryLocation"]);
+        Assert.Empty(config["GameArguments"]!.AsArray());
+    }
+
+    [Fact]
+    public async Task InstallAsync_RecordedLoader_ReplacesInPlaceAndKeepsTheConfiguration()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = StarMapZip(exe: "old");
+        await InstallAsync();
+
+        // The user pointed StarMap at a repository and added an argument by hand.
+        await File.WriteAllTextAsync(ConfigPath(DefaultDirectory), $$"""
+            {
+              "GameLocation": "{{_gameDirectory.Replace(@"\", @"\\")}}",
+              "RepositoryLocation": "C:\\Repos",
+              "GameArguments": ["-Verbose"]
+            }
+            """);
+        _downloader.Bytes = StarMapZip(exe: "new");
+
+        var result = await InstallAsync(release: StarMapRelease("0.4.7"));
+
+        Assert.True(result.Replaced);
+        Assert.Equal(DefaultDirectory, result.Directory);
+        Assert.Equal("new", await File.ReadAllTextAsync(Path.Combine(DefaultDirectory, "StarMap.exe")));
+        var config = await ReadConfigAsync(DefaultDirectory);
+        Assert.Equal(_gameDirectory, (string?)config["GameLocation"]);
+        Assert.Equal(@"C:\Repos", (string?)config["RepositoryLocation"]);
+        Assert.Equal("-Verbose", (string?)config["GameArguments"]![0]);
+        Assert.Single((await _settings.GetAsync())!.LoaderDirectoryPaths);
+    }
+
+    [Fact]
+    public async Task InstallAsync_ReplacementArchiveShipsAConfiguration_TheUsersFileIsKept()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = StarMapZip();
+        await InstallAsync();
+        await File.WriteAllTextAsync(ConfigPath(DefaultDirectory), $$"""
+            { "GameLocation": "{{_gameDirectory.Replace(@"\", @"\\")}}", "RepositoryLocation": "C:\\Repos" }
+            """);
+        _downloader.Bytes = StarMapZip(extra: ("StarMapConfig.json", """{ "GameLocation": "", "Fresh": true }"""));
+
+        await InstallAsync(release: StarMapRelease("0.4.7"));
+
+        var config = await ReadConfigAsync(DefaultDirectory);
+        Assert.Equal(_gameDirectory, (string?)config["GameLocation"]);
+        Assert.Equal(@"C:\Repos", (string?)config["RepositoryLocation"]);
+        Assert.False(config.ContainsKey("Fresh"));
+    }
+
+    [Fact]
+    public async Task InstallAsync_RecordedUnderTheIdInOtherCase_ReplacesThatRecord()
+    {
+        var elsewhere = Path.Combine(_tempRoot, "Elsewhere");
+        await SaveSettingsAsync(_gameDirectory, new Dictionary<string, string> { ["starmap"] = elsewhere });
+        _downloader.Bytes = StarMapZip();
+
+        var result = await InstallAsync();
+
+        Assert.Equal(elsewhere, result.Directory);
+        Assert.True(result.Replaced);
+        Assert.True(File.Exists(Path.Combine(elsewhere, "StarMap.exe")));
+        Assert.Single((await _settings.GetAsync())!.LoaderDirectoryPaths);
+    }
+
+    [Fact]
+    public async Task InstallAsync_KeepsTheOtherLoadersInTheSettings()
+    {
+        await SaveSettingsAsync(_gameDirectory, new Dictionary<string, string> { ["Cheese-Loader"] = @"C:\Games\Cheese" });
+        _downloader.Bytes = StarMapZip();
+
+        await InstallAsync();
+
+        var settings = await _settings.GetAsync();
+        Assert.Equal(_gameDirectory, settings!.GameDirectoryPath);
+        Assert.Equal(@"C:\Games\Cheese", settings.LoaderDirectoryPaths["Cheese-Loader"]);
+        Assert.Equal(DefaultDirectory, settings.LoaderDirectoryPaths[LoaderId]);
+    }
+
+    #endregion
+
+    #region Where it goes
+
+    [Fact]
+    public async Task InstallAsync_GivenDirectory_InstallsThereAndRecordsIt()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = StarMapZip();
+        var chosen = Path.Combine(_tempRoot, "Tools", "My StarMap");
+
+        var result = await InstallAsync(directory: chosen);
+
+        Assert.Equal(chosen, result.Directory);
+        Assert.True(File.Exists(Path.Combine(chosen, "StarMap.exe")));
+        Assert.Equal(chosen, await RecordedDirectoryAsync());
+    }
+
+    [Fact]
+    public async Task InstallAsync_RelativeDirectory_ThrowsArgumentException()
+    {
+        await SaveGameDirectoryAsync();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => InstallAsync(directory: "Tools/StarMap"));
+
+        Assert.Empty(_downloader.ArchivePaths);
+    }
+
+    [Fact]
+    public async Task InstallAsync_RecordedElsewhere_GivenAnotherDirectory_Refuses()
+    {
+        var elsewhere = Path.Combine(_tempRoot, "Elsewhere");
+        await SaveSettingsAsync(_gameDirectory, new Dictionary<string, string> { [LoaderId] = elsewhere });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => InstallAsync(directory: Path.Combine(_tempRoot, "Other")));
+
+        Assert.Contains(elsewhere, ex.Message);
+        Assert.Empty(_downloader.ArchivePaths);
+    }
+
+    [Fact]
+    public async Task InstallAsync_RecordedLoader_GivenItsOwnDirectory_Replaces()
+    {
+        var elsewhere = Path.Combine(_tempRoot, "Elsewhere");
+        await SaveSettingsAsync(_gameDirectory, new Dictionary<string, string> { [LoaderId] = elsewhere });
+        _downloader.Bytes = StarMapZip();
+
+        // The same directory, written with a trailing separator.
+        var result = await InstallAsync(directory: elsewhere + Path.DirectorySeparatorChar);
+
+        Assert.True(result.Replaced);
+        Assert.Equal(elsewhere, result.Directory);
+        Assert.True(File.Exists(Path.Combine(elsewhere, "StarMap.exe")));
+        Assert.Equal(elsewhere, await RecordedDirectoryAsync());
+    }
+
+    [Fact]
+    public async Task InstallAsync_DirectoryHoldsFilesBoreaDidNotInstall_Refuses()
+    {
+        await SaveGameDirectoryAsync();
+        Directory.CreateDirectory(DefaultDirectory);
+        var foreign = Path.Combine(DefaultDirectory, "StarMap.exe");
+        await File.WriteAllTextAsync(foreign, "installed by hand");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => InstallAsync());
+
+        Assert.Empty(_downloader.ArchivePaths);
+        Assert.Equal("installed by hand", await File.ReadAllTextAsync(foreign));
+        Assert.Null(await RecordedDirectoryAsync());
+    }
+
+    [Fact]
+    public async Task InstallAsync_EmptyExistingDirectory_Installs()
+    {
+        await SaveGameDirectoryAsync();
+        Directory.CreateDirectory(DefaultDirectory);
+        _downloader.Bytes = StarMapZip();
+
+        await InstallAsync();
+
+        Assert.True(File.Exists(Path.Combine(DefaultDirectory, "StarMap.exe")));
+    }
+
+    [Fact]
+    public async Task InstallAsync_StatedRoot_UnpacksOnlyThatDirectory()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = TestArchives.Build(
+            ("StarMap-0.4.6/StarMap.exe", "exe"),
+            ("StarMap-0.4.6/StarMap.dll", "dll"),
+            ("README.md", "beside the root"));
+
+        await InstallAsync(release: Release(new InstallInfo("StarMap-0.4.6", derived: false, target: InstallAnchor.Standalone)));
+
+        Assert.True(File.Exists(Path.Combine(DefaultDirectory, "StarMap.exe")));
+        Assert.False(File.Exists(Path.Combine(DefaultDirectory, "README.md")));
+        Assert.False(Directory.Exists(Path.Combine(DefaultDirectory, "StarMap-0.4.6")));
+    }
+
+    [Fact]
+    public async Task InstallAsync_StatedRootNotInTheArchive_FailsAndLeavesNothing()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = StarMapZip();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => InstallAsync(release: Release(new InstallInfo("elsewhere", derived: false, target: InstallAnchor.Standalone))));
+
+        Assert.Contains("elsewhere", ex.Message);
+        await AssertNothingInstalledAsync();
+    }
+
+    [Fact]
+    public async Task InstallAsync_LaunchTargetInASubdirectory_IsFoundWithTheSeparatorTranslated()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = TestArchives.Build(("bin/StarMap.exe", "exe"), ("bin/StarMap.dll", "dll"));
+        var provides = new LoaderProvides("bin/StarMap.exe", InstallAnchor.Mods, configure: StarMapConfigure);
+
+        await InstallAsync(loader: Listing(Standalone(), provides));
+
+        Assert.True(File.Exists(Path.Combine(DefaultDirectory, "bin", "StarMap.exe")));
+    }
+
+    [Fact]
+    public async Task InstallAsync_NoLaunchTarget_NeedsNoExecutable()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = TestArchives.Build(("StarMap.dll", "a library the game loads itself"));
+        var stamp = new InstallInfo(null, derived: false, target: InstallAnchor.GameRoot, path: "StarMap");
+        var loader = Listing(new InstallDescriptor(target: InstallAnchor.GameRoot, path: "StarMap"), Provides(StarMapConfigure, launch: null));
+
+        var result = await InstallAsync(loader: loader, release: Release(stamp));
+
+        Assert.True(File.Exists(Path.Combine(result.Directory, "StarMap.dll")));
+    }
+
+    [Fact]
+    public async Task InstallAsync_WrappingDirectoryWithoutAStatedRoot_IsNotDerivedForALoader()
+    {
+        // RFC 0035 rule 9: only a mod derives its wrapping directory as the root.
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = TestArchives.Build(("StarMap/StarMap.exe", "exe"), ("StarMap/StarMap.dll", "dll"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => InstallAsync());
+
+        Assert.Contains("StarMap.exe", ex.Message);
+        await AssertNothingInstalledAsync();
+    }
+
+    [Fact]
+    public async Task InstallAsync_ReleaseWithoutAStampedInstall_FollowsTheListing()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = StarMapZip();
+
+        var result = await InstallAsync(release: Release(install: null));
+
+        Assert.Equal(DefaultDirectory, result.Directory);
+        Assert.True(File.Exists(Path.Combine(DefaultDirectory, "StarMap.exe")));
+    }
+
+    [Fact]
+    public async Task InstallAsync_GameRootWithAPath_InstallsBelowTheGameDirectory()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = StarMapZip();
+        var expected = Path.Combine(_gameDirectory, "Loaders", "StarMap");
+
+        var result = await InstallAsync(release: Release(new InstallInfo(null, derived: false, target: InstallAnchor.GameRoot, path: "Loaders/StarMap")));
+
+        Assert.Equal(expected, result.Directory);
+        Assert.True(File.Exists(Path.Combine(expected, "StarMap.exe")));
+        Assert.Equal(expected, await RecordedDirectoryAsync());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(".")]
+    [InlineData("./")]
+    public async Task InstallAsync_GameRootWithoutAPathBelowIt_IsNotSupported(string? path)
+    {
+        await SaveGameDirectoryAsync();
+
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => InstallAsync(release: Release(new InstallInfo(null, derived: false, target: InstallAnchor.GameRoot, path: path))));
+
+        Assert.Empty(_downloader.ArchivePaths);
+    }
+
+    [Fact]
+    public async Task InstallAsync_GameRoot_GivenDirectory_ThrowsArgumentException()
+    {
+        await SaveGameDirectoryAsync();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => InstallAsync(
+            release: Release(new InstallInfo(null, derived: false, target: InstallAnchor.GameRoot, path: "StarMap")),
+            directory: Path.Combine(_tempRoot, "Other")));
+
+        Assert.Empty(_downloader.ArchivePaths);
+    }
+
+    [Fact]
+    public async Task InstallAsync_GameRoot_GameDirectoryUnknown_Throws()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => InstallAsync(release: Release(new InstallInfo(null, derived: false, target: InstallAnchor.GameRoot, path: "StarMap"))));
+
+        Assert.Empty(_downloader.ArchivePaths);
+    }
+
+    [Theory]
+    [InlineData(InstallAnchor.Mods)]
+    [InlineData(InstallAnchor.UserData)]
+    public async Task InstallAsync_PerInstanceAnchor_IsNotSupported(InstallAnchor anchor)
+    {
+        await SaveGameDirectoryAsync();
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => InstallAsync(release: Release(new InstallInfo(null, derived: false, target: anchor))));
+
+        Assert.Contains("instance", ex.Message);
+        Assert.Empty(_downloader.ArchivePaths);
+    }
+
+    [Fact]
+    public async Task InstallAsync_UnknownAnchor_IsNotSupported()
+    {
+        await SaveGameDirectoryAsync();
+
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => InstallAsync(release: Release(new InstallInfo(null, derived: false, target: InstallAnchor.Unknown))));
+
+        Assert.Empty(_downloader.ArchivePaths);
+    }
+
+    [Fact]
+    public async Task InstallAsync_UndescribedLoader_IsNotSupported()
+    {
+        await SaveGameDirectoryAsync();
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => InstallAsync(loader: Listing(null, Provides(StarMapConfigure)), release: Release(install: null)));
+
+        Assert.Contains("links", ex.Message);
+        Assert.Empty(_downloader.ArchivePaths);
+    }
+
+    #endregion
+
+    #region Configuration
+
+    [Fact]
+    public async Task InstallAsync_GameDirectoryUnknown_RefusesBeforeDownloading()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => InstallAsync());
+
+        Assert.Contains("game directory", ex.Message);
+        Assert.Empty(_downloader.ArchivePaths);
+        await AssertNothingInstalledAsync();
+    }
+
+    [Fact]
+    public async Task InstallAsync_NoConfigureTable_NeedsNoGameDirectoryAndWritesNoFile()
+    {
+        _downloader.Bytes = StarMapZip();
+
+        var result = await InstallAsync(loader: Listing(Standalone(), Provides(configure: null)));
+
+        Assert.Null(result.ConfigurationFile);
+        Assert.False(File.Exists(ConfigPath(DefaultDirectory)));
+        Assert.Equal(DefaultDirectory, await RecordedDirectoryAsync());
+    }
+
+    [Fact]
+    public async Task InstallAsync_UnknownConfigureFormat_IsNotSupportedBeforeDownloading()
+    {
+        await SaveGameDirectoryAsync();
+        var configure = new LoaderConfigure("StarMap.cfg", ConfigureFormat.Unknown, "GameLocation");
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => InstallAsync(loader: Listing(Standalone(), Provides(configure))));
+
+        Assert.Empty(_downloader.ArchivePaths);
+    }
+
+    #endregion
+
+    #region Rollback
+
+    [Fact]
+    public async Task InstallAsync_LaunchTargetMissing_FailsAndLeavesNothing()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = TestArchives.Build(("StarMap.dll", "dll"), ("readme.txt", "no executable"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => InstallAsync());
+
+        Assert.Contains("StarMap.exe", ex.Message);
+        await AssertNothingInstalledAsync();
+    }
+
+    [Fact]
+    public async Task InstallAsync_FailsInAnEmptyExistingDirectory_ClearsItAndKeepsIt()
+    {
+        await SaveGameDirectoryAsync();
+        Directory.CreateDirectory(DefaultDirectory);
+        _downloader.Bytes = TestArchives.Build(("StarMap.dll", "dll"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => InstallAsync());
+
+        Assert.True(Directory.Exists(DefaultDirectory));
+        Assert.Empty(Directory.EnumerateFileSystemEntries(DefaultDirectory));
+        Assert.Null(await RecordedDirectoryAsync());
+    }
+
+    [Fact]
+    public async Task InstallAsync_EmptyArchive_FailsAndLeavesNothing()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = TestArchives.Build();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => InstallAsync());
+
+        Assert.Contains("no files", ex.Message);
+        await AssertNothingInstalledAsync();
+    }
+
+    [Fact]
+    public async Task InstallAsync_EntryEscapingTheDirectory_FailsAndLeavesNothing()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = TestArchives.Build(("StarMap.exe", "exe"), ("../escaped.txt", "outside"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => InstallAsync());
+
+        Assert.False(File.Exists(Path.Combine(_pathProvider.GetLoadersRoot(), "escaped.txt")));
+        await AssertNothingInstalledAsync();
+    }
+
+    [Fact]
+    public async Task InstallAsync_DownloadFails_LeavesNothing()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Failure = new DownloadFailedException("no source served the archive");
+
+        await Assert.ThrowsAsync<DownloadFailedException>(() => InstallAsync());
+
+        await AssertNothingInstalledAsync();
+    }
+
+    [Fact]
+    public async Task InstallAsync_SettingsCannotBeSaved_RollsBack()
+    {
+        var installer = new FileLoaderInstaller(
+            _pathProvider,
+            _downloader,
+            new FailingSettingsRepository(new BoreaSettings(_gameDirectory)),
+            new LoaderConfigurator());
+        _downloader.Bytes = StarMapZip();
+
+        await Assert.ThrowsAsync<IOException>(() => installer.InstallAsync(StarMap(), StarMapRelease()));
+
+        Assert.False(Directory.Exists(DefaultDirectory));
+    }
+
+    [Fact]
+    public async Task InstallAsync_ReplacementFails_LeavesTheDirectory()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = StarMapZip();
+        await InstallAsync();
+        _downloader.Bytes = TestArchives.Build();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => InstallAsync(release: StarMapRelease("0.4.7")));
+
+        Assert.True(File.Exists(Path.Combine(DefaultDirectory, "StarMap.exe")));
+        Assert.Equal(DefaultDirectory, await RecordedDirectoryAsync());
+    }
+
+    #endregion
+
+    #region Refusals and plumbing
+
+    [Fact]
+    public async Task InstallAsync_ModRelease_IsNotSupported()
+    {
+        await SaveGameDirectoryAsync();
+
+        await Assert.ThrowsAsync<NotSupportedException>(() => InstallAsync(release: Release(install: null, type: ContentType.Mod)));
+
+        Assert.Empty(_downloader.ArchivePaths);
+    }
+
+    [Fact]
+    public async Task InstallAsync_ModListing_ThrowsArgumentException()
+    {
+        await SaveGameDirectoryAsync();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => InstallAsync(loader: Listing(null, null, ContentType.Mod)));
+
+        Assert.Empty(_downloader.ArchivePaths);
+    }
+
+    [Fact]
+    public async Task InstallAsync_ReleaseOfAnotherLoader_ThrowsArgumentException()
+    {
+        await SaveGameDirectoryAsync();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => InstallAsync(release: Release(StandaloneStamp, id: "Cheese-Loader")));
+
+        Assert.Empty(_downloader.ArchivePaths);
+    }
+
+    [Fact]
+    public async Task InstallAsync_NotAZip_IsNotSupported()
+    {
+        await SaveGameDirectoryAsync();
+
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => InstallAsync(release: Release(StandaloneStamp, contentType: "application/x-7z-compressed")));
+
+        Assert.Empty(_downloader.ArchivePaths);
+    }
+
+    [Fact]
+    public async Task InstallAsync_HandsProgressAndTheTokenToTheDownloader()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = StarMapZip();
+        var progress = new Progress<DownloadProgress>();
+        using var cancellation = new CancellationTokenSource();
+
+        await _installer.InstallAsync(StarMap(), StarMapRelease(), null, progress, cancellation.Token);
+
+        Assert.Same(progress, _downloader.LastProgress);
+        Assert.Equal(cancellation.Token, _downloader.LastToken);
+    }
+
+    [Fact]
+    public async Task InstallAsync_DeletesTheTemporaryArchive()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = StarMapZip();
+
+        await InstallAsync();
+
+        Assert.False(File.Exists(Assert.Single(_downloader.ArchivePaths)));
+    }
+
+    [Fact]
+    public async Task InstallAsync_NullArguments_ThrowArgumentNullException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _installer.InstallAsync(null!, StarMapRelease()));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _installer.InstallAsync(StarMap(), null!));
+    }
+
+    [Fact]
+    public void Constructor_NullDependency_ThrowsArgumentNullException()
+    {
+        var configurator = new LoaderConfigurator();
+
+        Assert.Throws<ArgumentNullException>(() => new FileLoaderInstaller(null!, _downloader, _settings, configurator));
+        Assert.Throws<ArgumentNullException>(() => new FileLoaderInstaller(_pathProvider, null!, _settings, configurator));
+        Assert.Throws<ArgumentNullException>(() => new FileLoaderInstaller(_pathProvider, _downloader, null!, configurator));
+        Assert.Throws<ArgumentNullException>(() => new FileLoaderInstaller(_pathProvider, _downloader, _settings, null!));
+    }
+
+    #endregion
+
+    /// <summary>Settings that can be read but not written, to exercise the rollback.</summary>
+    private sealed class FailingSettingsRepository(BoreaSettings? current) : IBoreaSettingsRepository
+    {
+        public Task<BoreaSettings?> GetAsync(CancellationToken cancellationToken = default) => Task.FromResult(current);
+
+        public Task SaveAsync(BoreaSettings settings, CancellationToken cancellationToken = default) =>
+            throw new IOException("The disk is full.");
+    }
+}

--- a/tests/Borea.Storage.Tests/ModLoaders/FileLoaderInstallerTests.cs
+++ b/tests/Borea.Storage.Tests/ModLoaders/FileLoaderInstallerTests.cs
@@ -142,6 +142,28 @@ public sealed class FileLoaderInstallerTests : IDisposable
         Assert.All(_downloader.ArchivePaths, path => Assert.False(File.Exists(path)));
     }
 
+    private async Task InstallOldLoaderAsync()
+    {
+        await SaveGameDirectoryAsync();
+        _downloader.Bytes = StarMapZip("old", ("old-only.txt", "old-only"));
+        await InstallAsync();
+    }
+
+    private async Task AssertOldLoaderRemainsAsync()
+    {
+        Assert.Equal("old", await File.ReadAllTextAsync(Path.Combine(DefaultDirectory, "StarMap.exe")));
+        Assert.Equal("old-only", await File.ReadAllTextAsync(Path.Combine(DefaultDirectory, "old-only.txt")));
+        Assert.Equal(DefaultDirectory, await RecordedDirectoryAsync());
+        AssertNoTransactionDirectories();
+    }
+
+    private void AssertNoTransactionDirectories()
+    {
+        var parent = Path.GetDirectoryName(DefaultDirectory)!;
+        if (Directory.Exists(parent))
+            Assert.Empty(Directory.EnumerateDirectories(parent, $".{LoaderId}.borea-*"));
+    }
+
     #region The real listing
 
     [Fact]
@@ -202,7 +224,7 @@ public sealed class FileLoaderInstallerTests : IDisposable
     public async Task InstallAsync_RecordedLoader_ReplacesInPlaceAndKeepsTheConfiguration()
     {
         await SaveGameDirectoryAsync();
-        _downloader.Bytes = StarMapZip(exe: "old");
+        _downloader.Bytes = StarMapZip("old", ("old-only.txt", "old-only"));
         await InstallAsync();
 
         // The user pointed StarMap at a repository and added an argument by hand.
@@ -220,11 +242,13 @@ public sealed class FileLoaderInstallerTests : IDisposable
         Assert.True(result.Replaced);
         Assert.Equal(DefaultDirectory, result.Directory);
         Assert.Equal("new", await File.ReadAllTextAsync(Path.Combine(DefaultDirectory, "StarMap.exe")));
+        Assert.False(File.Exists(Path.Combine(DefaultDirectory, "old-only.txt")));
         var config = await ReadConfigAsync(DefaultDirectory);
         Assert.Equal(_gameDirectory, (string?)config["GameLocation"]);
         Assert.Equal(@"C:\Repos", (string?)config["RepositoryLocation"]);
         Assert.Equal("-Verbose", (string?)config["GameArguments"]![0]);
         Assert.Single((await _settings.GetAsync())!.LoaderDirectoryPaths);
+        AssertNoTransactionDirectories();
     }
 
     [Fact]
@@ -641,17 +665,54 @@ public sealed class FileLoaderInstallerTests : IDisposable
     }
 
     [Fact]
-    public async Task InstallAsync_ReplacementFails_LeavesTheDirectory()
+    public async Task InstallAsync_ReplacementExtractionFails_RestoresThePreviousDirectory()
     {
-        await SaveGameDirectoryAsync();
-        _downloader.Bytes = StarMapZip();
-        await InstallAsync();
-        _downloader.Bytes = TestArchives.Build();
+        await InstallOldLoaderAsync();
+        _downloader.Bytes = TestArchives.Build(("StarMap.exe", "new"), ("../escaped.txt", "outside"));
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => InstallAsync(release: StarMapRelease("0.4.7")));
 
-        Assert.True(File.Exists(Path.Combine(DefaultDirectory, "StarMap.exe")));
-        Assert.Equal(DefaultDirectory, await RecordedDirectoryAsync());
+        await AssertOldLoaderRemainsAsync();
+    }
+
+    [Fact]
+    public async Task InstallAsync_ReplacementLaunchTargetMissing_RestoresThePreviousDirectory()
+    {
+        await InstallOldLoaderAsync();
+        _downloader.Bytes = TestArchives.Build(("StarMap.dll", "new"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => InstallAsync(release: StarMapRelease("0.4.7")));
+
+        await AssertOldLoaderRemainsAsync();
+    }
+
+    [Fact]
+    public async Task InstallAsync_ReplacementConfigurationFails_RestoresThePreviousDirectory()
+    {
+        await InstallOldLoaderAsync();
+        _downloader.Bytes = StarMapZip(exe: "new");
+        var installer = new FileLoaderInstaller(_pathProvider, _downloader, _settings, new FailingLoaderConfigurator());
+
+        await Assert.ThrowsAsync<IOException>(() => installer.InstallAsync(StarMap(), StarMapRelease("0.4.7")));
+
+        await AssertOldLoaderRemainsAsync();
+    }
+
+    [Fact]
+    public async Task InstallAsync_ReplacementSettingsCannotBeSaved_RestoresThePreviousDirectory()
+    {
+        await InstallOldLoaderAsync();
+        _downloader.Bytes = StarMapZip(exe: "new");
+        var current = await _settings.GetAsync();
+        var installer = new FileLoaderInstaller(
+            _pathProvider,
+            _downloader,
+            new FailingSettingsRepository(current),
+            new LoaderConfigurator());
+
+        await Assert.ThrowsAsync<IOException>(() => installer.InstallAsync(StarMap(), StarMapRelease("0.4.7")));
+
+        await AssertOldLoaderRemainsAsync();
     }
 
     #endregion
@@ -751,5 +812,15 @@ public sealed class FileLoaderInstallerTests : IDisposable
 
         public Task SaveAsync(BoreaSettings settings, CancellationToken cancellationToken = default) =>
             throw new IOException("The disk is full.");
+    }
+
+    private sealed class FailingLoaderConfigurator : ILoaderConfigurator
+    {
+        public Task<string?> ConfigureAsync(
+            ModMetadata loader,
+            string loaderDirectory,
+            string gameDirectory,
+            CancellationToken cancellationToken = default) =>
+            throw new IOException("The configuration file cannot be written.");
     }
 }

--- a/tests/Borea.Storage.Tests/ModLoaders/LoaderConfiguratorTests.cs
+++ b/tests/Borea.Storage.Tests/ModLoaders/LoaderConfiguratorTests.cs
@@ -1,0 +1,386 @@
+using System.Text.Json.Nodes;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+using Borea.Storage.ModLoaders;
+using Tomlyn;
+using Tomlyn.Model;
+
+namespace Borea.Storage.Tests.ModLoaders;
+
+public sealed class LoaderConfiguratorTests : IDisposable
+{
+    private static readonly IReadOnlyDictionary<string, string> Links = new Dictionary<string, string>
+    {
+        ["forums"] = "https://forums.ahwoo.com/threads/starmap-mod-loader.384/",
+    };
+
+    private readonly string _tempRoot;
+    private readonly string _loaderDirectory;
+    private readonly string _gameDirectory;
+    private readonly LoaderConfigurator _configurator = new();
+
+    public LoaderConfiguratorTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+        _loaderDirectory = Path.Combine(_tempRoot, "StarMap");
+        _gameDirectory = Path.Combine(_tempRoot, "Game");
+        Directory.CreateDirectory(_loaderDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+
+    private string ConfigPath(string file = "StarMapConfig.json") =>
+        Path.Combine(_loaderDirectory, file.Replace('/', Path.DirectorySeparatorChar));
+
+    private static ModMetadata Loader(LoaderConfigure? configure, ContentType type = ContentType.ModLoader) => new(
+        specVersion: 1,
+        modId: "StarMap",
+        source: "index",
+        name: "StarMap",
+        authors: new[] { "KlaasWhite" },
+        abstractText: "Mod loader that runs code mods for Kitten Space Agency.",
+        license: "MIT",
+        links: Links,
+        gameMin: "2026.8.3.5117",
+        type: type,
+        install: type == ContentType.ModLoader ? new InstallDescriptor(target: InstallAnchor.Standalone) : null,
+        provides: type == ContentType.ModLoader ? new LoaderProvides("StarMap.exe", InstallAnchor.Mods, configure: configure) : null);
+
+    private static LoaderConfigure Json(string? gamePath = "GameLocation", string file = "StarMapConfig.json") =>
+        new(file, ConfigureFormat.Json, gamePath);
+
+    private static LoaderConfigure Toml(string? gamePath = "GameLocation", string file = "loader.toml") =>
+        new(file, ConfigureFormat.Toml, gamePath);
+
+    private Task<string?> ConfigureAsync(LoaderConfigure? configure) =>
+        _configurator.ConfigureAsync(Loader(configure), _loaderDirectory, _gameDirectory);
+
+    private Task WriteConfigAsync(string text, string file = "StarMapConfig.json") =>
+        File.WriteAllTextAsync(ConfigPath(file), text);
+
+    private async Task<JsonObject> ReadJsonAsync(string file = "StarMapConfig.json") =>
+        (JsonObject)JsonNode.Parse(await File.ReadAllTextAsync(ConfigPath(file)))!;
+
+    private async Task<TomlTable> ReadTomlAsync(string file = "loader.toml") =>
+        TomlSerializer.Deserialize<TomlTable>(await File.ReadAllTextAsync(ConfigPath(file)))!;
+
+    #region JSON
+
+    [Fact]
+    public async Task ConfigureAsync_Json_NoFile_CreatesItWithOnlyTheKey()
+    {
+        var written = await ConfigureAsync(Json());
+
+        Assert.Equal(ConfigPath(), written);
+        var json = await ReadJsonAsync();
+        Assert.Equal(_gameDirectory, (string?)json["GameLocation"]);
+        Assert.Single(json);
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_Json_ExistingKeysSurvive()
+    {
+        // What StarMap writes on its first run, plus a nested table.
+        await WriteConfigAsync("""
+            {
+              "GameLocation": "",
+              "RepositoryLocation": "C:\\Repos",
+              "GameArguments": ["-a", "-b"],
+              "Extra": { "kept": true }
+            }
+            """);
+
+        await ConfigureAsync(Json());
+
+        var json = await ReadJsonAsync();
+        Assert.Equal(_gameDirectory, (string?)json["GameLocation"]);
+        Assert.Equal(@"C:\Repos", (string?)json["RepositoryLocation"]);
+        Assert.Equal(2, json["GameArguments"]!.AsArray().Count);
+        Assert.True((bool?)json["Extra"]!["kept"]);
+        Assert.Equal(4, json.Count);
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_Json_NestedKey_CreatesTheObjects()
+    {
+        await ConfigureAsync(Json("loader.game.path"));
+
+        var json = await ReadJsonAsync();
+        Assert.Equal(_gameDirectory, (string?)json["loader"]!["game"]!["path"]);
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_Json_NestedKeyIntoAnExistingObject_KeepsItsSiblings()
+    {
+        await WriteConfigAsync("""{ "loader": { "verbose": true } }""");
+
+        await ConfigureAsync(Json("loader.game.path"));
+
+        var json = await ReadJsonAsync();
+        Assert.True((bool?)json["loader"]!["verbose"]);
+        Assert.Equal(_gameDirectory, (string?)json["loader"]!["game"]!["path"]);
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_Json_ValueWhereAnObjectIsExpected_ThrowsAndLeavesTheFile()
+    {
+        const string original = """{ "loader": "text" }""";
+        await WriteConfigAsync(original);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => ConfigureAsync(Json("loader.game")));
+
+        Assert.Contains("'loader'", ex.Message);
+        Assert.Equal(original, await File.ReadAllTextAsync(ConfigPath()));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_Json_RootIsNotAnObject_Throws()
+    {
+        await WriteConfigAsync("[1, 2]");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => ConfigureAsync(Json()));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_Json_InvalidJson_ThrowsAndLeavesTheFile()
+    {
+        const string original = "{ not json";
+        await WriteConfigAsync(original);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => ConfigureAsync(Json()));
+
+        Assert.Contains(ConfigPath(), ex.Message);
+        Assert.Equal(original, await File.ReadAllTextAsync(ConfigPath()));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_Json_DuplicateKey_ThrowsAndLeavesTheFile()
+    {
+        const string original = """{ "GameLocation": "a", "GameLocation": "b", "RepositoryLocation": "kept" }""";
+        await WriteConfigAsync(original);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => ConfigureAsync(Json()));
+
+        Assert.Contains(ConfigPath(), ex.Message);
+        Assert.Equal(original, await File.ReadAllTextAsync(ConfigPath()));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_Json_CommentsAndTrailingCommas_AreRead()
+    {
+        await WriteConfigAsync("""
+            {
+              // hand-edited
+              "RepositoryLocation": "kept",
+            }
+            """);
+
+        await ConfigureAsync(Json());
+
+        var json = await ReadJsonAsync();
+        Assert.Equal("kept", (string?)json["RepositoryLocation"]);
+        Assert.Equal(_gameDirectory, (string?)json["GameLocation"]);
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_Json_WhitespaceOnlyFile_IsTreatedAsEmpty()
+    {
+        await WriteConfigAsync("  \n");
+
+        await ConfigureAsync(Json());
+
+        Assert.Equal(_gameDirectory, (string?)(await ReadJsonAsync())["GameLocation"]);
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_FileInASubdirectory_CreatesIt()
+    {
+        var written = await ConfigureAsync(Json(file: "config/loader.json"));
+
+        Assert.Equal(ConfigPath("config/loader.json"), written);
+        Assert.True(File.Exists(written));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_TrailingSeparatorOnTheGameDirectory_IsNotWritten()
+    {
+        await _configurator.ConfigureAsync(Loader(Json()), _loaderDirectory, _gameDirectory + Path.DirectorySeparatorChar);
+
+        Assert.Equal(_gameDirectory, (string?)(await ReadJsonAsync())["GameLocation"]);
+    }
+
+    #endregion
+
+    #region TOML
+
+    [Fact]
+    public async Task ConfigureAsync_Toml_NoFile_CreatesItWithOnlyTheKey()
+    {
+        var written = await ConfigureAsync(Toml());
+
+        Assert.Equal(ConfigPath("loader.toml"), written);
+        var toml = await ReadTomlAsync();
+        Assert.Equal(_gameDirectory, toml["GameLocation"]);
+        Assert.Single(toml);
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_Toml_ExistingKeysAndTablesSurvive()
+    {
+        await WriteConfigAsync("""
+            name = "kept"
+            ports = [1, 2]
+
+            [paths]
+            other = "kept too"
+            """, "loader.toml");
+
+        await ConfigureAsync(Toml("paths.game"));
+
+        var toml = await ReadTomlAsync();
+        Assert.Equal("kept", toml["name"]);
+        Assert.Equal(2, ((TomlArray)toml["ports"]).Count);
+        var paths = (TomlTable)toml["paths"];
+        Assert.Equal("kept too", paths["other"]);
+        Assert.Equal(_gameDirectory, paths["game"]);
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_Toml_Comments_Survive()
+    {
+        await WriteConfigAsync("""
+            # hand-edited
+            name = "kept"
+            """, "loader.toml");
+
+        await ConfigureAsync(Toml());
+
+        Assert.Contains("# hand-edited", await File.ReadAllTextAsync(ConfigPath("loader.toml")));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_Toml_NestedKey_CreatesTheTables()
+    {
+        await ConfigureAsync(Toml("loader.game.path"));
+
+        var toml = await ReadTomlAsync();
+        Assert.Equal(_gameDirectory, ((TomlTable)((TomlTable)toml["loader"])["game"])["path"]);
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_Toml_ValueWhereATableIsExpected_ThrowsAndLeavesTheFile()
+    {
+        const string original = "loader = \"text\"\n";
+        await WriteConfigAsync(original, "loader.toml");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => ConfigureAsync(Toml("loader.game")));
+
+        Assert.Contains("'loader'", ex.Message);
+        Assert.Equal(original, await File.ReadAllTextAsync(ConfigPath("loader.toml")));
+    }
+
+    [Theory]
+    [InlineData("GameLocation = \"a\"\nGameLocation = \"b\"\n", "GameLocation")]
+    [InlineData("[paths]\nx = 1\n[paths]\nx = 2\n", "x")]
+    public async Task ConfigureAsync_Toml_DuplicateKey_ThrowsAndLeavesTheFile(string original, string key)
+    {
+        await WriteConfigAsync(original, "loader.toml");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => ConfigureAsync(Toml()));
+
+        Assert.Contains(ConfigPath("loader.toml"), ex.Message);
+        Assert.Contains($"'{key}'", ex.Message);
+        Assert.Equal(original, await File.ReadAllTextAsync(ConfigPath("loader.toml")));
+    }
+
+    [Theory]
+    [InlineData("a.b = 1\na.c = 2\n")]
+    [InlineData("[a]\nb = 1\n[a.c]\nd = 2\n")]
+    [InlineData("[[arr]]\nx = 1\n[[arr]]\nx = 2\n")]
+    public async Task ConfigureAsync_Toml_KeysThatOnlyLookRepeated_AreAccepted(string original)
+    {
+        await WriteConfigAsync(original, "loader.toml");
+
+        await ConfigureAsync(Toml());
+
+        Assert.Equal(_gameDirectory, (await ReadTomlAsync())["GameLocation"]);
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_Toml_InvalidToml_ThrowsAndLeavesTheFile()
+    {
+        const string original = "name = \n";
+        await WriteConfigAsync(original, "loader.toml");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => ConfigureAsync(Toml()));
+
+        Assert.Contains(ConfigPath("loader.toml"), ex.Message);
+        Assert.Equal(original, await File.ReadAllTextAsync(ConfigPath("loader.toml")));
+    }
+
+    #endregion
+
+    #region Nothing to write, and refusals
+
+    [Fact]
+    public async Task ConfigureAsync_NoConfigureTable_ReturnsNullAndWritesNothing()
+    {
+        var written = await ConfigureAsync(null);
+
+        Assert.Null(written);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(_loaderDirectory));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_NoGamePathKey_ReturnsNullAndWritesNothing()
+    {
+        var written = await ConfigureAsync(Json(gamePath: null));
+
+        Assert.Null(written);
+        Assert.False(File.Exists(ConfigPath()));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_UnknownFormat_IsNotSupported()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => ConfigureAsync(new LoaderConfigure("loader.cfg", ConfigureFormat.Unknown, "GameLocation")));
+
+        Assert.False(File.Exists(ConfigPath("loader.cfg")));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_ModListing_ThrowsArgumentException()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _configurator.ConfigureAsync(Loader(null, ContentType.Mod), _loaderDirectory, _gameDirectory));
+    }
+
+    [Theory]
+    [InlineData("relative/loader")]
+    [InlineData("")]
+    public async Task ConfigureAsync_RelativeLoaderDirectory_ThrowsArgumentException(string directory)
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => _configurator.ConfigureAsync(Loader(Json()), directory, _gameDirectory));
+    }
+
+    [Theory]
+    [InlineData("relative/game")]
+    [InlineData("")]
+    public async Task ConfigureAsync_RelativeGameDirectory_ThrowsArgumentException(string directory)
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => _configurator.ConfigureAsync(Loader(Json()), _loaderDirectory, directory));
+    }
+
+    [Fact]
+    public async Task ConfigureAsync_NullLoader_ThrowsArgumentNullException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _configurator.ConfigureAsync(null!, _loaderDirectory, _gameDirectory));
+    }
+
+    #endregion
+}

--- a/tests/Borea.Storage.Tests/Mods/FakeModDownloader.cs
+++ b/tests/Borea.Storage.Tests/Mods/FakeModDownloader.cs
@@ -1,0 +1,37 @@
+using System.Security.Cryptography;
+using Borea.Core.Mods;
+
+namespace Borea.Storage.Tests.Mods;
+
+/// <summary>
+/// Hands out configured bytes as the archive, or fails, and remembers where it was asked to write.
+/// </summary>
+internal sealed class FakeModDownloader : IModDownloader
+{
+    public byte[] Bytes { get; set; } = Array.Empty<byte>();
+
+    public Exception? Failure { get; set; }
+
+    public List<string> ArchivePaths { get; } = new();
+
+    public IProgress<DownloadProgress>? LastProgress { get; private set; }
+
+    public CancellationToken LastToken { get; private set; }
+
+    public async Task<DownloadResult> DownloadAsync(
+        ModVersionMetadata release,
+        string archivePath,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArchivePaths.Add(archivePath);
+        LastProgress = progress;
+        LastToken = cancellationToken;
+
+        if (Failure is not null)
+            throw Failure;
+
+        await File.WriteAllBytesAsync(archivePath, Bytes, cancellationToken);
+        return new DownloadResult(release.Download.Url, Bytes.Length, Convert.ToHexString(SHA256.HashData(Bytes)));
+    }
+}

--- a/tests/Borea.Storage.Tests/Mods/FileModInstallerTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/FileModInstallerTests.cs
@@ -1,4 +1,3 @@
-using System.IO.Compression;
 using System.Security.Cryptography;
 using Borea.Core.Dependencies;
 using Borea.Core.Instances;
@@ -54,21 +53,7 @@ public sealed class FileModInstallerTests : IAsyncLifetime
 
     private static string Sha256Of(byte[] bytes) => Convert.ToHexString(SHA256.HashData(bytes));
 
-    private static byte[] BuildZip(params (string Path, string Content)[] entries)
-    {
-        using var stream = new MemoryStream();
-        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
-        {
-            foreach (var (path, content) in entries)
-            {
-                var entry = archive.CreateEntry(path);
-                using var writer = new StreamWriter(entry.Open());
-                writer.Write(content);
-            }
-        }
-
-        return stream.ToArray();
-    }
+    private static byte[] BuildZip(params (string Path, string Content)[] entries) => TestArchives.Build(entries);
 
     private static ModVersionMetadata Release(
         InstallInfo? install = null,
@@ -458,37 +443,6 @@ public sealed class FileModInstallerTests : IAsyncLifetime
     }
 
     #endregion
-
-    /// <summary>Hands out configured bytes as the archive, or fails, and remembers where it was asked to write.</summary>
-    private sealed class FakeModDownloader : IModDownloader
-    {
-        public byte[] Bytes { get; set; } = Array.Empty<byte>();
-
-        public Exception? Failure { get; set; }
-
-        public List<string> ArchivePaths { get; } = new();
-
-        public IProgress<DownloadProgress>? LastProgress { get; private set; }
-
-        public CancellationToken LastToken { get; private set; }
-
-        public async Task<DownloadResult> DownloadAsync(
-            ModVersionMetadata release,
-            string archivePath,
-            IProgress<DownloadProgress>? progress = null,
-            CancellationToken cancellationToken = default)
-        {
-            ArchivePaths.Add(archivePath);
-            LastProgress = progress;
-            LastToken = cancellationToken;
-
-            if (Failure is not null)
-                throw Failure;
-
-            await File.WriteAllBytesAsync(archivePath, Bytes, cancellationToken);
-            return new DownloadResult(release.Download.Url, Bytes.Length, Sha256Of(Bytes));
-        }
-    }
 
     /// <summary>A manifest that cannot be written, to exercise the rollback.</summary>
     private sealed class FailingModStateRepository : IModStateRepository

--- a/tests/Borea.Storage.Tests/Mods/TestArchives.cs
+++ b/tests/Borea.Storage.Tests/Mods/TestArchives.cs
@@ -1,0 +1,25 @@
+using System.IO.Compression;
+
+namespace Borea.Storage.Tests.Mods;
+
+/// <summary>
+/// Builds the zip archives the install tests use.
+/// </summary>
+internal static class TestArchives
+{
+    public static byte[] Build(params (string Path, string Content)[] entries)
+    {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (path, content) in entries)
+            {
+                var entry = archive.CreateEntry(path);
+                using var writer = new StreamWriter(entry.Open());
+                writer.Write(content);
+            }
+        }
+
+        return stream.ToArray();
+    }
+}

--- a/tests/Borea.Storage.Tests/Paths/GamePathProviderTests.cs
+++ b/tests/Borea.Storage.Tests/Paths/GamePathProviderTests.cs
@@ -210,4 +210,16 @@ public sealed class GamePathProviderTests
         Assert.DoesNotContain(provider.GetInstancesRoot(), provider.GetBoreaSettingsPath());
         Assert.DoesNotContain(provider.GetInstancesRoot(), provider.GetIndexPath());
     }
+
+    [Fact]
+    public void GetLoadersRoot_IsBesideTheInstancesRootAndNotInsideIt()
+    {
+        var provider = new GamePathProvider(null);
+
+        var loaders = provider.GetLoadersRoot();
+
+        Assert.Equal("Loaders", Path.GetFileName(loaders));
+        Assert.Equal(Path.GetDirectoryName(provider.GetInstancesRoot()), Path.GetDirectoryName(loaders));
+        Assert.DoesNotContain(provider.GetInstancesRoot(), loaders);
+    }
 }

--- a/tests/Borea.Storage.Tests/Paths/TestGamePathProvider.cs
+++ b/tests/Borea.Storage.Tests/Paths/TestGamePathProvider.cs
@@ -20,6 +20,7 @@ internal sealed class TestGamePathProvider : IGamePathProvider
 
     public string GetIndexPath() => Path.Combine(_root, "index.json");
     public string GetInstancesRoot() => Path.Combine(_root, "Instances");
+    public string GetLoadersRoot() => Path.Combine(_root, "Loaders");
     public string GetInstanceRoot(Guid instanceId) => Path.Combine(GetInstancesRoot(), instanceId.ToString());
     public string GetInstanceModsFolder(Guid instanceId) => Path.Combine(GetInstanceRoot(instanceId), "mods");
     public string GetInstanceSavesFolder(Guid instanceId) => Path.Combine(GetInstanceRoot(instanceId), "saves");


### PR DESCRIPTION
Closes #51. Stacked on #72, so the base is `install-mod`: the archive download and the unpack with the stamped root come from there.

**Borea installs a mod loader itself now, from its listing in the index, and points it at the game.** Until now a user downloaded StarMap by hand, unpacked it somewhere, edited its config file, and typed the folder into Borea's settings. Borea did not know anything about StarMap in particular before, and it still does not: it reads what the listing says and follows it. A second loader with a listing of its own works the same way without new code.

What happens when Borea installs a loader, in six steps:

1. **Check the two documents.** The listing (the author's file) and the release (the stamped file with the download link) must both describe a mod loader with the same id.
2. **Work out where it goes.** The StarMap release says "standalone", so Borea picks a folder of its own, `Loaders/StarMap` in its data folder. The caller can name another folder. A loader that says "below the game folder" goes there instead.
3. **Download.** The zip is fetched and its hash checked, with the same code #72 uses for mods.
4. **Unpack and check.** The zip is unpacked into that folder. Then Borea checks that the file the listing says to run, `StarMap.exe`, is really there (RFC 0035 rule 3). If not, the install fails and the folder is removed again.
5. **Configure.** Borea writes the game path into the loader's own config file. It writes only the one key the listing names, `GameLocation`, and leaves every other line alone. A file that does not exist yet is created with just that key.
6. **Record.** Borea writes into its settings that StarMap is installed in this folder. The launcher (#77) reads that to start the game.

**Installing again.** A loader that is already recorded is installed into the same folder, over the old files. The config file is kept as it is, even when the new zip ships a fresh one, because the user may have edited it. Then the game path key is written again.

**What Borea refuses.** A folder that already holds files Borea did not put there. A loader that wants to go directly into the game folder, because those files could never be taken out again. The two anchors that mean "inside an instance", because Borea remembers one folder per loader and not one per instance. And an install while the game directory is not set, because then the config cannot be filled in.

**Not in this pull request:** adopting a StarMap the user installed by hand, uninstalling a loader, the wiring into the composition root (#70) and the launcher (#77), and rewriting the game path in every loader when the game directory changes. The path provider built at startup does not see the new record until a restart, which the composition root owns.

LLM usage disclosure: Claude Fable 5.1 (and Opus 5 for the code review workflow) was used collaboratively with me to create parts of this. I read, reviewed and tested all of it myself and like it.
