### PR TITLE
Attach an SBOM to every release

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "cyclonedx": {
+      "version": "6.2.0",
+      "commands": [
+        "dotnet-CycloneDX"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,61 @@ jobs:
           # Already compressed.
           compression-level: 0
 
+  sbom:
+    name: sbom
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+
+      # Release, like the builds, so the Debug-only packages stay out.
+      - name: Restore the release graph
+        run: dotnet restore src/Borea.App/Borea.App.csproj -p:Configuration=Release
+
+      # The tool version is pinned in .config/dotnet-tools.json, where Dependabot keeps it current.
+      - name: Write the SBOM
+        env:
+          VERSION: ${{ needs.test.outputs.version }}
+        run: |
+          dotnet tool restore
+          dotnet CycloneDX src/Borea.App/Borea.App.csproj \
+            --output dist --filename "Borea-$VERSION.cdx.json" --output-format Json \
+            --set-name Borea --set-version "$VERSION" --set-type Application \
+            --exclude-dev --disable-package-restore
+
+      - name: Check the SBOM
+        env:
+          VERSION: ${{ needs.test.outputs.version }}
+        run: |
+          bom="dist/Borea-$VERSION.cdx.json"
+          names=$(jq -r '.components[].name' "$bom")
+          for p in Avalonia CommunityToolkit.Mvvm Tomlyn SkiaSharp; do
+            if ! grep -qx "$p" <<< "$names"; then
+              echo "The SBOM does not list $p." >&2
+              exit 1
+            fi
+          done
+          for p in xunit Microsoft.NET.Test.Sdk coverlet.collector AvaloniaUI.DiagnosticsSupport; do
+            if grep -qx "$p" <<< "$names"; then
+              echo "The SBOM lists $p, which does not ship." >&2
+              exit 1
+            fi
+          done
+          if ! jq -e '([.components[]["bom-ref"]] - [.dependencies[].ref]) == []' "$bom" > /dev/null; then
+            echo "A package is missing from the dependency graph." >&2
+            exit 1
+          fi
+          echo "$(wc -l <<< "$names") packages."
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: sbom
+          path: dist/*.cdx.json
+          if-no-files-found: error
+
   verify-macos:
     name: verify (macOS)
     needs: publish
@@ -137,7 +192,7 @@ jobs:
 
   release:
     name: release
-    needs: publish
+    needs: [test, publish, sbom]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -148,6 +203,10 @@ jobs:
         with:
           pattern: archive-*
           merge-multiple: true
+          path: dist
+      - uses: actions/download-artifact@v8
+        with:
+          name: sbom
           path: dist
 
       - name: Compute the checksums
@@ -163,6 +222,17 @@ jobs:
         with:
           subject-path: dist/*
 
+      # Binds the release SBOM to each archive, so `gh attestation verify <archive>` with the
+      # CycloneDX predicate type proves that the list belongs to it.
+      - name: Attest the SBOM
+        if: github.event_name == 'push'
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            dist/*.zip
+            dist/*.tar.gz
+          sbom-path: dist/Borea-${{ needs.test.outputs.version }}.cdx.json
+
       # The changelog is fetched here instead of with `gh release create --generate-notes`,
       # so a re-run for the same tag can rewrite the whole body, checksum table included.
       - name: Write the release body
@@ -170,6 +240,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          VERSION: ${{ needs.test.outputs.version }}
         run: |
           gh api --method POST "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
             -f tag_name="$GITHUB_REF_NAME" --jq .body > generated.md || : > generated.md
@@ -205,6 +276,23 @@ jobs:
           {
             echo "gh attestation verify <file> --repo $GITHUB_REPOSITORY \\"
             echo "  --signer-workflow $GITHUB_REPOSITORY/.github/workflows/release.yml"
+          } >> body.md
+          cat >> body.md <<'EOF'
+          ```
+
+          EOF
+          cat >> body.md <<EOF
+          \`Borea-$VERSION.cdx.json\` is the software bill of materials, in CycloneDX JSON. It includes the NuGet packages Borea.App is built from, with version, license and hash.
+          One list covers all four builds, so it holds the native asset packages of every platform.
+          The same list is attested to each archive, and you can use this command to prove that it belongs to one.
+          With \`--format json\`, the output includes the attested list.
+
+          \`\`\`
+          EOF
+          {
+            echo "gh attestation verify <archive> --repo $GITHUB_REPOSITORY \\"
+            echo "  --signer-workflow $GITHUB_REPOSITORY/.github/workflows/release.yml \\"
+            echo "  --predicate-type https://cyclonedx.org/bom"
           } >> body.md
           cat >> body.md <<'EOF'
           ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,26 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.name.outputs.version }}
     steps:
+      - name: Name this release
+        id: name
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          if [ "$REF_TYPE" = tag ]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version=0.0.0-dev
+          fi
+          case "$version" in
+            "" | *[!A-Za-z0-9.+-]* )
+              echo "Tag $GITHUB_REF_NAME is not a version this workflow can publish." >&2
+              exit 1 ;;
+          esac
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v6
         with:
@@ -42,27 +61,15 @@ jobs:
       - name: Name this build
         id: name
         env:
-          REF_TYPE: ${{ github.ref_type }}
+          VERSION: ${{ needs.test.outputs.version }}
           RID: ${{ matrix.rid }}
-        run: |
-          if [ "$REF_TYPE" = tag ]; then
-            version="${GITHUB_REF_NAME#v}"
-          else
-            version=0.0.0-dev
-          fi
-          case "$version" in
-            "" | *[!A-Za-z0-9.+-]* )
-              echo "Tag $GITHUB_REF_NAME is not a version this workflow can publish." >&2
-              exit 1 ;;
-          esac
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "archive=Borea-$version-$RID" >> "$GITHUB_OUTPUT"
+        run: echo "archive=Borea-$VERSION-$RID" >> "$GITHUB_OUTPUT"
 
       # Self-contained, so nobody needs a .NET runtime.
       # Each target builds on a Linux runner.
       - name: Publish
         env:
-          VERSION: ${{ steps.name.outputs.version }}
+          VERSION: ${{ needs.test.outputs.version }}
           ARCHIVE: ${{ steps.name.outputs.archive }}
           RID: ${{ matrix.rid }}
         run: >

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ gh attestation verify <file> --repo KSAModding/Borea \
   --signer-workflow KSAModding/Borea/.github/workflows/release.yml
 ```
 
+`Borea-<version>.cdx.json` is the software bill of materials, in CycloneDX JSON.
+It includes the NuGet packages Borea.App is built from, with version, license and hash.
+One list covers all four builds, so it holds the native asset packages of every platform.
+The same list is attested to each archive, and you can use this command to prove that it belongs to one.
+With `--format json`, the output includes the attested list.
+
+```sh
+gh attestation verify <archive> --repo KSAModding/Borea \
+  --signer-workflow KSAModding/Borea/.github/workflows/release.yml \
+  --predicate-type https://cyclonedx.org/bom
+```
+
 # Credits
 - [MrJeranimo](https://github.com/MrJeranimo) - Original Creator and Developer
 


### PR DESCRIPTION
Closes #81. Stacked on #78, so the base branch is `release-workflow`.

**Every release now ships a software bill of materials next to the builds.**
An SBOM is a list of every third-party package inside a program, with the exact version, the license and a hash of each package. With it, anyone can answer "does this Borea build carry the vulnerable version of package X" by reading one file instead of rebuilding Borea. `SHA256SUMS.txt` says the files are unchanged, the provenance attestation says which workflow run built them, and the SBOM says what is inside them.

How it works:

1. A new `sbom` job restores `Borea.App` the way the builds do and runs the CycloneDX .NET tool on the restored package graph. The tool is pinned in `.config/dotnet-tools.json`, which Dependabot keeps current with the other NuGet packages.
2. The job checks the result: Avalonia, CommunityToolkit.Mvvm, Tomlyn and one transitive package are listed, nothing test-only or Debug-only is, and every package sits in the dependency graph.
3. The release job adds the file to the checksum table and the release assets, and attests it twice: build provenance like every other file, and an SBOM attestation that binds the list to each archive.

What the user gets: one more release asset, `Borea-<version>.cdx.json`, one more row in the checksum table, and a verify command in the release text and the README.

The version is now named once in the `test` job and read by every later job, so a bad tag fails before the tests run.

Two things differ from the issue text. `actions/attest-sbom` is deprecated and only wraps `actions/attest`, so the workflow uses `actions/attest` directly. The optional dependency submission is left out: it needs `contents: write` in a job that restores packages, and once #82 lands a lock file, GitHub's dependency graph reads the transitive closure from it anyway. #82 itself is not needed first, because the SBOM command does not change when the lock file arrives.

**Tested locally:** the tool run on `Borea.App` (31 packages, each with license and hash, the Debug-only DiagnosticsSupport excluded), the check script with a failing case, the release body step, and `actionlint`. GitHub's own dependency graph of the repository lists the same packages plus exactly the 13 test packages and the Debug-only one. **Not tested yet:** the attestation and the upload, which only run on a real tag, same as #78.

One limit: the SBOM lists the NuGet packages, not the .NET runtime that the self-contained builds carry. The runtime version is in `Borea.App.deps.json` inside each archive.

LLM usage disclosure: Claude Fable 5.1 (and Opus 5 for the code review workflow) was used collaboratively with me to create parts of this. I read, reviewed and tested all of it myself and like it.
