### PR TITLE
Adopt a mod loader installed by hand

### DIFF
--- a/Borea.slnx
+++ b/Borea.slnx
@@ -14,6 +14,7 @@
     <Project Path="tests/Borea.Network.Tests/Borea.Network.Tests.csproj" />
     <Project Path="tests/Borea.Storage.Tests/Borea.Storage.Tests.csproj" />
     <Project Path="tests/Borea.Storage.Tests/Fixtures/GameVersionFixture/GameVersionFixture.csproj" />
+    <Project Path="tests/Borea.Storage.Tests/Fixtures/LoaderVersionFixture/LoaderVersionFixture.csproj" />
     <Project Path="tests/Borea.Storage.Tests/Fixtures/UnparseableVersionFixture/UnparseableVersionFixture.csproj" />
   </Folder>
 </Solution>

--- a/src/Borea.Cli/Commands/SettingsCommand.cs
+++ b/src/Borea.Cli/Commands/SettingsCommand.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using Borea.Cli.Output;
+using Borea.Core.ModLoaders;
 using Borea.Core.Mods;
 using Borea.Core.Settings;
 
@@ -76,7 +77,8 @@ internal static class SettingsCommand
         {
             var id = parseResult.GetRequiredValue(loaderId);
             var fullPath = Path.GetFullPath(parseResult.GetRequiredValue(directory));
-            await cli.SettingsRepository.SaveAsync(cli.Settings.WithLoaderDirectory(id, fullPath), ct).ConfigureAwait(false);
+            var installation = new LoaderInstallation(fullPath, version: null, rawVersion: null, isAdopted: true);
+            await cli.SettingsRepository.SaveAsync(cli.Settings.WithLoaderInstallation(id, installation), ct).ConfigureAwait(false);
 
             output.WriteLine($"Loader {id} directory: {fullPath}");
             WarnWhenMissing(error, fullPath);
@@ -100,21 +102,26 @@ internal static class SettingsCommand
     {
         output.WriteLine($"Game directory: {settings.GameDirectoryPath ?? "not set"}");
 
-        if (settings.LoaderDirectoryPaths.Count == 0)
+        if (settings.LoaderInstallations.Count == 0)
         {
             output.WriteLine("Loader directories: none");
             return;
         }
 
         output.WriteLine("Loader directories:");
-        foreach (var (loaderId, path) in settings.LoaderDirectoryPaths.OrderBy(p => p.Key, ModIds.Comparer))
-            output.WriteLine($"  {loaderId}: {path}");
+        foreach (var (loaderId, installation) in settings.LoaderInstallations.OrderBy(p => p.Key, ModIds.Comparer))
+            output.WriteLine($"  {loaderId}: {installation.DirectoryPath}");
     }
 
     /// <summary>The JSON shape of <c>settings show</c>.</summary>
     private sealed record SettingsView(string? GameDirectory, IReadOnlyDictionary<string, string> LoaderDirectories)
     {
         public static SettingsView From(BoreaSettings settings)
-            => new(settings.GameDirectoryPath, settings.LoaderDirectoryPaths);
+            => new(
+                settings.GameDirectoryPath,
+                settings.LoaderInstallations.ToDictionary(
+                    pair => pair.Key,
+                    pair => pair.Value.DirectoryPath,
+                    ModIds.Comparer));
     }
 }

--- a/src/Borea.Composition/BoreaServices.cs
+++ b/src/Borea.Composition/BoreaServices.cs
@@ -114,7 +114,11 @@ public sealed class BoreaServices : IDisposable
 
         // every other service resolves its paths through the provider
         // built from those settings.
-        var paths = new GamePathProvider(settings.GameDirectoryPath, settings.LoaderDirectoryPaths, boreaRoot);
+        var loaderDirectories = settings.LoaderInstallations.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value.DirectoryPath,
+            ModIds.Comparer);
+        var paths = new GamePathProvider(settings.GameDirectoryPath, loaderDirectories, boreaRoot);
 
         // Network. Every service that talks to a remote host is built here on the
         // one client. Only the SpaceDock repository takes the resolver, because a

--- a/src/Borea.Composition/BoreaServices.cs
+++ b/src/Borea.Composition/BoreaServices.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using Borea.Core.Game;
 using Borea.Core.Index;
 using Borea.Core.Instances;
+using Borea.Core.ModLoaders;
 using Borea.Core.ModPacks;
 using Borea.Core.Mods;
 using Borea.Core.Paths;
@@ -14,6 +15,7 @@ using Borea.Network.Sources;
 using Borea.Network.SpaceDock;
 using Borea.Storage.Game;
 using Borea.Storage.Instances;
+using Borea.Storage.ModLoaders;
 using Borea.Storage.ModPacks;
 using Borea.Storage.Mods;
 using Borea.Storage.Paths;
@@ -78,6 +80,12 @@ public sealed class BoreaServices : IDisposable
 
     public required IModDownloader Downloader { get; init; }
 
+    public required ILoaderInstaller LoaderInstaller { get; init; }
+
+    public required ILoaderAdopter LoaderAdopter { get; init; }
+
+    public required ILoaderUninstaller LoaderUninstaller { get; init; }
+
     public required ILatestVersionPing LatestVersion { get; init; }
 
     public required IInstalledGameVersionProvider InstalledVersion { get; init; }
@@ -130,19 +138,26 @@ public sealed class BoreaServices : IDisposable
         {
             [SpaceDockModRepository.SourceName] = new SpaceDockModRepository(http, resolver),
         };
+        var mods = new CompositeModRepository(sources);
+        var downloader = new HttpModDownloader(http);
+        var settingsRepository = new FileBoreaSettingsRepository(paths);
+        var loaderConfiguration = new LoaderConfigurator();
 
         return new BoreaServices(http)
         {
             Settings = settings,
             Paths = paths,
-            SettingsRepository = new FileBoreaSettingsRepository(paths),
+            SettingsRepository = settingsRepository,
             Instances = new FileInstanceRepository(paths),
             ModState = new FileModStateRepository(paths),
             ModFavorites = new FileModFavoritesRepository(paths),
             ModPackFavorites = new FileModPackFavoritesRepository(paths),
             Uninstaller = new FileModUninstaller(paths),
-            Mods = new CompositeModRepository(sources),
-            Downloader = new HttpModDownloader(http),
+            Mods = mods,
+            Downloader = downloader,
+            LoaderInstaller = new FileLoaderInstaller(paths, downloader, settingsRepository, loaderConfiguration),
+            LoaderAdopter = new FileLoaderAdopter(settingsRepository, loaderConfiguration),
+            LoaderUninstaller = new FileLoaderUninstaller(settingsRepository),
             LatestVersion = new LatestVersionPing(http),
             InstalledVersion = new InstalledGameVersionProvider(paths),
             IndexFetcher = new ContentIndexFetcher(http, ContentIndexUri),

--- a/src/Borea.Core/ModLoaders/ILoaderAdopter.cs
+++ b/src/Borea.Core/ModLoaders/ILoaderAdopter.cs
@@ -1,0 +1,28 @@
+using Borea.Core.Mods;
+
+namespace Borea.Core.ModLoaders;
+
+/// <summary>
+/// Validates and records a mod loader that Borea did not install.
+/// </summary>
+public interface ILoaderAdopter
+{
+    /// <summary>
+    /// Checks the launch target and its file version, reads the configured game
+    /// path without changing it, and records the loader as adopted.
+    /// </summary>
+    Task<LoaderAdoptionResult> AdoptAsync(
+        ModMetadata loader,
+        IReadOnlyList<ModVersionMetadata> releases,
+        string directory,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record LoaderAdoptionResult(
+    string LoaderId,
+    string Directory,
+    string? RawVersion,
+    ModVersion? Version,
+    string? ConfiguredGameDirectory,
+    bool? GameDirectoryMatches,
+    IReadOnlyList<string> Warnings);

--- a/src/Borea.Core/ModLoaders/ILoaderConfigurationReader.cs
+++ b/src/Borea.Core/ModLoaders/ILoaderConfigurationReader.cs
@@ -1,0 +1,19 @@
+using Borea.Core.Mods;
+
+namespace Borea.Core.ModLoaders;
+
+/// <summary>
+/// Reads the game path named by a loader's authored configuration contract.
+/// </summary>
+public interface ILoaderConfigurationReader
+{
+    /// <summary>
+    /// Returns the configured game path without changing the loader's file.
+    /// Null means that no path is declared, the file is absent, or the key is
+    /// absent.
+    /// </summary>
+    Task<string?> ReadConfiguredGamePathAsync(
+        ModMetadata loader,
+        string loaderDirectory,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Borea.Core/ModLoaders/ILoaderUninstaller.cs
+++ b/src/Borea.Core/ModLoaders/ILoaderUninstaller.cs
@@ -1,0 +1,18 @@
+namespace Borea.Core.ModLoaders;
+
+public interface ILoaderUninstaller
+{
+    /// <summary>
+    /// Removes the loader record. The directory is removed only when Borea
+    /// created it.
+    /// </summary>
+    Task<LoaderUninstallResult> UninstallAsync(
+        string loaderId,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record LoaderUninstallResult(
+    string LoaderId,
+    string? Directory,
+    bool RecordRemoved,
+    bool DirectoryRemoved);

--- a/src/Borea.Core/ModLoaders/LoaderInstallation.cs
+++ b/src/Borea.Core/ModLoaders/LoaderInstallation.cs
@@ -1,0 +1,34 @@
+using Borea.Core.Mods;
+
+namespace Borea.Core.ModLoaders;
+
+/// <summary>
+/// The loader installation Borea records for launch, update, and uninstall.
+/// </summary>
+public sealed class LoaderInstallation
+{
+    public string DirectoryPath { get; }
+
+    /// <summary>The matched indexed release, or null when it is unknown.</summary>
+    public ModVersion? Version { get; }
+
+    /// <summary>The file version read from the launch target, if available.</summary>
+    public string? RawVersion { get; }
+
+    /// <summary>True when Borea did not create the loader directory.</summary>
+    public bool IsAdopted { get; }
+
+    public LoaderInstallation(string directoryPath, ModVersion? version, string? rawVersion, bool isAdopted)
+    {
+        if (string.IsNullOrWhiteSpace(directoryPath))
+            throw new ArgumentException("Loader directory path cannot be null or whitespace.", nameof(directoryPath));
+
+        if (rawVersion is not null && string.IsNullOrWhiteSpace(rawVersion))
+            throw new ArgumentException("Raw loader version, if provided, cannot be whitespace.", nameof(rawVersion));
+
+        DirectoryPath = directoryPath;
+        Version = version;
+        RawVersion = rawVersion;
+        IsAdopted = isAdopted;
+    }
+}

--- a/src/Borea.Core/Settings/BoreaSettings.cs
+++ b/src/Borea.Core/Settings/BoreaSettings.cs
@@ -1,4 +1,5 @@
-﻿using Borea.Core.Mods;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
 
 namespace Borea.Core.Settings;
 
@@ -11,57 +12,59 @@ public sealed class BoreaSettings
     public string? GameDirectoryPath { get; }
 
     /// <summary>
-    /// Where each installed mod loader lives, keyed by loader id. Empty means none.
+    /// Installation state for each loader, keyed by loader id. Empty means none.
     /// </summary>
-    public IReadOnlyDictionary<string, string> LoaderDirectoryPaths { get; }
+    public IReadOnlyDictionary<string, LoaderInstallation> LoaderInstallations { get; }
 
-    public BoreaSettings(string? gameDirectoryPath, IReadOnlyDictionary<string, string>? loaderDirectoryPaths = null)
+    public BoreaSettings(
+        string? gameDirectoryPath,
+        IReadOnlyDictionary<string, LoaderInstallation>? loaderInstallations = null)
     {
         if (gameDirectoryPath is not null && string.IsNullOrWhiteSpace(gameDirectoryPath))
             throw new ArgumentException("Game directory path, if provided, cannot be whitespace.", nameof(gameDirectoryPath));
 
         GameDirectoryPath = gameDirectoryPath;
-        LoaderDirectoryPaths = Build(loaderDirectoryPaths, nameof(loaderDirectoryPaths));
+        LoaderInstallations = Build(loaderInstallations, nameof(loaderInstallations));
     }
 
     /// <summary>
     /// A copy with the game directory replaced. The loaders stay as they are.
     /// </summary>
     public BoreaSettings WithGameDirectory(string? gameDirectoryPath)
-        => new(gameDirectoryPath, LoaderDirectoryPaths);
+        => new(gameDirectoryPath, LoaderInstallations);
 
     /// <summary>
-    /// A copy with one loader's directory set. The id is stored as given here,
+    /// A copy with one loader installation set. The id is stored as given here,
     /// also when the loader was known under another casing.
     /// </summary>
-    public BoreaSettings WithLoaderDirectory(string loaderId, string directoryPath)
+    public BoreaSettings WithLoaderInstallation(string loaderId, LoaderInstallation installation)
     {
         ModIds.Validate(loaderId, nameof(loaderId));
-
-        if (string.IsNullOrWhiteSpace(directoryPath))
-            throw new ArgumentException("Loader directory path cannot be null or whitespace.", nameof(directoryPath));
+        ArgumentNullException.ThrowIfNull(installation);
 
         // An assignment through the indexer keeps the key that is already
         // there, so the old casing goes first.
-        var paths = new Dictionary<string, string>(LoaderDirectoryPaths, ModIds.Comparer);
-        paths.Remove(loaderId);
-        paths[loaderId] = directoryPath;
+        var installations = new Dictionary<string, LoaderInstallation>(LoaderInstallations, ModIds.Comparer);
+        installations.Remove(loaderId);
+        installations[loaderId] = installation;
 
-        return new BoreaSettings(GameDirectoryPath, paths);
+        return new BoreaSettings(GameDirectoryPath, installations);
     }
 
-    private static IReadOnlyDictionary<string, string> Build(IReadOnlyDictionary<string, string>? paths, string paramName)
+    private static IReadOnlyDictionary<string, LoaderInstallation> Build(
+        IReadOnlyDictionary<string, LoaderInstallation>? installations,
+        string paramName)
     {
-        var built = new Dictionary<string, string>(ModIds.Comparer);
+        var built = new Dictionary<string, LoaderInstallation>(ModIds.Comparer);
 
-        foreach (var (loaderId, path) in paths ?? new Dictionary<string, string>())
+        foreach (var (loaderId, installation) in installations ?? new Dictionary<string, LoaderInstallation>())
         {
             ModIds.Validate(loaderId, paramName);
 
-            if (string.IsNullOrWhiteSpace(path))
-                throw new ArgumentException($"The path for loader '{loaderId}' cannot be whitespace.", paramName);
+            if (installation is null)
+                throw new ArgumentException($"The installation for loader '{loaderId}' cannot be null.", paramName);
 
-            if (!built.TryAdd(loaderId, path))
+            if (!built.TryAdd(loaderId, installation))
                 throw new ArgumentException($"Loader id '{loaderId}' appears more than once when compared case-insensitively.", paramName);
         }
 

--- a/src/Borea.Storage/ModLoaders/FileLoaderAdopter.cs
+++ b/src/Borea.Storage/ModLoaders/FileLoaderAdopter.cs
@@ -53,12 +53,34 @@ public sealed class FileLoaderAdopter : ILoaderAdopter
 
         var rawVersion = ReadFileVersion(executable);
         var version = MatchVersion(loader, releases, rawVersion);
-        var configuredGameDirectory = await _configuration
-            .ReadConfiguredGamePathAsync(loader, loaderDirectory, cancellationToken)
-            .ConfigureAwait(false);
+        string? configuredGameDirectory = null;
+        string? configurationWarning = null;
+        try
+        {
+            configuredGameDirectory = await _configuration
+                .ReadConfiguredGamePathAsync(loader, loaderDirectory, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is IOException
+            or UnauthorizedAccessException
+            or InvalidOperationException
+            or NotSupportedException
+            or ArgumentException)
+        {
+            configurationWarning =
+                $"Borea could not inspect the game directory configured for {loader.Name}. {exception.Message} The configuration was not changed.";
+        }
+
         var gameDirectoryMatches = CompareGameDirectory(settings.GameDirectoryPath, configuredGameDirectory);
 
-        var warnings = Warnings(loader, rawVersion, version, settings.GameDirectoryPath, configuredGameDirectory, gameDirectoryMatches);
+        var warnings = Warnings(
+            loader,
+            rawVersion,
+            version,
+            settings.GameDirectoryPath,
+            configuredGameDirectory,
+            gameDirectoryMatches,
+            configurationWarning);
         var installations = settings.LoaderInstallations.ToDictionary(pair => pair.Key, pair => pair.Value, ModIds.Comparer);
         installations.Remove(loader.ModId);
         installations[loader.ModId] = new LoaderInstallation(loaderDirectory, version, rawVersion, isAdopted: true);
@@ -98,7 +120,8 @@ public sealed class FileLoaderAdopter : ILoaderAdopter
         ModVersion? version,
         string? managedGameDirectory,
         string? configuredGameDirectory,
-        bool? gameDirectoryMatches)
+        bool? gameDirectoryMatches,
+        string? configurationWarning)
     {
         var warnings = new List<string>();
 
@@ -107,7 +130,11 @@ public sealed class FileLoaderAdopter : ILoaderAdopter
         else if (version is null)
             warnings.Add($"The file version '{rawVersion}' does not match an indexed release of {loader.Name}. The loader version is unknown.");
 
-        if (gameDirectoryMatches == false)
+        if (configurationWarning is not null)
+        {
+            warnings.Add(configurationWarning);
+        }
+        else if (gameDirectoryMatches == false)
         {
             warnings.Add(
                 $"{loader.Name} is configured for '{configuredGameDirectory}', not the game directory Borea manages at '{managedGameDirectory}'. The configuration was not changed.");

--- a/src/Borea.Storage/ModLoaders/FileLoaderAdopter.cs
+++ b/src/Borea.Storage/ModLoaders/FileLoaderAdopter.cs
@@ -1,0 +1,186 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+using Borea.Core.Settings;
+
+namespace Borea.Storage.ModLoaders;
+
+/// <summary>
+/// File-backed <see cref="ILoaderAdopter"/>.
+/// </summary>
+public sealed class FileLoaderAdopter : ILoaderAdopter
+{
+    private readonly IBoreaSettingsRepository _settings;
+    private readonly ILoaderConfigurationReader _configuration;
+
+    public FileLoaderAdopter(
+        IBoreaSettingsRepository settings,
+        ILoaderConfigurationReader configuration)
+    {
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    }
+
+    public async Task<LoaderAdoptionResult> AdoptAsync(
+        ModMetadata loader,
+        IReadOnlyList<ModVersionMetadata> releases,
+        string directory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(loader);
+        ArgumentNullException.ThrowIfNull(releases);
+
+        if (loader.Type != ContentType.ModLoader)
+            throw new ArgumentException("Only a mod loader can be adopted.", nameof(loader));
+
+        var launch = loader.Provides?.Launch;
+        if (launch is null)
+            throw new NotSupportedException($"The listing of {loader.Name} does not say what to launch, so Borea cannot identify it on disk.");
+
+        var loaderDirectory = Absolute(directory, nameof(directory));
+        var executable = Path.GetFullPath(Path.Combine(loaderDirectory, launch.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(executable))
+            throw new InvalidOperationException($"'{loaderDirectory}' does not hold the listed launch file '{launch}'.");
+
+        var settings = await _settings.GetAsync(cancellationToken).ConfigureAwait(false) ?? new BoreaSettings(null);
+        if (settings.LoaderInstallations.TryGetValue(loader.ModId, out var recorded)
+            && !SamePath(recorded.DirectoryPath, loaderDirectory))
+        {
+            throw new InvalidOperationException(
+                $"{loader.Name} is already recorded at '{recorded.DirectoryPath}'. Remove that record or adopt that directory instead.");
+        }
+
+        var rawVersion = ReadFileVersion(executable);
+        var version = MatchVersion(loader, releases, rawVersion);
+        var configuredGameDirectory = await _configuration
+            .ReadConfiguredGamePathAsync(loader, loaderDirectory, cancellationToken)
+            .ConfigureAwait(false);
+        var gameDirectoryMatches = CompareGameDirectory(settings.GameDirectoryPath, configuredGameDirectory);
+
+        var warnings = Warnings(loader, rawVersion, version, settings.GameDirectoryPath, configuredGameDirectory, gameDirectoryMatches);
+        var installations = settings.LoaderInstallations.ToDictionary(pair => pair.Key, pair => pair.Value, ModIds.Comparer);
+        installations.Remove(loader.ModId);
+        installations[loader.ModId] = new LoaderInstallation(loaderDirectory, version, rawVersion, isAdopted: true);
+
+        await _settings.SaveAsync(
+            new BoreaSettings(settings.GameDirectoryPath, loaderInstallations: installations),
+            cancellationToken).ConfigureAwait(false);
+
+        return new LoaderAdoptionResult(
+            loader.ModId,
+            loaderDirectory,
+            rawVersion,
+            version,
+            configuredGameDirectory,
+            gameDirectoryMatches,
+            new ReadOnlyCollection<string>(warnings));
+    }
+
+    private static ModVersion? MatchVersion(
+        ModMetadata loader,
+        IReadOnlyList<ModVersionMetadata> releases,
+        string? rawVersion)
+    {
+        if (!TryParseFileVersion(rawVersion, out var candidate))
+            return null;
+
+        var release = releases.FirstOrDefault(release =>
+            release.Type == ContentType.ModLoader
+            && ModIds.Equals(release.ModId, loader.ModId)
+            && release.Version == candidate);
+        return release?.Version;
+    }
+
+    private static List<string> Warnings(
+        ModMetadata loader,
+        string? rawVersion,
+        ModVersion? version,
+        string? managedGameDirectory,
+        string? configuredGameDirectory,
+        bool? gameDirectoryMatches)
+    {
+        var warnings = new List<string>();
+
+        if (rawVersion is null)
+            warnings.Add($"Borea could not read a file version from the launch file of {loader.Name}. The loader version is unknown.");
+        else if (version is null)
+            warnings.Add($"The file version '{rawVersion}' does not match an indexed release of {loader.Name}. The loader version is unknown.");
+
+        if (gameDirectoryMatches == false)
+        {
+            warnings.Add(
+                $"{loader.Name} is configured for '{configuredGameDirectory}', not the game directory Borea manages at '{managedGameDirectory}'. The configuration was not changed.");
+        }
+        else if (gameDirectoryMatches is null)
+        {
+            warnings.Add(
+                $"Borea could not confirm the game directory configured for {loader.Name}. The configuration was not changed.");
+        }
+
+        return warnings;
+    }
+
+    private static string? ReadFileVersion(string executable)
+    {
+        try
+        {
+            var info = FileVersionInfo.GetVersionInfo(executable);
+            var version = !string.IsNullOrWhiteSpace(info.FileVersion)
+                ? info.FileVersion
+                : !string.IsNullOrWhiteSpace(info.ProductVersion)
+                    ? info.ProductVersion
+                    : null;
+            return version?.Trim();
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return null;
+        }
+    }
+
+    private static bool TryParseFileVersion(string? rawVersion, out ModVersion version)
+    {
+        if (ModVersion.TryParse(rawVersion, out version))
+            return true;
+
+        var parts = rawVersion?.Split('.');
+        return parts is { Length: 4 }
+            && parts[3] == "0"
+            && ModVersion.TryParse(string.Join('.', parts.Take(3)), out version);
+    }
+
+    private static bool? CompareGameDirectory(string? managed, string? configured)
+    {
+        if (string.IsNullOrWhiteSpace(managed) || configured is null)
+            return null;
+
+        if (string.IsNullOrWhiteSpace(configured))
+            return false;
+
+        if (!Path.IsPathFullyQualified(managed) || !Path.IsPathFullyQualified(configured))
+            return false;
+
+        return SamePath(managed, configured);
+    }
+
+    private static string Absolute(string path, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("A loader directory is required.", paramName);
+
+        if (!Path.IsPathFullyQualified(path))
+            throw new ArgumentException("The loader directory must be absolute.", paramName);
+
+        return Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+    }
+
+    private static bool SamePath(string left, string right)
+    {
+        var comparison = OperatingSystem.IsLinux() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+        return string.Equals(
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(left)),
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(right)),
+            comparison);
+    }
+}

--- a/src/Borea.Storage/ModLoaders/FileLoaderInstaller.cs
+++ b/src/Borea.Storage/ModLoaders/FileLoaderInstaller.cs
@@ -40,7 +40,8 @@ public sealed class FileLoaderInstaller : ILoaderInstaller
         RequireInstallable(loader, release);
 
         var settings = await _settings.GetAsync(cancellationToken).ConfigureAwait(false) ?? new BoreaSettings(null);
-        var recorded = settings.LoaderDirectoryPaths.TryGetValue(loader.ModId, out var known) ? Path.GetFullPath(known) : null;
+        var recordedInstallation = settings.LoaderInstallations.TryGetValue(loader.ModId, out var known) ? known : null;
+        var recorded = recordedInstallation is null ? null : Path.GetFullPath(recordedInstallation.DirectoryPath);
 
         var (target, path, root) = Describe(loader, release);
         var destination = Resolve(loader, target, path, directory, recorded, settings.GameDirectoryPath);
@@ -84,9 +85,16 @@ public sealed class FileLoaderInstaller : ILoaderInstaller
                 ? null
                 : await _configurator.ConfigureAsync(loader, destination, gameDirectory!, cancellationToken).ConfigureAwait(false);
 
-            var paths = settings.LoaderDirectoryPaths.ToDictionary(p => p.Key, p => p.Value, ModIds.Comparer);
-            paths[loader.ModId] = destination;
-            await _settings.SaveAsync(new BoreaSettings(settings.GameDirectoryPath, paths), cancellationToken).ConfigureAwait(false);
+            var installations = settings.LoaderInstallations.ToDictionary(p => p.Key, p => p.Value, ModIds.Comparer);
+            installations.Remove(loader.ModId);
+            installations[loader.ModId] = new LoaderInstallation(
+                destination,
+                release.Version,
+                rawVersion: null,
+                isAdopted: recordedInstallation?.IsAdopted ?? !created);
+            await _settings.SaveAsync(
+                new BoreaSettings(settings.GameDirectoryPath, loaderInstallations: installations),
+                cancellationToken).ConfigureAwait(false);
 
             return new LoaderInstallResult(loader.ModId, release.Version, destination, download, configurationFile, replacing);
         }

--- a/src/Borea.Storage/ModLoaders/FileLoaderUninstaller.cs
+++ b/src/Borea.Storage/ModLoaders/FileLoaderUninstaller.cs
@@ -1,0 +1,48 @@
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+using Borea.Core.Settings;
+
+namespace Borea.Storage.ModLoaders;
+
+/// <summary>
+/// File-backed <see cref="ILoaderUninstaller"/>.
+/// </summary>
+public sealed class FileLoaderUninstaller : ILoaderUninstaller
+{
+    private readonly IBoreaSettingsRepository _settings;
+
+    public FileLoaderUninstaller(IBoreaSettingsRepository settings)
+    {
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+    }
+
+    public async Task<LoaderUninstallResult> UninstallAsync(
+        string loaderId,
+        CancellationToken cancellationToken = default)
+    {
+        ModIds.Validate(loaderId, nameof(loaderId));
+
+        var settings = await _settings.GetAsync(cancellationToken).ConfigureAwait(false);
+        if (settings is null || !settings.LoaderInstallations.TryGetValue(loaderId, out var installation))
+            return new LoaderUninstallResult(loaderId, null, RecordRemoved: false, DirectoryRemoved: false);
+
+        var directoryRemoved = false;
+        if (!installation.IsAdopted && Directory.Exists(installation.DirectoryPath))
+        {
+            if (!Path.IsPathFullyQualified(installation.DirectoryPath))
+                throw new InvalidOperationException($"The recorded directory for '{loaderId}' is not absolute, so Borea will not delete it.");
+
+            cancellationToken.ThrowIfCancellationRequested();
+            Directory.Delete(Path.GetFullPath(installation.DirectoryPath), recursive: true);
+            directoryRemoved = true;
+        }
+
+        var installations = settings.LoaderInstallations.ToDictionary(pair => pair.Key, pair => pair.Value, ModIds.Comparer);
+        installations.Remove(loaderId);
+        await _settings.SaveAsync(
+            new BoreaSettings(settings.GameDirectoryPath, loaderInstallations: installations),
+            cancellationToken).ConfigureAwait(false);
+
+        return new LoaderUninstallResult(loaderId, installation.DirectoryPath, RecordRemoved: true, DirectoryRemoved: directoryRemoved);
+    }
+}

--- a/src/Borea.Storage/ModLoaders/LoaderConfigurator.cs
+++ b/src/Borea.Storage/ModLoaders/LoaderConfigurator.cs
@@ -14,7 +14,7 @@ namespace Borea.Storage.ModLoaders;
 /// The file is read as a tree, the one key is set, and the tree is written
 /// back, so every other key survives.
 /// </summary>
-public sealed class LoaderConfigurator : ILoaderConfigurator
+public sealed class LoaderConfigurator : ILoaderConfigurator, ILoaderConfigurationReader
 {
     private static readonly JsonDocumentOptions JsonReadOptions = new()
     {
@@ -59,6 +59,106 @@ public sealed class LoaderConfigurator : ILoaderConfigurator
 
         await AtomicFile.WriteAllTextAsync(file, written, cancellationToken).ConfigureAwait(false);
         return file;
+    }
+
+    public async Task<string?> ReadConfiguredGamePathAsync(
+        ModMetadata loader,
+        string loaderDirectory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(loader);
+
+        if (loader.Type != ContentType.ModLoader)
+            throw new ArgumentException("Only a mod loader has a configuration file to read.", nameof(loader));
+
+        var directory = Absolute(loaderDirectory, nameof(loaderDirectory));
+        var configure = loader.Provides?.Configure;
+        if (configure?.GamePath is null)
+            return null;
+
+        if (configure.Format is not (ConfigureFormat.Json or ConfigureFormat.Toml))
+            throw new NotSupportedException($"The listing of {loader.Name} keeps its configuration in a format this version of Borea cannot read.");
+
+        var file = Path.GetFullPath(Path.Combine(directory, configure.File.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(file))
+            return null;
+
+        var text = await File.ReadAllTextAsync(file, cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+
+        var keys = configure.GamePath.Split('.');
+        return configure.Format == ConfigureFormat.Json
+            ? ReadJsonGamePath(text, keys, file, loader)
+            : ReadTomlGamePath(text, keys, file, loader);
+    }
+
+    private static string? ReadJsonGamePath(string text, string[] keys, string file, ModMetadata loader)
+    {
+        JsonNode? node;
+        try
+        {
+            node = JsonNode.Parse(text, documentOptions: JsonReadOptions);
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidOperationException($"'{file}' is not valid JSON, so Borea cannot inspect {loader.Name}. {exception.Message}", exception);
+        }
+
+        var table = node as JsonObject
+            ?? throw new InvalidOperationException($"'{file}' does not hold a JSON object at its root, so Borea cannot inspect its game path.");
+
+        for (var i = 0; i < keys.Length - 1; i++)
+        {
+            if (table[keys[i]] is null)
+                return null;
+
+            table = table[keys[i]] as JsonObject
+                ?? throw new InvalidOperationException(
+                    $"'{file}' holds a value at '{string.Join('.', keys.Take(i + 1))}' where the listing of {loader.Name} expects an object.");
+        }
+
+        var value = table[keys[^1]];
+        if (value is null)
+            return null;
+
+        return value is JsonValue json && json.TryGetValue<string>(out var result)
+            ? result
+            : throw new InvalidOperationException($"'{file}' does not hold a string at '{string.Join('.', keys)}'.");
+    }
+
+    private static string? ReadTomlGamePath(string text, string[] keys, string file, ModMetadata loader)
+    {
+        var options = new TomlSerializerOptions { MetadataStore = new TomlMetadataStore() };
+
+        TomlTable table;
+        try
+        {
+            if (DuplicateKey(text, options) is { } duplicate)
+                throw new InvalidOperationException($"'{file}' holds the key '{duplicate}' twice, so Borea cannot inspect {loader.Name} without choosing one value.");
+
+            table = TomlSerializer.Deserialize<TomlTable>(text, options) ?? new TomlTable();
+        }
+        catch (TomlException exception)
+        {
+            throw new InvalidOperationException($"'{file}' is not valid TOML, so Borea cannot inspect {loader.Name}. {exception.Message}", exception);
+        }
+
+        for (var i = 0; i < keys.Length - 1; i++)
+        {
+            if (!table.TryGetValue(keys[i], out var existing))
+                return null;
+
+            table = existing as TomlTable
+                ?? throw new InvalidOperationException(
+                    $"'{file}' holds a value at '{string.Join('.', keys.Take(i + 1))}' where the listing of {loader.Name} expects a table.");
+        }
+
+        if (!table.TryGetValue(keys[^1], out var value))
+            return null;
+
+        return value as string
+            ?? throw new InvalidOperationException($"'{file}' does not hold a string at '{string.Join('.', keys)}'.");
     }
 
     private static string SetJson(string? text, string[] keys, string value, string file, ModMetadata loader)

--- a/src/Borea.Storage/Settings/BoreaSettingsDto.cs
+++ b/src/Borea.Storage/Settings/BoreaSettingsDto.cs
@@ -1,12 +1,23 @@
-﻿namespace Borea.Storage.Settings;
+namespace Borea.Storage.Settings;
 
 public sealed class BoreaSettingsDto
 {
     public string? GameDirectoryPath { get; set; }
 
     /// <summary>
-    /// Loader id to install directory. Absent when none, so no empty table is written.
-    /// Keep last: TOML puts every key after a table header inside that table.
+    /// Loader id to installation record. Absent when none, so no empty table is
+    /// written. Keep last because TOML puts each later key below this table.
     /// </summary>
-    public Dictionary<string, string>? LoaderDirectoryPaths { get; set; }
+    public Dictionary<string, LoaderInstallationDto>? LoaderInstallations { get; set; }
+}
+
+public sealed class LoaderInstallationDto
+{
+    public string DirectoryPath { get; set; } = string.Empty;
+
+    public string? Version { get; set; }
+
+    public string? RawVersion { get; set; }
+
+    public bool IsAdopted { get; set; }
 }

--- a/src/Borea.Storage/Settings/BoreaSettingsMapper.cs
+++ b/src/Borea.Storage/Settings/BoreaSettingsMapper.cs
@@ -1,4 +1,6 @@
-﻿using Borea.Core.Settings;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+using Borea.Core.Settings;
 
 namespace Borea.Storage.Settings;
 
@@ -7,11 +9,30 @@ public static class BoreaSettingsMapper
     public static BoreaSettingsDto ToDto(BoreaSettings settings) => new()
     {
         GameDirectoryPath = settings.GameDirectoryPath,
-        LoaderDirectoryPaths = settings.LoaderDirectoryPaths.Count == 0
+        LoaderInstallations = settings.LoaderInstallations.Count == 0
             ? null
-            : settings.LoaderDirectoryPaths.ToDictionary(p => p.Key, p => p.Value),
+            : settings.LoaderInstallations.ToDictionary(
+                pair => pair.Key,
+                pair => ToDto(pair.Value)),
     };
 
-    public static BoreaSettings FromDto(BoreaSettingsDto dto) =>
-        new(dto.GameDirectoryPath, dto.LoaderDirectoryPaths);
+    public static BoreaSettings FromDto(BoreaSettingsDto dto) => new(
+        dto.GameDirectoryPath,
+        dto.LoaderInstallations?.ToDictionary(
+            pair => pair.Key,
+            pair => FromDto(pair.Value)));
+
+    private static LoaderInstallationDto ToDto(LoaderInstallation installation) => new()
+    {
+        DirectoryPath = installation.DirectoryPath,
+        Version = installation.Version?.ToString(),
+        RawVersion = installation.RawVersion,
+        IsAdopted = installation.IsAdopted,
+    };
+
+    private static LoaderInstallation FromDto(LoaderInstallationDto dto) => new(
+        dto.DirectoryPath,
+        dto.Version is null ? null : ModVersion.Parse(dto.Version),
+        dto.RawVersion,
+        dto.IsAdopted);
 }

--- a/tests/Borea.Cli.Tests/SettingsCommandTests.cs
+++ b/tests/Borea.Cli.Tests/SettingsCommandTests.cs
@@ -144,9 +144,13 @@ public sealed class SettingsCommandTests : IDisposable
         // Loader ids that collide by case are rejected when the settings load.
         Directory.CreateDirectory(_host.Root);
         await File.WriteAllTextAsync(_host.Paths.GetBoreaSettingsPath(), """
-            [LoaderDirectoryPaths]
-            StarMap = 'C:\Games\StarMap'
-            starmap = 'C:\Games\Other'
+            [LoaderInstallations.StarMap]
+            DirectoryPath = 'C:\Games\StarMap'
+            IsAdopted = true
+
+            [LoaderInstallations.starmap]
+            DirectoryPath = 'C:\Games\Other'
+            IsAdopted = true
             """);
 
         var run = await _host.RunAsync("settings", "show");

--- a/tests/Borea.Composition.Tests/BoreaServicesTests.cs
+++ b/tests/Borea.Composition.Tests/BoreaServicesTests.cs
@@ -1,4 +1,5 @@
 using Borea.Core.Dependencies;
+using Borea.Core.ModLoaders;
 using Borea.Core.Mods;
 using Borea.Core.Settings;
 using Borea.Network.Index;
@@ -22,7 +23,7 @@ public sealed class BoreaServicesTests : IDisposable
         using var services = await BoreaServices.BuildAsync(_tempRoot);
 
         Assert.Null(services.Settings.GameDirectoryPath);
-        Assert.Empty(services.Settings.LoaderDirectoryPaths);
+        Assert.Empty(services.Settings.LoaderInstallations);
         Assert.Null(services.Paths.GetGameDirectoryPath());
         Assert.Null(services.Paths.GetLoaderDirectoryPath("StarMap"));
     }
@@ -38,7 +39,7 @@ public sealed class BoreaServicesTests : IDisposable
     [Fact]
     public async Task BuildAsync_SettingsNamingNoGame_KnowsTheLoaderOnly()
     {
-        await SaveAsync(new BoreaSettings(null, new Dictionary<string, string> { ["StarMap"] = StarMapPath }));
+        await SaveAsync(new BoreaSettings(null, LoaderAt(StarMapPath)));
 
         using var services = await BoreaServices.BuildAsync(_tempRoot);
 
@@ -49,7 +50,7 @@ public sealed class BoreaServicesTests : IDisposable
     [Fact]
     public async Task BuildAsync_FullSettings_KnowsTheGameAndTheLoader()
     {
-        await SaveAsync(new BoreaSettings(GamePath, new Dictionary<string, string> { ["StarMap"] = StarMapPath }));
+        await SaveAsync(new BoreaSettings(GamePath, LoaderAt(StarMapPath)));
 
         using var services = await BoreaServices.BuildAsync(_tempRoot);
 
@@ -74,9 +75,13 @@ public sealed class BoreaServicesTests : IDisposable
         // build must surface that instead of starting with empty settings.
         Directory.CreateDirectory(_tempRoot);
         await File.WriteAllTextAsync(SettingsPath, """
-            [LoaderDirectoryPaths]
-            StarMap = 'C:\Games\StarMap'
-            starmap = 'C:\Games\Other'
+            [LoaderInstallations.StarMap]
+            DirectoryPath = 'C:\Games\StarMap'
+            IsAdopted = true
+
+            [LoaderInstallations.starmap]
+            DirectoryPath = 'C:\Games\Other'
+            IsAdopted = true
             """);
 
         await Assert.ThrowsAsync<ArgumentException>(() => BoreaServices.BuildAsync(_tempRoot));
@@ -161,6 +166,11 @@ public sealed class BoreaServicesTests : IDisposable
         dependencies: Array.Empty<ModDependency>());
 
     private string SettingsPath => new GamePathProvider(gameDirectory: null, boreaRoot: _tempRoot).GetBoreaSettingsPath();
+
+    private static Dictionary<string, LoaderInstallation> LoaderAt(string path) => new()
+    {
+        ["StarMap"] = new LoaderInstallation(path, ModVersion.Parse("0.4.6"), "0.4.6.0", isAdopted: true),
+    };
 
     private Task SaveAsync(BoreaSettings settings)
         => new FileBoreaSettingsRepository(new GamePathProvider(gameDirectory: null, boreaRoot: _tempRoot)).SaveAsync(settings);

--- a/tests/Borea.Composition.Tests/BoreaServicesTests.cs
+++ b/tests/Borea.Composition.Tests/BoreaServicesTests.cs
@@ -5,6 +5,7 @@ using Borea.Core.Settings;
 using Borea.Network.Index;
 using Borea.Network.Sources;
 using Borea.Storage.Game;
+using Borea.Storage.ModLoaders;
 using Borea.Storage.Paths;
 using Borea.Storage.Settings;
 
@@ -116,6 +117,9 @@ public sealed class BoreaServicesTests : IDisposable
         using var services = await BoreaServices.BuildAsync(_tempRoot);
 
         Assert.IsType<CompositeModRepository>(services.Mods);
+        Assert.IsType<FileLoaderInstaller>(services.LoaderInstaller);
+        Assert.IsType<FileLoaderAdopter>(services.LoaderAdopter);
+        Assert.IsType<FileLoaderUninstaller>(services.LoaderUninstaller);
     }
 
     [Fact]

--- a/tests/Borea.Core.Tests/Settings/BoreaSettingsTests.cs
+++ b/tests/Borea.Core.Tests/Settings/BoreaSettingsTests.cs
@@ -1,14 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
 using Borea.Core.Settings;
-using Xunit;
 
 namespace Borea.Core.Tests.Settings;
 
 public sealed class BoreaSettingsTests
 {
-    private static Dictionary<string, string> StarMapAt(string path = @"C:\Games\StarMap") =>
-        new() { ["StarMap"] = path };
+    private static Dictionary<string, LoaderInstallation> StarMapAt(string path = @"C:\Games\StarMap") =>
+        new()
+        {
+            ["StarMap"] = new LoaderInstallation(path, ModVersion.Parse("0.4.6"), "0.4.6.0", isAdopted: true),
+        };
 
     [Fact]
     public void Constructor_NothingProvided_LeavesGameNullAndNoLoader()
@@ -16,7 +18,7 @@ public sealed class BoreaSettingsTests
         var settings = new BoreaSettings(null);
 
         Assert.Null(settings.GameDirectoryPath);
-        Assert.Empty(settings.LoaderDirectoryPaths);
+        Assert.Empty(settings.LoaderInstallations);
     }
 
     [Fact]
@@ -25,7 +27,7 @@ public sealed class BoreaSettingsTests
         var settings = new BoreaSettings(@"C:\Games\KSA");
 
         Assert.Equal(@"C:\Games\KSA", settings.GameDirectoryPath);
-        Assert.Empty(settings.LoaderDirectoryPaths);
+        Assert.Empty(settings.LoaderInstallations);
     }
 
     [Fact]
@@ -34,20 +36,19 @@ public sealed class BoreaSettingsTests
         var settings = new BoreaSettings(null, StarMapAt());
 
         Assert.Null(settings.GameDirectoryPath);
-        Assert.Equal(@"C:\Games\StarMap", settings.LoaderDirectoryPaths["StarMap"]);
+        Assert.Equal(@"C:\Games\StarMap", settings.LoaderInstallations["StarMap"].DirectoryPath);
     }
 
     [Fact]
     public void Constructor_SeveralLoaders_KeepsEachOne()
     {
-        var settings = new BoreaSettings(@"C:\Games\KSA", new Dictionary<string, string>
-        {
-            ["StarMap"] = @"C:\Games\StarMap",
-            ["Cheese-Loader"] = @"C:\Games\Cheese",
-        });
+        var installations = StarMapAt();
+        installations["Cheese-Loader"] = new LoaderInstallation(@"C:\Games\Cheese", null, null, isAdopted: false);
 
-        Assert.Equal(2, settings.LoaderDirectoryPaths.Count);
-        Assert.Equal(@"C:\Games\Cheese", settings.LoaderDirectoryPaths["Cheese-Loader"]);
+        var settings = new BoreaSettings(@"C:\Games\KSA", installations);
+
+        Assert.Equal(2, settings.LoaderInstallations.Count);
+        Assert.Equal(@"C:\Games\Cheese", settings.LoaderInstallations["Cheese-Loader"].DirectoryPath);
     }
 
     [Fact]
@@ -55,21 +56,20 @@ public sealed class BoreaSettingsTests
     {
         var settings = new BoreaSettings(null, StarMapAt());
 
-        Assert.Equal(@"C:\Games\StarMap", settings.LoaderDirectoryPaths["starmap"]);
-        Assert.Contains("StarMap", settings.LoaderDirectoryPaths.Keys);
+        Assert.Equal(@"C:\Games\StarMap", settings.LoaderInstallations["starmap"].DirectoryPath);
+        Assert.Contains("StarMap", settings.LoaderInstallations.Keys);
     }
 
     [Fact]
     public void Constructor_LoaderIdsCollidingByCase_ThrowsArgumentException()
     {
-        // TOML keys are case-sensitive, ids are not.
-        var paths = new Dictionary<string, string>
+        var installations = new Dictionary<string, LoaderInstallation>
         {
-            ["StarMap"] = @"C:\Games\StarMap",
-            ["starmap"] = @"C:\Games\Other",
+            ["StarMap"] = new LoaderInstallation(@"C:\Games\StarMap", null, null, isAdopted: true),
+            ["starmap"] = new LoaderInstallation(@"C:\Games\Other", null, null, isAdopted: true),
         };
 
-        Assert.Throws<ArgumentException>(() => new BoreaSettings(null, paths));
+        Assert.Throws<ArgumentException>(() => new BoreaSettings(null, installations));
     }
 
     [Theory]
@@ -83,9 +83,9 @@ public sealed class BoreaSettingsTests
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public void Constructor_WhitespaceLoaderPath_ThrowsArgumentException(string loaderPath)
+    public void LoaderInstallation_WhitespaceDirectoryPath_ThrowsArgumentException(string loaderPath)
     {
-        Assert.Throws<ArgumentException>(() => new BoreaSettings(null, StarMapAt(loaderPath)));
+        Assert.Throws<ArgumentException>(() => new LoaderInstallation(loaderPath, null, null, isAdopted: true));
     }
 
     [Theory]
@@ -94,20 +94,23 @@ public sealed class BoreaSettingsTests
     [InlineData("CON")]
     public void Constructor_InvalidLoaderId_ThrowsArgumentException(string loaderId)
     {
-        var paths = new Dictionary<string, string> { [loaderId] = @"C:\Games\Loader" };
+        var installations = new Dictionary<string, LoaderInstallation>
+        {
+            [loaderId] = new LoaderInstallation(@"C:\Games\Loader", null, null, isAdopted: true),
+        };
 
-        Assert.Throws<ArgumentException>(() => new BoreaSettings(null, paths));
+        Assert.Throws<ArgumentException>(() => new BoreaSettings(null, installations));
     }
 
     [Fact]
-    public void LoaderDirectoryPaths_IsACopy_SoLaterEditsDoNotReachIt()
+    public void LoaderInstallations_IsACopy_SoLaterEditsDoNotReachIt()
     {
-        var paths = StarMapAt();
-        var settings = new BoreaSettings(null, paths);
+        var installations = StarMapAt();
+        var settings = new BoreaSettings(null, installations);
 
-        paths["StarMap"] = @"C:\Somewhere\Else";
+        installations["StarMap"] = new LoaderInstallation(@"C:\Somewhere\Else", null, null, isAdopted: true);
 
-        Assert.Equal(@"C:\Games\StarMap", settings.LoaderDirectoryPaths["StarMap"]);
+        Assert.Equal(@"C:\Games\StarMap", settings.LoaderInstallations["StarMap"].DirectoryPath);
     }
 
     [Fact]
@@ -118,50 +121,53 @@ public sealed class BoreaSettingsTests
         var changed = settings.WithGameDirectory(@"D:\KSA");
 
         Assert.Equal(@"D:\KSA", changed.GameDirectoryPath);
-        Assert.Equal(@"C:\Games\StarMap", changed.LoaderDirectoryPaths["StarMap"]);
+        Assert.Equal(@"C:\Games\StarMap", changed.LoaderInstallations["StarMap"].DirectoryPath);
         Assert.Equal(@"C:\Games\KSA", settings.GameDirectoryPath);
     }
 
     [Fact]
-    public void WithLoaderDirectory_AddsALoader_AndKeepsTheRest()
+    public void WithLoaderInstallation_AddsALoader_AndKeepsTheRest()
     {
         var settings = new BoreaSettings(@"C:\Games\KSA", StarMapAt());
+        var installation = new LoaderInstallation(@"C:\Games\Cheese", null, null, isAdopted: true);
 
-        var changed = settings.WithLoaderDirectory("Cheese-Loader", @"C:\Games\Cheese");
+        var changed = settings.WithLoaderInstallation("Cheese-Loader", installation);
 
         Assert.Equal(@"C:\Games\KSA", changed.GameDirectoryPath);
-        Assert.Equal(@"C:\Games\StarMap", changed.LoaderDirectoryPaths["StarMap"]);
-        Assert.Equal(@"C:\Games\Cheese", changed.LoaderDirectoryPaths["Cheese-Loader"]);
-        Assert.Single(settings.LoaderDirectoryPaths);
+        Assert.Equal(@"C:\Games\StarMap", changed.LoaderInstallations["StarMap"].DirectoryPath);
+        Assert.Equal(@"C:\Games\Cheese", changed.LoaderInstallations["Cheese-Loader"].DirectoryPath);
+        Assert.Single(settings.LoaderInstallations);
     }
 
     [Fact]
-    public void WithLoaderDirectory_SameIdInAnotherCase_ReplacesTheEntryAndItsCasing()
+    public void WithLoaderInstallation_SameIdInAnotherCase_ReplacesTheEntryAndItsCasing()
     {
         var settings = new BoreaSettings(null, StarMapAt());
+        var installation = new LoaderInstallation(@"C:\Games\Other", null, null, isAdopted: true);
 
-        var changed = settings.WithLoaderDirectory("starmap", @"C:\Games\Other");
+        var changed = settings.WithLoaderInstallation("starmap", installation);
 
-        var loader = Assert.Single(changed.LoaderDirectoryPaths);
+        var loader = Assert.Single(changed.LoaderInstallations);
         Assert.Equal("starmap", loader.Key);
-        Assert.Equal(@"C:\Games\Other", loader.Value);
+        Assert.Equal(@"C:\Games\Other", loader.Value.DirectoryPath);
     }
 
     [Theory]
     [InlineData("not a valid id")]
     [InlineData("")]
-    public void WithLoaderDirectory_InvalidId_ThrowsArgumentException(string loaderId)
+    public void WithLoaderInstallation_InvalidId_ThrowsArgumentException(string loaderId)
     {
         var settings = new BoreaSettings(null);
+        var installation = new LoaderInstallation(@"C:\Games\Loader", null, null, isAdopted: true);
 
-        Assert.Throws<ArgumentException>(() => settings.WithLoaderDirectory(loaderId, @"C:\Games\Loader"));
+        Assert.Throws<ArgumentException>(() => settings.WithLoaderInstallation(loaderId, installation));
     }
 
     [Fact]
-    public void WithLoaderDirectory_WhitespacePath_ThrowsArgumentException()
+    public void WithLoaderInstallation_NullInstallation_ThrowsArgumentNullException()
     {
         var settings = new BoreaSettings(null);
 
-        Assert.Throws<ArgumentException>(() => settings.WithLoaderDirectory("StarMap", "   "));
+        Assert.Throws<ArgumentNullException>(() => settings.WithLoaderInstallation("StarMap", null!));
     }
 }

--- a/tests/Borea.Storage.Tests/Borea.Storage.Tests.csproj
+++ b/tests/Borea.Storage.Tests/Borea.Storage.Tests.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <!-- Built by the solution, never compiled against. -->
     <VersionFixture Include="Fixtures\GameVersionFixture\GameVersionFixture.csproj" />
+    <VersionFixture Include="Fixtures\LoaderVersionFixture\LoaderVersionFixture.csproj" />
     <VersionFixture Include="Fixtures\UnparseableVersionFixture\UnparseableVersionFixture.csproj" />
     <ProjectReference Include="@(VersionFixture)" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/tests/Borea.Storage.Tests/Fixtures/LoaderVersionFixture/LoaderVersionFixture.csproj
+++ b/tests/Borea.Storage.Tests/Fixtures/LoaderVersionFixture/LoaderVersionFixture.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <FileVersion>0.4.6.0</FileVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/tests/Borea.Storage.Tests/ModLoaders/FileLoaderAdopterTests.cs
+++ b/tests/Borea.Storage.Tests/ModLoaders/FileLoaderAdopterTests.cs
@@ -1,0 +1,211 @@
+using System.Text.Json;
+using Borea.Core.Dependencies;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+using Borea.Core.Settings;
+using Borea.Storage.ModLoaders;
+using Borea.Storage.Settings;
+using Borea.Storage.Tests.Mods;
+using Borea.Storage.Tests.Paths;
+
+namespace Borea.Storage.Tests.ModLoaders;
+
+public sealed class FileLoaderAdopterTests : IDisposable
+{
+    private const string LoaderVersionFixture = "LoaderVersionFixture.dll";
+
+    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+    private readonly TestGamePathProvider _paths;
+    private readonly FileBoreaSettingsRepository _settings;
+    private readonly FileLoaderAdopter _adopter;
+
+    public FileLoaderAdopterTests()
+    {
+        _paths = new TestGamePathProvider(_tempRoot);
+        _settings = new FileBoreaSettingsRepository(_paths);
+        _adopter = new FileLoaderAdopter(_settings, new LoaderConfigurator());
+    }
+
+    private string GameDirectory => Path.Combine(_tempRoot, "Game");
+
+    private string LoaderDirectory => Path.Combine(_tempRoot, "Manual StarMap");
+
+    [Fact]
+    public async Task AdoptAsync_RealStarMapLayout_MatchesAndRecordsTheRelease()
+    {
+        await _settings.SaveAsync(new BoreaSettings(GameDirectory));
+        PlaceStarMap(GameDirectory);
+        var configBefore = await File.ReadAllBytesAsync(Path.Combine(LoaderDirectory, "StarMapConfig.json"));
+
+        var result = await _adopter.AdoptAsync(StarMap(), new[] { StarMapRelease() }, LoaderDirectory);
+
+        Assert.Equal("0.4.6.0", result.RawVersion);
+        Assert.Equal(ModVersion.Parse("0.4.6"), result.Version);
+        Assert.Equal(GameDirectory, result.ConfiguredGameDirectory);
+        Assert.True(result.GameDirectoryMatches is true);
+        Assert.Empty(result.Warnings);
+        Assert.Equal(configBefore, await File.ReadAllBytesAsync(Path.Combine(LoaderDirectory, "StarMapConfig.json")));
+
+        var installation = (await _settings.GetAsync())!.LoaderInstallations["StarMap"];
+        Assert.Equal(LoaderDirectory, installation.DirectoryPath);
+        Assert.Equal(ModVersion.Parse("0.4.6"), installation.Version);
+        Assert.Equal("0.4.6.0", installation.RawVersion);
+        Assert.True(installation.IsAdopted);
+    }
+
+    [Fact]
+    public async Task AdoptAsync_LaunchExecutableMissing_RefusesWithoutARecord()
+    {
+        Directory.CreateDirectory(LoaderDirectory);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _adopter.AdoptAsync(StarMap(), new[] { StarMapRelease() }, LoaderDirectory));
+
+        Assert.Contains("StarMap.exe", exception.Message);
+        Assert.Null(await _settings.GetAsync());
+    }
+
+    [Fact]
+    public async Task AdoptAsync_FileVersionHasNoIndexedRelease_RecordsUnknownWithAWarning()
+    {
+        PlaceStarMap(GameDirectory);
+
+        var result = await _adopter.AdoptAsync(StarMap(), Array.Empty<ModVersionMetadata>(), LoaderDirectory);
+
+        Assert.Equal("0.4.6.0", result.RawVersion);
+        Assert.Null(result.Version);
+        Assert.Contains(result.Warnings, warning => warning.Contains("does not match an indexed release", StringComparison.Ordinal));
+
+        var installation = (await _settings.GetAsync())!.LoaderInstallations["StarMap"];
+        Assert.Null(installation.Version);
+        Assert.True(installation.IsAdopted);
+    }
+
+    [Fact]
+    public async Task AdoptAsync_ConfiguredForAnotherGame_WarnsAndDoesNotRewriteTheFile()
+    {
+        await _settings.SaveAsync(new BoreaSettings(GameDirectory));
+        var otherGame = Path.Combine(_tempRoot, "Other Game");
+        PlaceStarMap(otherGame);
+        var configPath = Path.Combine(LoaderDirectory, "StarMapConfig.json");
+        var before = await File.ReadAllBytesAsync(configPath);
+
+        var result = await _adopter.AdoptAsync(StarMap(), new[] { StarMapRelease() }, LoaderDirectory);
+
+        Assert.Equal(otherGame, result.ConfiguredGameDirectory);
+        Assert.True(result.GameDirectoryMatches is false);
+        Assert.Contains(result.Warnings, warning => warning.Contains("was not changed", StringComparison.Ordinal));
+        Assert.Equal(before, await File.ReadAllBytesAsync(configPath));
+    }
+
+    [Fact]
+    public async Task AdoptAsync_EmptyConfiguredGamePath_WarnsThatItDoesNotMatch()
+    {
+        await _settings.SaveAsync(new BoreaSettings(GameDirectory));
+        PlaceStarMap(string.Empty);
+
+        var result = await _adopter.AdoptAsync(StarMap(), new[] { StarMapRelease() }, LoaderDirectory);
+
+        Assert.Equal(string.Empty, result.ConfiguredGameDirectory);
+        Assert.True(result.GameDirectoryMatches is false);
+        Assert.Contains(result.Warnings, warning => warning.Contains("was not changed", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AdoptAsync_ConfiguredGamePathCannotBeRead_WarnsAndRecordsTheLoader()
+    {
+        await _settings.SaveAsync(new BoreaSettings(GameDirectory));
+        PlaceStarMap(GameDirectory);
+        File.Delete(Path.Combine(LoaderDirectory, "StarMapConfig.json"));
+
+        var result = await _adopter.AdoptAsync(StarMap(), new[] { StarMapRelease() }, LoaderDirectory);
+
+        Assert.Null(result.ConfiguredGameDirectory);
+        Assert.Null(result.GameDirectoryMatches);
+        Assert.Contains(result.Warnings, warning => warning.Contains("could not confirm", StringComparison.Ordinal));
+        Assert.True((await _settings.GetAsync())!.LoaderInstallations["StarMap"].IsAdopted);
+    }
+
+    [Fact]
+    public async Task AdoptAsync_RecordedAtAnotherDirectory_Refuses()
+    {
+        PlaceStarMap(GameDirectory);
+        var recorded = new LoaderInstallation(Path.Combine(_tempRoot, "Elsewhere"), null, null, isAdopted: true);
+        await _settings.SaveAsync(new BoreaSettings(
+            GameDirectory,
+            loaderInstallations: new Dictionary<string, LoaderInstallation> { ["StarMap"] = recorded }));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _adopter.AdoptAsync(StarMap(), new[] { StarMapRelease() }, LoaderDirectory));
+    }
+
+    [Fact]
+    public async Task AdoptAsync_RelativeDirectory_ThrowsArgumentException()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _adopter.AdoptAsync(StarMap(), new[] { StarMapRelease() }, "StarMap"));
+    }
+
+    [Fact]
+    public void Constructor_NullDependency_ThrowsArgumentNullException()
+    {
+        var configuration = new LoaderConfigurator();
+
+        Assert.Throws<ArgumentNullException>(() => new FileLoaderAdopter(null!, configuration));
+        Assert.Throws<ArgumentNullException>(() => new FileLoaderAdopter(_settings, null!));
+    }
+
+    private void PlaceStarMap(string configuredGameDirectory)
+    {
+        Directory.CreateDirectory(LoaderDirectory);
+        File.Copy(
+            Path.Combine(AppContext.BaseDirectory, LoaderVersionFixture),
+            Path.Combine(LoaderDirectory, "StarMap.exe"));
+        File.WriteAllText(Path.Combine(LoaderDirectory, "StarMap.dll"), "loader");
+        File.WriteAllText(
+            Path.Combine(LoaderDirectory, "StarMapConfig.json"),
+            JsonSerializer.Serialize(new
+            {
+                GameLocation = configuredGameDirectory,
+                RepositoryLocation = "C:\\Repositories",
+            }));
+    }
+
+    private static ModMetadata StarMap() => new(
+        specVersion: 1,
+        modId: "StarMap",
+        source: "index",
+        name: "StarMap",
+        authors: new[] { "KlaasWhite" },
+        abstractText: "The loader.",
+        license: "MIT",
+        links: MetadataFixtures.SampleLinks(),
+        gameMin: "2026.8.3.5117",
+        type: ContentType.ModLoader,
+        install: new InstallDescriptor(target: InstallAnchor.Standalone),
+        provides: new LoaderProvides(
+            launch: "StarMap.exe",
+            contentDir: InstallAnchor.Mods,
+            configure: new LoaderConfigure("StarMapConfig.json", ConfigureFormat.Json, "GameLocation")));
+
+    private static ModVersionMetadata StarMapRelease() => new(
+        specVersion: 1,
+        modId: "StarMap",
+        version: ModVersion.Parse("0.4.6"),
+        releaseStatus: ReleaseStatus.Stable,
+        releaseDate: new DateTimeOffset(2026, 8, 2, 16, 47, 50, TimeSpan.Zero),
+        gameMin: "2026.8.3.5117",
+        gameMinRevision: 5117,
+        download: new DownloadInfo("https://example.invalid/StarMap.zip", null, null, "application/zip"),
+        installSizeBytes: null,
+        dependencies: Array.Empty<ModDependency>(),
+        type: ContentType.ModLoader,
+        install: new InstallInfo(null, derived: true, target: InstallAnchor.Standalone));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+
+}

--- a/tests/Borea.Storage.Tests/ModLoaders/FileLoaderAdopterTests.cs
+++ b/tests/Borea.Storage.Tests/ModLoaders/FileLoaderAdopterTests.cs
@@ -127,6 +127,24 @@ public sealed class FileLoaderAdopterTests : IDisposable
     }
 
     [Fact]
+    public async Task AdoptAsync_InvalidConfiguration_WarnsAndRecordsTheLoader()
+    {
+        await _settings.SaveAsync(new BoreaSettings(GameDirectory));
+        PlaceStarMap(GameDirectory);
+        var configPath = Path.Combine(LoaderDirectory, "StarMapConfig.json");
+        await File.WriteAllTextAsync(configPath, "{ invalid");
+        var configBefore = await File.ReadAllBytesAsync(configPath);
+
+        var result = await _adopter.AdoptAsync(StarMap(), new[] { StarMapRelease() }, LoaderDirectory);
+
+        Assert.Null(result.ConfiguredGameDirectory);
+        Assert.Null(result.GameDirectoryMatches);
+        Assert.Contains(result.Warnings, warning => warning.Contains("not valid JSON", StringComparison.Ordinal));
+        Assert.Equal(configBefore, await File.ReadAllBytesAsync(configPath));
+        Assert.True((await _settings.GetAsync())!.LoaderInstallations["StarMap"].IsAdopted);
+    }
+
+    [Fact]
     public async Task AdoptAsync_RecordedAtAnotherDirectory_Refuses()
     {
         PlaceStarMap(GameDirectory);

--- a/tests/Borea.Storage.Tests/ModLoaders/FileLoaderInstallerTests.cs
+++ b/tests/Borea.Storage.Tests/ModLoaders/FileLoaderInstallerTests.cs
@@ -118,8 +118,16 @@ public sealed class FileLoaderInstallerTests : IDisposable
             ("StarMap.runtimeconfig.json", "{}"),
         }.Concat(extra).ToArray());
 
-    private Task SaveSettingsAsync(string? gameDirectory, IReadOnlyDictionary<string, string>? loaders = null) =>
+    private Task SaveSettingsAsync(string? gameDirectory, IReadOnlyDictionary<string, LoaderInstallation>? loaders = null) =>
         _settings.SaveAsync(new BoreaSettings(gameDirectory, loaders));
+
+    private static Dictionary<string, LoaderInstallation> LoaderAt(
+        string path,
+        string id = LoaderId,
+        bool isAdopted = false) => new()
+        {
+            [id] = new LoaderInstallation(path, ModVersion.Parse("0.4.6"), rawVersion: null, isAdopted: isAdopted),
+        };
 
     private Task SaveGameDirectoryAsync() => SaveSettingsAsync(_gameDirectory);
 
@@ -129,7 +137,9 @@ public sealed class FileLoaderInstallerTests : IDisposable
     private async Task<string?> RecordedDirectoryAsync()
     {
         var settings = await _settings.GetAsync();
-        return settings is not null && settings.LoaderDirectoryPaths.TryGetValue(LoaderId, out var path) ? path : null;
+        return settings is not null && settings.LoaderInstallations.TryGetValue(LoaderId, out var installation)
+            ? installation.DirectoryPath
+            : null;
     }
 
     private static async Task<JsonObject> ReadConfigAsync(string directory) =>
@@ -163,6 +173,11 @@ public sealed class FileLoaderInstallerTests : IDisposable
         Assert.Equal(StarMapRelease().Download.Url, result.Download.Url);
         Assert.Equal(Convert.ToHexString(SHA256.HashData(_downloader.Bytes)), result.Download.Sha256);
         Assert.Single(_downloader.ArchivePaths);
+
+        var installation = (await _settings.GetAsync())!.LoaderInstallations[LoaderId];
+        Assert.False(installation.IsAdopted);
+        Assert.Equal(ModVersion.Parse("0.4.6"), installation.Version);
+        Assert.Null(installation.RawVersion);
     }
 
     [Fact]
@@ -224,7 +239,9 @@ public sealed class FileLoaderInstallerTests : IDisposable
         Assert.Equal(_gameDirectory, (string?)config["GameLocation"]);
         Assert.Equal(@"C:\Repos", (string?)config["RepositoryLocation"]);
         Assert.Equal("-Verbose", (string?)config["GameArguments"]![0]);
-        Assert.Single((await _settings.GetAsync())!.LoaderDirectoryPaths);
+        var settings = await _settings.GetAsync();
+        Assert.Single(settings!.LoaderInstallations);
+        Assert.Equal(ModVersion.Parse("0.4.7"), settings.LoaderInstallations[LoaderId].Version);
     }
 
     [Fact]
@@ -250,7 +267,7 @@ public sealed class FileLoaderInstallerTests : IDisposable
     public async Task InstallAsync_RecordedUnderTheIdInOtherCase_ReplacesThatRecord()
     {
         var elsewhere = Path.Combine(_tempRoot, "Elsewhere");
-        await SaveSettingsAsync(_gameDirectory, new Dictionary<string, string> { ["starmap"] = elsewhere });
+        await SaveSettingsAsync(_gameDirectory, LoaderAt(elsewhere, id: "starmap"));
         _downloader.Bytes = StarMapZip();
 
         var result = await InstallAsync();
@@ -258,21 +275,21 @@ public sealed class FileLoaderInstallerTests : IDisposable
         Assert.Equal(elsewhere, result.Directory);
         Assert.True(result.Replaced);
         Assert.True(File.Exists(Path.Combine(elsewhere, "StarMap.exe")));
-        Assert.Single((await _settings.GetAsync())!.LoaderDirectoryPaths);
+        Assert.Single((await _settings.GetAsync())!.LoaderInstallations);
     }
 
     [Fact]
     public async Task InstallAsync_KeepsTheOtherLoadersInTheSettings()
     {
-        await SaveSettingsAsync(_gameDirectory, new Dictionary<string, string> { ["Cheese-Loader"] = @"C:\Games\Cheese" });
+        await SaveSettingsAsync(_gameDirectory, LoaderAt(@"C:\Games\Cheese", id: "Cheese-Loader"));
         _downloader.Bytes = StarMapZip();
 
         await InstallAsync();
 
         var settings = await _settings.GetAsync();
         Assert.Equal(_gameDirectory, settings!.GameDirectoryPath);
-        Assert.Equal(@"C:\Games\Cheese", settings.LoaderDirectoryPaths["Cheese-Loader"]);
-        Assert.Equal(DefaultDirectory, settings.LoaderDirectoryPaths[LoaderId]);
+        Assert.Equal(@"C:\Games\Cheese", settings.LoaderInstallations["Cheese-Loader"].DirectoryPath);
+        Assert.Equal(DefaultDirectory, settings.LoaderInstallations[LoaderId].DirectoryPath);
     }
 
     #endregion
@@ -307,7 +324,7 @@ public sealed class FileLoaderInstallerTests : IDisposable
     public async Task InstallAsync_RecordedElsewhere_GivenAnotherDirectory_Refuses()
     {
         var elsewhere = Path.Combine(_tempRoot, "Elsewhere");
-        await SaveSettingsAsync(_gameDirectory, new Dictionary<string, string> { [LoaderId] = elsewhere });
+        await SaveSettingsAsync(_gameDirectory, LoaderAt(elsewhere));
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => InstallAsync(directory: Path.Combine(_tempRoot, "Other")));
 
@@ -319,7 +336,7 @@ public sealed class FileLoaderInstallerTests : IDisposable
     public async Task InstallAsync_RecordedLoader_GivenItsOwnDirectory_Replaces()
     {
         var elsewhere = Path.Combine(_tempRoot, "Elsewhere");
-        await SaveSettingsAsync(_gameDirectory, new Dictionary<string, string> { [LoaderId] = elsewhere });
+        await SaveSettingsAsync(_gameDirectory, LoaderAt(elsewhere));
         _downloader.Bytes = StarMapZip();
 
         // The same directory, written with a trailing separator.
@@ -356,6 +373,7 @@ public sealed class FileLoaderInstallerTests : IDisposable
         await InstallAsync();
 
         Assert.True(File.Exists(Path.Combine(DefaultDirectory, "StarMap.exe")));
+        Assert.True((await _settings.GetAsync())!.LoaderInstallations[LoaderId].IsAdopted);
     }
 
     [Fact]

--- a/tests/Borea.Storage.Tests/ModLoaders/FileLoaderUninstallerTests.cs
+++ b/tests/Borea.Storage.Tests/ModLoaders/FileLoaderUninstallerTests.cs
@@ -1,0 +1,95 @@
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+using Borea.Core.Settings;
+using Borea.Storage.ModLoaders;
+using Borea.Storage.Settings;
+using Borea.Storage.Tests.Paths;
+
+namespace Borea.Storage.Tests.ModLoaders;
+
+public sealed class FileLoaderUninstallerTests : IDisposable
+{
+    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+    private readonly FileBoreaSettingsRepository _settings;
+    private readonly FileLoaderUninstaller _uninstaller;
+
+    public FileLoaderUninstallerTests()
+    {
+        _settings = new FileBoreaSettingsRepository(new TestGamePathProvider(_tempRoot));
+        _uninstaller = new FileLoaderUninstaller(_settings);
+    }
+
+    [Fact]
+    public async Task UninstallAsync_AdoptedLoader_PreservesDirectoryAndRemovesRecord()
+    {
+        var directory = await RecordAsync(isAdopted: true);
+        var file = Path.Combine(directory, "user-file.txt");
+        await File.WriteAllTextAsync(file, "keep");
+
+        var result = await _uninstaller.UninstallAsync("StarMap");
+
+        Assert.True(result.RecordRemoved);
+        Assert.False(result.DirectoryRemoved);
+        Assert.True(File.Exists(file));
+        Assert.Empty((await _settings.GetAsync())!.LoaderInstallations);
+    }
+
+    [Fact]
+    public async Task UninstallAsync_BoreaInstalledLoader_RemovesDirectoryAndRecord()
+    {
+        var directory = await RecordAsync(isAdopted: false);
+        await File.WriteAllTextAsync(Path.Combine(directory, "StarMap.exe"), "loader");
+
+        var result = await _uninstaller.UninstallAsync("starmap");
+
+        Assert.True(result.RecordRemoved);
+        Assert.True(result.DirectoryRemoved);
+        Assert.False(Directory.Exists(directory));
+        Assert.Empty((await _settings.GetAsync())!.LoaderInstallations);
+    }
+
+    [Fact]
+    public async Task UninstallAsync_UnknownLoader_IsNoOp()
+    {
+        var result = await _uninstaller.UninstallAsync("StarMap");
+
+        Assert.False(result.RecordRemoved);
+        Assert.False(result.DirectoryRemoved);
+        Assert.Null(result.Directory);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not a valid id")]
+    public async Task UninstallAsync_InvalidLoaderId_ThrowsArgumentException(string loaderId)
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => _uninstaller.UninstallAsync(loaderId));
+    }
+
+    [Fact]
+    public void Constructor_NullSettings_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FileLoaderUninstaller(null!));
+    }
+
+    private async Task<string> RecordAsync(bool isAdopted)
+    {
+        var directory = Path.Combine(_tempRoot, "StarMap");
+        Directory.CreateDirectory(directory);
+        var installation = new LoaderInstallation(
+            directory,
+            ModVersion.Parse("0.4.6"),
+            "0.4.6.0",
+            isAdopted);
+        await _settings.SaveAsync(new BoreaSettings(
+            gameDirectoryPath: null,
+            loaderInstallations: new Dictionary<string, LoaderInstallation> { ["StarMap"] = installation }));
+        return directory;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+}

--- a/tests/Borea.Storage.Tests/Settings/FileBoreaSettingsRepositoryTests.cs
+++ b/tests/Borea.Storage.Tests/Settings/FileBoreaSettingsRepositoryTests.cs
@@ -1,4 +1,6 @@
-﻿using Borea.Core.Settings;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+using Borea.Core.Settings;
 using Borea.Storage.Settings;
 using Borea.Storage.Tests.Paths;
 
@@ -28,10 +30,10 @@ public sealed class FileBoreaSettingsRepositoryTests : IDisposable
     [Fact]
     public async Task SaveThenGet_RoundTripsTheGameAndTheLoaders()
     {
-        var settings = new BoreaSettings(@"C:\Games\KSA", new Dictionary<string, string>
+        var settings = new BoreaSettings(@"C:\Games\KSA", new Dictionary<string, LoaderInstallation>
         {
-            ["StarMap"] = @"C:\Games\StarMap",
-            ["Cheese-Loader"] = @"C:\Games\Cheese",
+            ["StarMap"] = Installation(@"C:\Games\StarMap", "0.4.6", "0.4.6.0", isAdopted: true),
+            ["Cheese-Loader"] = Installation(@"C:\Games\Cheese", "1.2.0", rawVersion: null, isAdopted: false),
         });
 
         await _repository.SaveAsync(settings);
@@ -39,35 +41,44 @@ public sealed class FileBoreaSettingsRepositoryTests : IDisposable
 
         Assert.NotNull(reloaded);
         Assert.Equal(@"C:\Games\KSA", reloaded!.GameDirectoryPath);
-        Assert.Equal(2, reloaded.LoaderDirectoryPaths.Count);
-        Assert.Equal(@"C:\Games\StarMap", reloaded.LoaderDirectoryPaths["StarMap"]);
-        Assert.Equal(@"C:\Games\Cheese", reloaded.LoaderDirectoryPaths["Cheese-Loader"]);
+        Assert.Equal(2, reloaded.LoaderInstallations.Count);
+
+        var starMap = reloaded.LoaderInstallations["StarMap"];
+        Assert.Equal(@"C:\Games\StarMap", starMap.DirectoryPath);
+        Assert.Equal(ModVersion.Parse("0.4.6"), starMap.Version);
+        Assert.Equal("0.4.6.0", starMap.RawVersion);
+        Assert.True(starMap.IsAdopted);
+
+        var cheese = reloaded.LoaderInstallations["Cheese-Loader"];
+        Assert.Equal(@"C:\Games\Cheese", cheese.DirectoryPath);
+        Assert.False(cheese.IsAdopted);
     }
 
     [Fact]
     public async Task SaveThenGet_RoundTripsPartialSettings_GameOnly()
     {
-        // Confirms the "installed one, not the other" scenario this whole
-        // nullable design was built for actually persists correctly.
         var settings = new BoreaSettings(@"C:\Games\KSA");
 
         await _repository.SaveAsync(settings);
         var reloaded = await _repository.GetAsync();
 
         Assert.Equal(@"C:\Games\KSA", reloaded!.GameDirectoryPath);
-        Assert.Empty(reloaded.LoaderDirectoryPaths);
+        Assert.Empty(reloaded.LoaderInstallations);
     }
 
     [Fact]
     public async Task SaveThenGet_RoundTripsPartialSettings_LoaderOnly()
     {
-        var settings = new BoreaSettings(null, new Dictionary<string, string> { ["StarMap"] = @"C:\Games\StarMap" });
+        var settings = new BoreaSettings(null, new Dictionary<string, LoaderInstallation>
+        {
+            ["StarMap"] = Installation(@"C:\Games\StarMap", "0.4.6", "0.4.6.0", isAdopted: true),
+        });
 
         await _repository.SaveAsync(settings);
         var reloaded = await _repository.GetAsync();
 
         Assert.Null(reloaded!.GameDirectoryPath);
-        Assert.Equal(@"C:\Games\StarMap", reloaded.LoaderDirectoryPaths["StarMap"]);
+        Assert.Equal(@"C:\Games\StarMap", reloaded.LoaderInstallations["StarMap"].DirectoryPath);
     }
 
     [Fact]
@@ -78,9 +89,9 @@ public sealed class FileBoreaSettingsRepositoryTests : IDisposable
         await _repository.SaveAsync(settings);
         var reloaded = await _repository.GetAsync();
 
-        Assert.NotNull(reloaded); // Distinct from "never saved" (null): a file exists, it just carries nothing.
+        Assert.NotNull(reloaded);
         Assert.Null(reloaded!.GameDirectoryPath);
-        Assert.Empty(reloaded.LoaderDirectoryPaths);
+        Assert.Empty(reloaded.LoaderInstallations);
     }
 
     [Fact]
@@ -90,7 +101,7 @@ public sealed class FileBoreaSettingsRepositoryTests : IDisposable
 
         var text = await File.ReadAllTextAsync(_pathProvider.GetBoreaSettingsPath());
 
-        Assert.DoesNotContain("LoaderDirectoryPaths", text);
+        Assert.DoesNotContain("LoaderInstallations", text);
     }
 
     [Fact]
@@ -98,9 +109,13 @@ public sealed class FileBoreaSettingsRepositoryTests : IDisposable
     {
         Directory.CreateDirectory(_tempRoot);
         await File.WriteAllTextAsync(_pathProvider.GetBoreaSettingsPath(), """
-            [LoaderDirectoryPaths]
-            StarMap = 'C:\Games\StarMap'
-            starmap = 'C:\Games\Other'
+            [LoaderInstallations.StarMap]
+            DirectoryPath = 'C:\Games\StarMap'
+            IsAdopted = true
+
+            [LoaderInstallations.starmap]
+            DirectoryPath = 'C:\Games\Other'
+            IsAdopted = true
             """);
 
         await Assert.ThrowsAsync<ArgumentException>(() => _repository.GetAsync());
@@ -115,13 +130,23 @@ public sealed class FileBoreaSettingsRepositoryTests : IDisposable
     [Fact]
     public async Task SaveAsync_Overwrites_PreviousValue()
     {
-        await _repository.SaveAsync(new BoreaSettings(@"C:\Old", null));
-        await _repository.SaveAsync(new BoreaSettings(@"C:\New", null));
+        await _repository.SaveAsync(new BoreaSettings(@"C:\Old"));
+        await _repository.SaveAsync(new BoreaSettings(@"C:\New"));
 
         var reloaded = await _repository.GetAsync();
 
         Assert.Equal(@"C:\New", reloaded!.GameDirectoryPath);
     }
+
+    private static LoaderInstallation Installation(
+        string path,
+        string version,
+        string? rawVersion,
+        bool isAdopted) => new(
+        path,
+        ModVersion.Parse(version),
+        rawVersion,
+        isAdopted);
 
     public void Dispose()
     {


### PR DESCRIPTION
Closes #80.

This pull request lets Borea adopt a mod loader that the user installed by hand. It is stacked on #85, so this pull request targets `install-loader`.

Borea checks the launch file named by the loader listing and reads its PE file version. It matches that version to the indexed releases when possible. An unknown version gives a warning but does not block adoption.

Borea also reads the game path from the loader configuration. It reports a different, empty, or unreadable path and does not change the file.

The loader record now says whether Borea created the directory. Uninstall deletes a Borea-created directory, but it only removes the record for an adopted or other user-owned directory.

Tests cover a StarMap layout, a missing launch file, an unknown version, a different or unreadable configured game path, settings persistence, and both uninstall ownership cases.
