### PR TITLE
Add the Borea.App preference store

### DIFF
--- a/src/Borea.Composition/BoreaServices.cs
+++ b/src/Borea.Composition/BoreaServices.cs
@@ -4,6 +4,7 @@ using Borea.Core.Instances;
 using Borea.Core.ModPacks;
 using Borea.Core.Mods;
 using Borea.Core.Paths;
+using Borea.Core.Preferences;
 using Borea.Core.Settings;
 using Borea.Core.State;
 using Borea.Network.MasterServer;
@@ -14,6 +15,7 @@ using Borea.Storage.Instances;
 using Borea.Storage.ModPacks;
 using Borea.Storage.Mods;
 using Borea.Storage.Paths;
+using Borea.Storage.Preferences;
 using Borea.Storage.Settings;
 using Borea.Storage.State;
 
@@ -55,6 +57,8 @@ public sealed class BoreaServices : IDisposable
     public required IGamePathProvider Paths { get; init; }
 
     public required IBoreaSettingsRepository SettingsRepository { get; init; }
+
+    public required IAppPreferencesRepository AppPreferences { get; init; }
 
     public required IInstanceRepository Instances { get; init; }
 
@@ -125,6 +129,7 @@ public sealed class BoreaServices : IDisposable
             Settings = settings,
             Paths = paths,
             SettingsRepository = new FileBoreaSettingsRepository(paths),
+            AppPreferences = new FileAppPreferencesRepository(paths),
             Instances = new FileInstanceRepository(paths),
             ModState = new FileModStateRepository(paths),
             ModFavorites = new FileModFavoritesRepository(paths),

--- a/src/Borea.Core/Paths/IGamePathProvider.cs
+++ b/src/Borea.Core/Paths/IGamePathProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Borea.Core.Paths;
+namespace Borea.Core.Paths;
 
 /// <summary>
 /// Resolves filesystem locations relevant to KSA, StarMap, and Borea's own
@@ -36,6 +36,11 @@ public interface IGamePathProvider
     /// Path to Borea's own settings.toml (game/StarMap install locations).
     /// </summary>
     string GetBoreaSettingsPath();
+
+    /// <summary>
+    /// Path to Borea.App preferences and custom themes.
+    /// </summary>
+    string GetAppPreferencesPath();
 
     /// <summary>
     /// Root folder for a specific instance, e.g.

--- a/src/Borea.Core/Preferences/AppPreferences.cs
+++ b/src/Borea.Core/Preferences/AppPreferences.cs
@@ -1,0 +1,85 @@
+namespace Borea.Core.Preferences;
+
+public sealed class AppPreferences
+{
+    public static AppPreferences Empty { get; } = new(selectedThemeName: null);
+
+    public string? SelectedThemeName { get; }
+
+    public IReadOnlyList<CustomThemePreference> CustomThemes { get; }
+
+    public AppPreferences(string? selectedThemeName, IEnumerable<CustomThemePreference>? customThemes = null)
+    {
+        if (selectedThemeName is not null && string.IsNullOrWhiteSpace(selectedThemeName))
+            throw new ArgumentException("Selected theme name, if provided, cannot be whitespace.", nameof(selectedThemeName));
+
+        SelectedThemeName = selectedThemeName;
+        CustomThemes = BuildCustomThemes(customThemes, nameof(customThemes));
+    }
+
+    public string ResolveSelectedThemeName(IReadOnlyCollection<string> bundledThemeNames, string defaultThemeName)
+    {
+        var bundledNames = BuildBundledThemeNames(bundledThemeNames);
+
+        if (!bundledNames.Contains(defaultThemeName))
+            throw new ArgumentException("The default theme must be one of the bundled themes.", nameof(defaultThemeName));
+
+        if (SelectedThemeName is null)
+            return defaultThemeName;
+
+        var bundledMatch = bundledNames.FirstOrDefault(name => string.Equals(name, SelectedThemeName, StringComparison.Ordinal));
+        if (bundledMatch is not null)
+            return bundledMatch;
+
+        var customMatch = CustomThemes.FirstOrDefault(theme => string.Equals(theme.Name, SelectedThemeName, StringComparison.Ordinal));
+        return customMatch?.Name ?? defaultThemeName;
+    }
+
+    public void ValidateBundledThemeNames(IReadOnlyCollection<string> bundledThemeNames)
+    {
+        var bundledNames = BuildBundledThemeNames(bundledThemeNames);
+
+        foreach (var customTheme in CustomThemes)
+        {
+            if (bundledNames.Contains(customTheme.Name))
+                throw new ArgumentException($"Custom theme '{customTheme.Name}' conflicts with a bundled theme.", nameof(bundledThemeNames));
+        }
+    }
+
+    private static IReadOnlyList<CustomThemePreference> BuildCustomThemes(IEnumerable<CustomThemePreference>? customThemes, string paramName)
+    {
+        var themes = new List<CustomThemePreference>();
+        var names = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var theme in customThemes ?? [])
+        {
+            if (theme is null)
+                throw new ArgumentException("Custom themes cannot contain null.", paramName);
+
+            if (!names.Add(theme.Name))
+                throw new ArgumentException($"Custom theme '{theme.Name}' appears more than once.", paramName);
+
+            themes.Add(theme);
+        }
+
+        return themes.AsReadOnly();
+    }
+
+    private static HashSet<string> BuildBundledThemeNames(IReadOnlyCollection<string> bundledThemeNames)
+    {
+        if (bundledThemeNames is null)
+            throw new ArgumentNullException(nameof(bundledThemeNames));
+
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var name in bundledThemeNames)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Bundled theme names cannot be null or whitespace.", nameof(bundledThemeNames));
+
+            if (!names.Add(name))
+                throw new ArgumentException($"Bundled theme '{name}' appears more than once.", nameof(bundledThemeNames));
+        }
+
+        return names;
+    }
+}

--- a/src/Borea.Core/Preferences/AppPreferencesLoadResult.cs
+++ b/src/Borea.Core/Preferences/AppPreferencesLoadResult.cs
@@ -1,0 +1,14 @@
+namespace Borea.Core.Preferences;
+
+public enum AppPreferencesLoadStatus
+{
+    Loaded,
+    NotFound,
+    Invalid,
+    Unavailable,
+}
+
+public sealed record AppPreferencesLoadResult(
+    AppPreferencesLoadStatus Status,
+    AppPreferences Preferences,
+    string? Error = null);

--- a/src/Borea.Core/Preferences/CustomThemePreference.cs
+++ b/src/Borea.Core/Preferences/CustomThemePreference.cs
@@ -1,0 +1,51 @@
+namespace Borea.Core.Preferences;
+
+public sealed class CustomThemePreference
+{
+    public string Name { get; }
+
+    public string MainColor { get; }
+
+    public string SecondaryColor { get; }
+
+    public string GlobalPanelsColor { get; }
+
+    public string TextColor { get; }
+
+    public CustomThemePreference(string name, string mainColor, string secondaryColor, string globalPanelsColor, string textColor)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Theme name cannot be null or whitespace.", nameof(name));
+
+        Name = name;
+        MainColor = ValidateColor(mainColor, nameof(mainColor));
+        SecondaryColor = ValidateColor(secondaryColor, nameof(secondaryColor));
+        GlobalPanelsColor = ValidateColor(globalPanelsColor, nameof(globalPanelsColor));
+        TextColor = ValidateColor(textColor, nameof(textColor));
+    }
+
+    private static string ValidateColor(string color, string paramName)
+    {
+        if (color is null)
+            throw new ArgumentNullException(paramName);
+
+        if (color.Length != 7 || color[0] != '#' || !color.AsSpan(1).ContainsOnlyAsciiHexDigits())
+            throw new ArgumentException("Theme colors must use the #RRGGBB format.", paramName);
+
+        return color;
+    }
+}
+
+internal static class HexColorExtensions
+{
+    public static bool ContainsOnlyAsciiHexDigits(this ReadOnlySpan<char> value)
+    {
+        foreach (var character in value)
+        {
+            if (!char.IsAsciiHexDigit(character))
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Borea.Core/Preferences/IAppPreferencesRepository.cs
+++ b/src/Borea.Core/Preferences/IAppPreferencesRepository.cs
@@ -1,0 +1,13 @@
+namespace Borea.Core.Preferences;
+
+public interface IAppPreferencesRepository
+{
+    Task<AppPreferencesLoadResult> GetAsync(
+        IReadOnlyCollection<string> bundledThemeNames,
+        CancellationToken cancellationToken = default);
+
+    Task SaveAsync(
+        AppPreferences preferences,
+        IReadOnlyCollection<string> bundledThemeNames,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Borea.Storage/Paths/GamePathProvider.cs
+++ b/src/Borea.Storage/Paths/GamePathProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Borea.Core.Mods;
 using Borea.Core.Paths;
 
@@ -53,6 +53,7 @@ public sealed class GamePathProvider : IGamePathProvider
     public string GetModFavoritesPath() => Path.Combine(_boreaRoot, "mod-favorites.toml");
     public string GetModPackFavoritesPath() => Path.Combine(_boreaRoot, "modpack-favorites.toml");
     public string GetBoreaSettingsPath() => Path.Combine(_boreaRoot, "borea-settings.toml");
+    public string GetAppPreferencesPath() => Path.Combine(_boreaRoot, "app-preferences.json");
     public string? GetGameDirectoryPath() => _gameDirectory;
 
     public string? GetLoaderDirectoryPath(string loaderId)

--- a/src/Borea.Storage/Preferences/AppPreferencesDocumentDto.cs
+++ b/src/Borea.Storage/Preferences/AppPreferencesDocumentDto.cs
@@ -1,0 +1,23 @@
+namespace Borea.Storage.Preferences;
+
+internal sealed class AppPreferencesDocumentDto
+{
+    public int FormatVersion { get; set; }
+
+    public string? SelectedTheme { get; set; }
+
+    public List<CustomThemePreferenceDto?>? CustomThemes { get; set; }
+}
+
+internal sealed class CustomThemePreferenceDto
+{
+    public required string Name { get; set; }
+
+    public required string MainColor { get; set; }
+
+    public required string SecondaryColor { get; set; }
+
+    public required string GlobalPanelsColor { get; set; }
+
+    public required string TextColor { get; set; }
+}

--- a/src/Borea.Storage/Preferences/AppPreferencesMapper.cs
+++ b/src/Borea.Storage/Preferences/AppPreferencesMapper.cs
@@ -1,0 +1,33 @@
+using Borea.Core.Preferences;
+
+namespace Borea.Storage.Preferences;
+
+internal static class AppPreferencesMapper
+{
+    public static AppPreferencesDocumentDto ToDto(AppPreferences preferences) => new()
+    {
+        FormatVersion = FileAppPreferencesRepository.CurrentFormatVersion,
+        SelectedTheme = preferences.SelectedThemeName,
+        CustomThemes = preferences.CustomThemes.Select(theme => (CustomThemePreferenceDto?)ToDto(theme)).ToList(),
+    };
+
+    public static AppPreferences FromDto(AppPreferencesDocumentDto dto)
+        => new(dto.SelectedTheme, dto.CustomThemes?.Select(FromDto));
+
+    private static CustomThemePreferenceDto ToDto(CustomThemePreference theme) => new()
+    {
+        Name = theme.Name,
+        MainColor = theme.MainColor,
+        SecondaryColor = theme.SecondaryColor,
+        GlobalPanelsColor = theme.GlobalPanelsColor,
+        TextColor = theme.TextColor,
+    };
+
+    private static CustomThemePreference FromDto(CustomThemePreferenceDto? theme)
+    {
+        if (theme is null)
+            throw new ArgumentException("Custom themes cannot contain null.", nameof(theme));
+
+        return new(theme.Name, theme.MainColor, theme.SecondaryColor, theme.GlobalPanelsColor, theme.TextColor);
+    }
+}

--- a/src/Borea.Storage/Preferences/FileAppPreferencesRepository.cs
+++ b/src/Borea.Storage/Preferences/FileAppPreferencesRepository.cs
@@ -1,0 +1,158 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Borea.Core.Paths;
+using Borea.Core.Preferences;
+
+namespace Borea.Storage.Preferences;
+
+public sealed class FileAppPreferencesRepository : IAppPreferencesRepository
+{
+    internal const int CurrentFormatVersion = 1;
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+        WriteIndented = true,
+    };
+
+    private readonly IGamePathProvider _pathProvider;
+
+    public FileAppPreferencesRepository(IGamePathProvider pathProvider)
+    {
+        _pathProvider = pathProvider ?? throw new ArgumentNullException(nameof(pathProvider));
+    }
+
+    public async Task<AppPreferencesLoadResult> GetAsync(
+        IReadOnlyCollection<string> bundledThemeNames,
+        CancellationToken cancellationToken = default)
+    {
+        if (bundledThemeNames is null)
+            throw new ArgumentNullException(nameof(bundledThemeNames));
+
+        var path = _pathProvider.GetAppPreferencesPath();
+        try
+        {
+            var text = await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
+            RejectDuplicateProperties(text);
+
+            var dto = JsonSerializer.Deserialize<AppPreferencesDocumentDto>(text, JsonOptions);
+            if (dto is null)
+                return Invalid(path, "The document is empty.");
+
+            if (dto.FormatVersion != CurrentFormatVersion)
+                return Invalid(path, $"Format version {dto.FormatVersion} is not supported.");
+
+            var preferences = AppPreferencesMapper.FromDto(dto);
+            preferences.ValidateBundledThemeNames(bundledThemeNames);
+            return new(AppPreferencesLoadStatus.Loaded, preferences);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (FileNotFoundException)
+        {
+            return new(AppPreferencesLoadStatus.NotFound, AppPreferences.Empty);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return new(AppPreferencesLoadStatus.NotFound, AppPreferences.Empty);
+        }
+        catch (JsonException exception)
+        {
+            return Invalid(path, exception.Message);
+        }
+        catch (NotSupportedException exception)
+        {
+            return Invalid(path, exception.Message);
+        }
+        catch (ArgumentException exception)
+        {
+            return Invalid(path, exception.Message);
+        }
+        catch (IOException exception)
+        {
+            return Unavailable(path, exception.Message);
+        }
+        catch (UnauthorizedAccessException exception)
+        {
+            return Unavailable(path, exception.Message);
+        }
+    }
+
+    public async Task SaveAsync(
+        AppPreferences preferences,
+        IReadOnlyCollection<string> bundledThemeNames,
+        CancellationToken cancellationToken = default)
+    {
+        if (preferences is null)
+            throw new ArgumentNullException(nameof(preferences));
+
+        preferences.ValidateBundledThemeNames(bundledThemeNames);
+
+        var path = _pathProvider.GetAppPreferencesPath();
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+
+        var text = JsonSerializer.Serialize(AppPreferencesMapper.ToDto(preferences), JsonOptions) + "\n";
+        var tempPath = $"{path}.{Guid.NewGuid():N}.tmp";
+
+        try
+        {
+            await File.WriteAllTextAsync(tempPath, text, cancellationToken).ConfigureAwait(false);
+            File.Move(tempPath, path, overwrite: true);
+        }
+        finally
+        {
+            TryDeleteLeftover(tempPath);
+        }
+    }
+
+    private static void RejectDuplicateProperties(string text)
+    {
+        using var document = JsonDocument.Parse(text);
+        RejectDuplicateProperties(document.RootElement);
+    }
+
+    private static void RejectDuplicateProperties(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            var names = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var property in element.EnumerateObject())
+            {
+                if (!names.Add(property.Name))
+                    throw new JsonException($"Property '{property.Name}' appears more than once.");
+
+                RejectDuplicateProperties(property.Value);
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in element.EnumerateArray())
+                RejectDuplicateProperties(item);
+        }
+    }
+
+    private static AppPreferencesLoadResult Invalid(string path, string error)
+        => new(AppPreferencesLoadStatus.Invalid, AppPreferences.Empty, $"{path} is not valid app preference data. {error}");
+
+    private static AppPreferencesLoadResult Unavailable(string path, string error)
+        => new(AppPreferencesLoadStatus.Unavailable, AppPreferences.Empty, $"{path} could not be read. {error}");
+
+    private static void TryDeleteLeftover(string tempPath)
+    {
+        try
+        {
+            if (File.Exists(tempPath))
+                File.Delete(tempPath);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/tests/Borea.Composition.Tests/BoreaServicesTests.cs
+++ b/tests/Borea.Composition.Tests/BoreaServicesTests.cs
@@ -3,6 +3,7 @@ using Borea.Core.Settings;
 using Borea.Network.Sources;
 using Borea.Storage.Game;
 using Borea.Storage.Paths;
+using Borea.Storage.Preferences;
 using Borea.Storage.Settings;
 
 namespace Borea.Composition.Tests;
@@ -62,6 +63,7 @@ public sealed class BoreaServicesTests : IDisposable
         using var services = await BoreaServices.BuildAsync(_tempRoot);
 
         Assert.StartsWith(_tempRoot, services.Paths.GetBoreaSettingsPath());
+        Assert.StartsWith(_tempRoot, services.Paths.GetAppPreferencesPath());
         Assert.StartsWith(_tempRoot, services.Paths.GetInstancesRoot());
     }
 
@@ -109,6 +111,14 @@ public sealed class BoreaServicesTests : IDisposable
         using var services = await BoreaServices.BuildAsync(_tempRoot);
 
         Assert.IsType<CompositeModRepository>(services.Mods);
+    }
+
+    [Fact]
+    public async Task AppPreferences_IsTheFileRepository()
+    {
+        using var services = await BoreaServices.BuildAsync(_tempRoot);
+
+        Assert.IsType<FileAppPreferencesRepository>(services.AppPreferences);
     }
 
     [Fact]

--- a/tests/Borea.Storage.Tests/Paths/GamePathProviderTests.cs
+++ b/tests/Borea.Storage.Tests/Paths/GamePathProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using Borea.Storage.Paths;
+using Borea.Storage.Paths;
 
 namespace Borea.Storage.Tests.Paths;
 
@@ -31,6 +31,7 @@ public sealed class GamePathProviderTests
         var provider = new GamePathProvider(null, boreaRoot: @"D:\Portable\Borea");
 
         Assert.StartsWith(@"D:\Portable\Borea", provider.GetBoreaSettingsPath());
+        Assert.StartsWith(@"D:\Portable\Borea", provider.GetAppPreferencesPath());
         Assert.StartsWith(@"D:\Portable\Borea", provider.GetInstancesRoot());
         Assert.StartsWith(@"D:\Portable\Borea", provider.GetModFavoritesPath());
     }
@@ -195,6 +196,7 @@ public sealed class GamePathProviderTests
             provider.GetModFavoritesPath(),
             provider.GetModPackFavoritesPath(),
             provider.GetBoreaSettingsPath(),
+            provider.GetAppPreferencesPath(),
             provider.GetIndexPath()
         };
 
@@ -208,6 +210,7 @@ public sealed class GamePathProviderTests
 
         Assert.DoesNotContain(provider.GetInstancesRoot(), provider.GetActiveInstancePointerPath());
         Assert.DoesNotContain(provider.GetInstancesRoot(), provider.GetBoreaSettingsPath());
+        Assert.DoesNotContain(provider.GetInstancesRoot(), provider.GetAppPreferencesPath());
         Assert.DoesNotContain(provider.GetInstancesRoot(), provider.GetIndexPath());
     }
 }

--- a/tests/Borea.Storage.Tests/Paths/TestGamePathProvider.cs
+++ b/tests/Borea.Storage.Tests/Paths/TestGamePathProvider.cs
@@ -1,4 +1,4 @@
-﻿using Borea.Core.Mods;
+using Borea.Core.Mods;
 using Borea.Core.Paths;
 
 namespace Borea.Storage.Tests.Paths;
@@ -31,6 +31,7 @@ internal sealed class TestGamePathProvider : IGamePathProvider
     public string GetModFavoritesPath() => Path.Combine(_root, "mod-favorites.toml");
     public string GetModPackFavoritesPath() => Path.Combine(_root, "modpack-favorites.toml");
     public string GetBoreaSettingsPath() => Path.Combine(_root, "borea-settings.toml");
+    public string GetAppPreferencesPath() => Path.Combine(_root, "app-preferences.json");
     public string? GetGameDirectoryPath() => _hasGameDirectory ? Path.Combine(_root, "Game") : null;
     public string? GetLoaderDirectoryPath(string loaderId)
     {

--- a/tests/Borea.Storage.Tests/Preferences/FileAppPreferencesRepositoryTests.cs
+++ b/tests/Borea.Storage.Tests/Preferences/FileAppPreferencesRepositoryTests.cs
@@ -1,0 +1,210 @@
+using System.Text.Json;
+using Borea.Core.Preferences;
+using Borea.Storage.Preferences;
+using Borea.Storage.Tests.Paths;
+
+namespace Borea.Storage.Tests.Preferences;
+
+public sealed class FileAppPreferencesRepositoryTests : IDisposable
+{
+    private static readonly string[] BundledThemeNames = ["Borealis", "Light", "Dark"];
+
+    private readonly string _tempRoot;
+    private readonly TestGamePathProvider _pathProvider;
+    private readonly FileAppPreferencesRepository _repository;
+
+    public FileAppPreferencesRepositoryTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+        _pathProvider = new TestGamePathProvider(_tempRoot);
+        _repository = new FileAppPreferencesRepository(_pathProvider);
+    }
+
+    [Fact]
+    public async Task GetAsync_NoSavedPreferences_ReturnsTheDefaultThemeSafely()
+    {
+        var result = await _repository.GetAsync(BundledThemeNames);
+
+        Assert.Equal(AppPreferencesLoadStatus.NotFound, result.Status);
+        Assert.Equal("Borealis", result.Preferences.ResolveSelectedThemeName(BundledThemeNames, "Borealis"));
+    }
+
+    [Fact]
+    public async Task SaveThenGet_SavedBundledTheme_RestoresTheSelection()
+    {
+        await _repository.SaveAsync(new AppPreferences("Dark"), BundledThemeNames);
+
+        var result = await _repository.GetAsync(BundledThemeNames);
+
+        Assert.Equal(AppPreferencesLoadStatus.Loaded, result.Status);
+        Assert.Equal("Dark", result.Preferences.ResolveSelectedThemeName(BundledThemeNames, "Borealis"));
+        Assert.Empty(result.Preferences.CustomThemes);
+    }
+
+    [Fact]
+    public async Task SaveThenGet_SavedCustomTheme_RestoresTheThemeAndSelection()
+    {
+        var customTheme = new CustomThemePreference("Mission", "#102030", "#405060", "#708090", "#abcdef");
+        await _repository.SaveAsync(new AppPreferences("Mission", [customTheme]), BundledThemeNames);
+
+        var result = await _repository.GetAsync(BundledThemeNames);
+
+        Assert.Equal(AppPreferencesLoadStatus.Loaded, result.Status);
+        Assert.Equal("Mission", result.Preferences.ResolveSelectedThemeName(BundledThemeNames, "Borealis"));
+        var restored = Assert.Single(result.Preferences.CustomThemes);
+        Assert.Equal("Mission", restored.Name);
+        Assert.Equal("#102030", restored.MainColor);
+        Assert.Equal("#405060", restored.SecondaryColor);
+        Assert.Equal("#708090", restored.GlobalPanelsColor);
+        Assert.Equal("#abcdef", restored.TextColor);
+    }
+
+    [Fact]
+    public async Task GetAsync_InvalidJson_ReturnsInvalidAndTheDefaultThemeSafely()
+    {
+        await WriteAsync("{ not-json }");
+
+        var result = await _repository.GetAsync(BundledThemeNames);
+
+        Assert.Equal(AppPreferencesLoadStatus.Invalid, result.Status);
+        Assert.NotNull(result.Error);
+        Assert.Equal("Borealis", result.Preferences.ResolveSelectedThemeName(BundledThemeNames, "Borealis"));
+    }
+
+    [Fact]
+    public async Task GetAsync_UnknownSelectedTheme_LoadsAndUsesTheDefaultTheme()
+    {
+        await WriteAsync("""
+            {
+              "formatVersion": 1,
+              "selectedTheme": "Removed Theme",
+              "customThemes": []
+            }
+            """);
+
+        var result = await _repository.GetAsync(BundledThemeNames);
+
+        Assert.Equal(AppPreferencesLoadStatus.Loaded, result.Status);
+        Assert.Equal("Removed Theme", result.Preferences.SelectedThemeName);
+        Assert.Equal("Borealis", result.Preferences.ResolveSelectedThemeName(BundledThemeNames, "Borealis"));
+    }
+
+    [Fact]
+    public async Task GetAsync_PreferencePathIsADirectory_ReturnsUnavailable()
+    {
+        Directory.CreateDirectory(_pathProvider.GetAppPreferencesPath());
+
+        var result = await _repository.GetAsync(BundledThemeNames);
+
+        Assert.Equal(AppPreferencesLoadStatus.Unavailable, result.Status);
+        Assert.NotNull(result.Error);
+        Assert.Equal("Borealis", result.Preferences.ResolveSelectedThemeName(BundledThemeNames, "Borealis"));
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidDocuments))]
+    public async Task GetAsync_InvalidPreferenceDocument_ReturnsInvalid(string document)
+    {
+        await WriteAsync(document);
+
+        var result = await _repository.GetAsync(BundledThemeNames);
+
+        Assert.Equal(AppPreferencesLoadStatus.Invalid, result.Status);
+        Assert.Empty(result.Preferences.CustomThemes);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WritesTheVersionedExplicitFormat()
+    {
+        var customTheme = new CustomThemePreference("Mission", "#102030", "#405060", "#708090", "#abcdef");
+        await _repository.SaveAsync(new AppPreferences("Mission", [customTheme]), BundledThemeNames);
+
+        using var document = JsonDocument.Parse(await File.ReadAllTextAsync(_pathProvider.GetAppPreferencesPath()));
+        var root = document.RootElement;
+        Assert.Equal(1, root.GetProperty("formatVersion").GetInt32());
+        Assert.Equal("Mission", root.GetProperty("selectedTheme").GetString());
+        var savedTheme = Assert.Single(root.GetProperty("customThemes").EnumerateArray());
+        Assert.Equal("Mission", savedTheme.GetProperty("name").GetString());
+        Assert.Equal("#102030", savedTheme.GetProperty("mainColor").GetString());
+        Assert.False(root.TryGetProperty("bundledThemes", out _));
+    }
+
+    [Fact]
+    public async Task SaveAsync_CustomThemeConflictsWithBundledTheme_ThrowsWithoutWriting()
+    {
+        var customTheme = new CustomThemePreference("Dark", "#102030", "#405060", "#708090", "#abcdef");
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            _repository.SaveAsync(new AppPreferences("Dark", [customTheme]), BundledThemeNames));
+
+        Assert.False(File.Exists(_pathProvider.GetAppPreferencesPath()));
+    }
+
+    public static TheoryData<string> InvalidDocuments => new()
+    {
+        """
+        {
+          "formatVersion": 2,
+          "selectedTheme": "Dark",
+          "customThemes": []
+        }
+        """,
+        """
+        {
+          "formatVersion": 1,
+          "formatVersion": 1,
+          "customThemes": []
+        }
+        """,
+        """
+        {
+          "formatVersion": 1,
+          "customThemes": [
+            { "name": "Mission", "mainColor": "#102030", "secondaryColor": "#405060", "globalPanelsColor": "#708090", "textColor": "#abcdef" },
+            { "name": "Mission", "mainColor": "#102030", "secondaryColor": "#405060", "globalPanelsColor": "#708090", "textColor": "#abcdef" }
+          ]
+        }
+        """,
+        """
+        {
+          "formatVersion": 1,
+          "customThemes": [
+            { "name": "Dark", "mainColor": "#102030", "secondaryColor": "#405060", "globalPanelsColor": "#708090", "textColor": "#abcdef" }
+          ]
+        }
+        """,
+        """
+        {
+          "formatVersion": 1,
+          "customThemes": [
+            { "name": "Mission", "mainColor": "red", "secondaryColor": "#405060", "globalPanelsColor": "#708090", "textColor": "#abcdef" }
+          ]
+        }
+        """,
+        """
+        {
+          "formatVersion": 1,
+          "customThemes": [null]
+        }
+        """,
+        """
+        {
+          "formatVersion": 1,
+          "customThemes": [],
+          "unknown": true
+        }
+        """,
+    };
+
+    private async Task WriteAsync(string document)
+    {
+        Directory.CreateDirectory(_tempRoot);
+        await File.WriteAllTextAsync(_pathProvider.GetAppPreferencesPath(), document);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+}


### PR DESCRIPTION
## Summary

- Add a separate Borea.App preference contract for the selected theme and custom themes.
- Persist the preferences as versioned JSON under Borea's user-writable data directory.
- Expose the store through `BoreaServices.AppPreferences` without changing `MainViewModel`, views, or the current client JSON files.

## Why

The current UI branch reads `Settings.json` and `CustomThemes.json` from the packaged `Borea.App/client` directory.
That directory is application content and is not a safe place for user-writable state.

This change keeps app preferences separate from `BoreaSettings`, which remains limited to the game directory and installed loader directories.
It also keeps bundled default themes read-only in `client/BoreaDefaultThemes.json`.

## Storage behavior

The store writes one file at `%LocalAppData%\Borea\app-preferences.json`.
It contains an explicit format version, the selected theme name, and custom themes with named `#RRGGBB` color fields.

The read boundary validates unsupported versions, unknown fields, duplicate JSON properties, duplicate custom names, conflicts with bundled names, null entries, and invalid colors.
Missing, invalid, or unavailable preference data returns a safe empty preference result so it cannot prevent the app window from opening.
An unknown selected theme remains readable and resolves to the bundled default selected by the caller.

Writes use a temporary file and atomic replacement.
Write failures remain visible to the caller so the app can report that a preference change was not saved.

## Integration boundary

@PlazmaBoltz keeps ownership of the theme model, `MainViewModel`, views, and app lifecycle integration on `ui-ux-dev`.
The integration point from this pull request is `BoreaServices.AppPreferences`.

The UI passes the bundled theme names to `GetAsync`, maps the returned custom themes into its theme model, and calls `ResolveSelectedThemeName` with `Borealis` as the default.
It saves the selected name and full custom-theme collection through `SaveAsync`.

Part of #90.
Builds on `ui-ux-dev`.