### PR TITLE
Add English and German localization to Borea.App

### DIFF
--- a/Borea.slnx
+++ b/Borea.slnx
@@ -8,6 +8,7 @@
     <Project Path="src/Borea.Storage/Borea.Storage.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Borea.App.Tests/Borea.App.Tests.csproj" />
     <Project Path="tests/Borea.Cli.Tests/Borea.Cli.Tests.csproj" />
     <Project Path="tests/Borea.Composition.Tests/Borea.Composition.Tests.csproj" />
     <Project Path="tests/Borea.Core.Tests/Borea.Core.Tests.csproj" />

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Borea is a cross-platform complete general content manager for Kitten Space Agen
 # Credits
 - [MrJeranimo](https://github.com/MrJeranimo) - Original Creator and Developer
 
+# Contributing translations
+You do not need to write C# to improve an existing translation. See the [localization guide](docs/localization.md) for instructions to correct text or propose a new language.
+
 # Repository Structure
 | Path | Description |
 | --- | --- |

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -1,0 +1,89 @@
+# Help translate Borea
+
+You do not need to write C# to improve an existing Borea translation. You can edit a resource file through the GitHub website and submit the change for review.
+
+## Find the language files
+
+Borea keeps user-interface text in [`src/Borea.App/Localization/Resources`](../src/Borea.App/Localization/Resources).
+
+- [`Resources.resx`](../src/Borea.App/Localization/Resources/Resources.resx) is the neutral English source.
+- [`Resources.de.resx`](../src/Borea.App/Localization/Resources/Resources.de.resx) is the German translation.
+- A translated file uses the name `Resources.<language>.resx`. For example, French uses `Resources.fr.resx`.
+
+The language part of the file name is a .NET culture name. Microsoft documents these names through [`CultureInfo.Name`](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo.name).
+
+## Improve an existing translation on GitHub
+
+1. Open the resource file for the language that you want to improve.
+2. Select the pencil icon to edit the file.
+3. Find the text inside the `<value>` element.
+4. Change only the user-visible text. Do not change the value of the `name` attribute.
+5. Check the proposed diff and select the option to create a pull request.
+6. In the pull request, state which language you changed and briefly explain the correction.
+
+For example, this entry uses `NavigationHome` as its stable key and `Home` as its English text:
+
+```xml
+<data name="NavigationHome" xml:space="preserve">
+  <value>Home</value>
+</data>
+```
+
+To improve a translation, edit the text between `<value>` and `</value>`. Keep the `NavigationHome` key and the XML tags unchanged.
+
+GitHub creates a personal fork automatically when you do not have direct write access. You do not need to install Borea or a development environment for a text-only correction.
+
+## Preserve placeholders
+
+Some text can contain placeholders such as `{0}`. A placeholder is replaced with a value while Borea runs.
+
+Keep every placeholder in the translation. You can move it to a natural position in the sentence, but do not translate it or change its number.
+
+For example:
+
+```xml
+<data name="ViewNotFoundFormat" xml:space="preserve">
+  <value>View not found: {0}</value>
+</data>
+```
+
+The translated value must still contain `{0}`.
+
+## Propose a new language
+
+Adding a new language needs a complete resource file and one small code change that registers the language in the selector. A translator can provide the resource file, and a maintainer can make the code change.
+
+1. Open an issue and state the language, its culture name, and whether you can translate it.
+2. Copy the neutral [`Resources.resx`](../src/Borea.App/Localization/Resources/Resources.resx) file to `Resources.<language>.resx`.
+3. Translate every `<value>` element and keep every `name` attribute unchanged.
+4. Keep product names, identifiers, paths, and placeholders unchanged unless their surrounding text needs a different word order.
+5. Submit one pull request for the new language.
+6. Ask a fluent speaker to review the translation when possible.
+
+A maintainer will add the language to [`LocalizationService`](../src/Borea.App/Localization/LocalizationService.cs). The resource parity test checks that the new file has the same keys as the English source.
+
+## Translation guidance
+
+- Write clear and natural text for the target language instead of translating each English word separately.
+- Use the same translation for the same term throughout the interface.
+- Keep button and navigation labels short.
+- Do not translate `Borea`, file paths, resource keys, or code identifiers.
+- Do not add explanations that are not present in the English source. Open an issue when the source text is unclear.
+
+## Optional local check
+
+Continuous integration checks every pull request. A text-only contributor can wait for that result.
+
+If you already have the .NET SDK, you can run the focused tests locally:
+
+```text
+dotnet test tests/Borea.App.Tests/Borea.App.Tests.csproj --no-restore
+```
+
+The parity test reports a failure when a translation file has a missing or additional resource key.
+
+## Technical references
+
+- [Localizing using ResX in Avalonia](https://docs.avaloniaui.net/docs/app-development/localizing)
+- [Resources in .NET apps](https://learn.microsoft.com/en-us/dotnet/core/extensions/resources)
+- [Localization in .NET](https://learn.microsoft.com/en-us/dotnet/core/extensions/localization)

--- a/src/Borea.App/App.axaml.cs
+++ b/src/Borea.App/App.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Borea.App.Localization;
 using Borea.App.ViewModels;
 using Borea.App.Views;
 using Borea.Composition;
@@ -16,13 +17,17 @@ public partial class App : Application
     /// </summary>
     public BoreaServices? Services { get; }
 
+    public LocalizationService Localization { get; }
+
     public App()
     {
+        Localization = new LocalizationService();
     }
 
     public App(BoreaServices services)
     {
         Services = services ?? throw new ArgumentNullException(nameof(services));
+        Localization = new LocalizationService();
     }
 
     public override void Initialize()
@@ -36,7 +41,7 @@ public partial class App : Application
         {
             desktop.MainWindow = new MainWindow
             {
-                DataContext = new MainViewModel(),
+                DataContext = new MainViewModel(Localization),
             };
         }
 

--- a/src/Borea.App/Borea.App.csproj
+++ b/src/Borea.App/Borea.App.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,6 +9,21 @@
   <ItemGroup>
     <Folder Include="Models\" />
     <AvaloniaResource Include="Assets\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Localization\Resources\Resources.resx">
+      <Generator>MSBuild:Compile</Generator>
+      <Link>Localization\Resources.resx</Link>
+      <StronglyTypedFileName>$(IntermediateOutputPath)Resources.Designer.cs</StronglyTypedFileName>
+      <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
+      <StronglyTypedNamespace>Borea.App.Localization</StronglyTypedNamespace>
+      <StronglyTypedClassName>Resources</StronglyTypedClassName>
+      <PublicClass>true</PublicClass>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Localization\Resources\Resources.de.resx">
+      <Link>Localization\Resources.de.resx</Link>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Borea.App/Localization/LocalizationService.cs
+++ b/src/Borea.App/Localization/LocalizationService.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Borea.App.Localization;
+
+public sealed class LocalizationService : INotifyPropertyChanged
+{
+    private static readonly SupportedCulture English = new("en", "English");
+    private static readonly SupportedCulture German = new("de", "Deutsch");
+    private static readonly IReadOnlyList<SupportedCulture> Cultures = [English, German];
+
+    private SupportedCulture _selectedCulture = English;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public IReadOnlyList<SupportedCulture> SupportedCultures => Cultures;
+
+    public SupportedCulture SelectedCulture
+    {
+        get => _selectedCulture;
+        set
+        {
+            if (value is null)
+                return;
+
+            TrySetCulture(value.Name);
+        }
+    }
+
+    public string SelectedCultureName => SelectedCulture.Name;
+
+    public string BrandLogoPlaceholder => Resources.BrandLogoPlaceholder;
+
+    public string NavigationHome => Resources.NavigationHome;
+
+    public string NavigationLibrary => Resources.NavigationLibrary;
+
+    public string NavigationDiscover => Resources.NavigationDiscover;
+
+    public string NavigationSettings => Resources.NavigationSettings;
+
+    public string PageHomeHeading => Resources.PageHomeHeading;
+
+    public string PageDiscoverHeading => Resources.PageDiscoverHeading;
+
+    public string PageLibraryHeading => Resources.PageLibraryHeading;
+
+    public string SettingsLanguageLabel => Resources.SettingsLanguageLabel;
+
+    public string SettingsThemeLabel => Resources.SettingsThemeLabel;
+
+    public LocalizationService()
+        : this(CultureInfo.CurrentUICulture)
+    {
+    }
+
+    public LocalizationService(CultureInfo requestedCulture)
+    {
+        ArgumentNullException.ThrowIfNull(requestedCulture);
+        SetCulture(ResolveSupportedCulture(requestedCulture));
+    }
+
+    public bool TrySetCulture(string? cultureName)
+    {
+        SupportedCulture? supportedCulture = null;
+
+        if (!string.IsNullOrWhiteSpace(cultureName))
+        {
+            try
+            {
+                supportedCulture = ResolveSupportedCulture(CultureInfo.GetCultureInfo(cultureName));
+            }
+            catch (CultureNotFoundException)
+            {
+            }
+        }
+
+        SetCulture(supportedCulture);
+        return supportedCulture is not null;
+    }
+
+    public string FormatViewNotFound(string viewName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(viewName);
+        return string.Format(CultureInfo.CurrentCulture, Resources.ViewNotFoundFormat, viewName);
+    }
+
+    private static SupportedCulture? ResolveSupportedCulture(CultureInfo culture)
+    {
+        for (var candidate = culture; candidate != CultureInfo.InvariantCulture; candidate = candidate.Parent)
+        {
+            var match = Cultures.FirstOrDefault(item =>
+                string.Equals(item.Name, candidate.Name, StringComparison.OrdinalIgnoreCase));
+            if (match is not null)
+                return match;
+        }
+
+        return null;
+    }
+
+    private void SetCulture(SupportedCulture? culture)
+    {
+        culture ??= English;
+        Resources.Culture = culture.Culture;
+        CultureInfo.CurrentUICulture = culture.Culture;
+
+        if (ReferenceEquals(_selectedCulture, culture))
+            return;
+
+        _selectedCulture = culture;
+        OnPropertyChanged(string.Empty);
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/src/Borea.App/Localization/Resources/Resources.de.resx
+++ b/src/Borea.App/Localization/Resources/Resources.de.resx
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BrandLogoPlaceholder" xml:space="preserve">
+    <value>Logo wird hier angezeigt</value>
+  </data>
+  <data name="NavigationDiscover" xml:space="preserve">
+    <value>Entdecken</value>
+  </data>
+  <data name="NavigationHome" xml:space="preserve">
+    <value>Startseite</value>
+  </data>
+  <data name="NavigationLibrary" xml:space="preserve">
+    <value>Bibliothek</value>
+  </data>
+  <data name="NavigationSettings" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="PageDiscoverHeading" xml:space="preserve">
+    <value>Entdecken</value>
+  </data>
+  <data name="PageHomeHeading" xml:space="preserve">
+    <value>Startseite</value>
+  </data>
+  <data name="PageLibraryHeading" xml:space="preserve">
+    <value>Bibliothek</value>
+  </data>
+  <data name="SettingsLanguageLabel" xml:space="preserve">
+    <value>Sprache</value>
+  </data>
+  <data name="SettingsThemeLabel" xml:space="preserve">
+    <value>Design</value>
+  </data>
+  <data name="ViewNotFoundFormat" xml:space="preserve">
+    <value>Ansicht nicht gefunden: {0}</value>
+  </data>
+</root>

--- a/src/Borea.App/Localization/Resources/Resources.resx
+++ b/src/Borea.App/Localization/Resources/Resources.resx
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BrandLogoPlaceholder" xml:space="preserve">
+    <value>Logo goes here</value>
+  </data>
+  <data name="NavigationDiscover" xml:space="preserve">
+    <value>Discover</value>
+  </data>
+  <data name="NavigationHome" xml:space="preserve">
+    <value>Home</value>
+  </data>
+  <data name="NavigationLibrary" xml:space="preserve">
+    <value>Library</value>
+  </data>
+  <data name="NavigationSettings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="PageDiscoverHeading" xml:space="preserve">
+    <value>Discover</value>
+  </data>
+  <data name="PageHomeHeading" xml:space="preserve">
+    <value>Home</value>
+  </data>
+  <data name="PageLibraryHeading" xml:space="preserve">
+    <value>Library</value>
+  </data>
+  <data name="SettingsLanguageLabel" xml:space="preserve">
+    <value>Language</value>
+  </data>
+  <data name="SettingsThemeLabel" xml:space="preserve">
+    <value>Theme</value>
+  </data>
+  <data name="ViewNotFoundFormat" xml:space="preserve">
+    <value>View not found: {0}</value>
+  </data>
+</root>

--- a/src/Borea.App/Localization/SupportedCulture.cs
+++ b/src/Borea.App/Localization/SupportedCulture.cs
@@ -1,0 +1,20 @@
+using System.Globalization;
+
+namespace Borea.App.Localization;
+
+public sealed class SupportedCulture
+{
+    public string Name => Culture.Name;
+
+    public string DisplayName { get; }
+
+    internal CultureInfo Culture { get; }
+
+    internal SupportedCulture(string name, string displayName)
+    {
+        Culture = CultureInfo.GetCultureInfo(name);
+        DisplayName = displayName;
+    }
+
+    public override string ToString() => DisplayName;
+}

--- a/src/Borea.App/ViewLocator.cs
+++ b/src/Borea.App/ViewLocator.cs
@@ -1,7 +1,10 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
+using Borea.App.Localization;
 using Borea.App.ViewModels;
 
 namespace Borea.App;
@@ -27,11 +30,42 @@ public class ViewLocator : IDataTemplate
             return (Control)Activator.CreateInstance(type)!;
         }
 
-        return new TextBlock { Text = "Not Found: " + name };
+        var localization = (Application.Current as App)?.Localization ?? new LocalizationService();
+        return new LocalizedViewNotFoundTextBlock(localization, name);
     }
 
     public bool Match(object? data)
     {
         return data is ViewModelBase;
+    }
+
+    private sealed class LocalizedViewNotFoundTextBlock : TextBlock
+    {
+        private readonly LocalizationService _localization;
+        private readonly string _viewName;
+
+        public LocalizedViewNotFoundTextBlock(LocalizationService localization, string viewName)
+        {
+            _localization = localization;
+            _viewName = viewName;
+            UpdateText();
+        }
+
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);
+            _localization.PropertyChanged += OnLocalizationChanged;
+            UpdateText();
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            _localization.PropertyChanged -= OnLocalizationChanged;
+            base.OnDetachedFromVisualTree(e);
+        }
+
+        private void OnLocalizationChanged(object? sender, PropertyChangedEventArgs e) => UpdateText();
+
+        private void UpdateText() => Text = _localization.FormatViewNotFound(_viewName);
     }
 }

--- a/src/Borea.App/ViewModels/MainViewModel.cs
+++ b/src/Borea.App/ViewModels/MainViewModel.cs
@@ -1,18 +1,18 @@
+using System;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Avalonia.Controls.Primitives;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.IO;
 using System.Linq;
-using CommunityToolkit.Mvvm;
+using Borea.App.Localization;
 
 namespace Borea.App.ViewModels;
 
 public partial class MainViewModel : ViewModelBase
 {
-    [ObservableProperty]
-    public partial string Greeting { get; set; } = "Welcome to Avalonia!";
+    public LocalizationService Localization { get; }
+
     [ObservableProperty]
     private string _mainColor = "#248cc0";
     [ObservableProperty]
@@ -76,6 +76,17 @@ public partial class MainViewModel : ViewModelBase
     private Dictionary<string, string[]> _themes = new Dictionary<string, string[]>();
     [ObservableProperty]
     private string _currentTheme = "Borealis";
+
+    public MainViewModel()
+        : this(new LocalizationService())
+    {
+    }
+
+    public MainViewModel(LocalizationService localization)
+    {
+        Localization = localization ?? throw new ArgumentNullException(nameof(localization));
+    }
+
     [RelayCommand]
     public void GetThemes() // used to get the themes from the json files
     {
@@ -100,7 +111,7 @@ public partial class MainViewModel : ViewModelBase
         }
         string settingsJson = File.ReadAllText("client/Settings.json");
         var settings = JsonSerializer.Deserialize<Dictionary<string, string>>(settingsJson);
-        CurrentTheme = settings != null && settings.ContainsKey("theme") ? settings["theme"] : "Error";
+        CurrentTheme = settings != null && settings.ContainsKey("theme") ? settings["theme"] : "Borealis";
         SetTheme(CurrentTheme); // set the theme to the current theme
     }
     public void SetTheme(string themeName) // used to set the theme

--- a/src/Borea.App/Views/MainWindow.axaml
+++ b/src/Borea.App/Views/MainWindow.axaml
@@ -30,37 +30,42 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <Panel Grid.Row="0" Background="{Binding SecondaryColor}">
-                    <TextBlock Text="Logo Goes Here" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    <TextBlock Text="{Binding Localization.BrandLogoPlaceholder}" HorizontalAlignment="Center" VerticalAlignment="Center" />
                 </Panel>
                 <Panel Grid.Row="1" Background="{Binding GlobalPanelsColor}" Margin="20">
-                    <Button Content="Home" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,5,0,5" Command="{Binding SetMainWindowHome}" Foreground="{Binding TextColor}" />
-                    <Button Content="Library" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,55,0,55" Command="{Binding SetMainWindowLibrary}" Foreground="{Binding TextColor}" />
-                    <Button Content="Discover" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,105,0,105" Command="{Binding SetMainWindowDiscover}" Foreground="{Binding TextColor}"/> <!--All of these will eventually be replaced with images instead of text-->
-                    <Button Content="Settings" HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,5,0,5" Command="{Binding SetMainWindowSettings}" Foreground="{Binding TextColor}" />
+                    <Button Content="{Binding Localization.NavigationHome}" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,5,0,5" Command="{Binding SetMainWindowHome}" Foreground="{Binding TextColor}" />
+                    <Button Content="{Binding Localization.NavigationLibrary}" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,55,0,55" Command="{Binding SetMainWindowLibrary}" Foreground="{Binding TextColor}" />
+                    <Button Content="{Binding Localization.NavigationDiscover}" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,105,0,105" Command="{Binding SetMainWindowDiscover}" Foreground="{Binding TextColor}"/> <!--All of these will eventually be replaced with images instead of text-->
+                    <Button Content="{Binding Localization.NavigationSettings}" HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,5,0,5" Command="{Binding SetMainWindowSettings}" Foreground="{Binding TextColor}" />
                 </Panel>
             </Grid>
         </Panel>
 
         <Panel Grid.Column="1" Background="{Binding MainColor}" IsEnabled="{Binding CurrentWindowHome}" IsVisible="{Binding CurrentWindowHome}"> <!-- Home  -->
-            <TextBlock Text="Home" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{Binding TextColor}" />
+            <TextBlock Text="{Binding Localization.PageHomeHeading}" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{Binding TextColor}" />
         </Panel>
 
 
 
         <Panel Grid.Column="1" Background="{Binding MainColor}" IsEnabled="{Binding CurrentWindowDiscover}" IsVisible="{Binding CurrentWindowDiscover}"> <!-- Discover  -->
-            <TextBlock Text="Discover" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{Binding TextColor}" />
+            <TextBlock Text="{Binding Localization.PageDiscoverHeading}" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{Binding TextColor}" />
         </Panel>
 
 
 
         <Panel Grid.Column="1" Background="{Binding MainColor}" IsEnabled="{Binding CurrentWindowLibrary}" IsVisible="{Binding CurrentWindowLibrary}"> <!-- Library  -->
-            <TextBlock Text="Library" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{Binding TextColor}" />
+            <TextBlock Text="{Binding Localization.PageLibraryHeading}" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{Binding TextColor}" />
         </Panel>
 
 
 
         <Panel Grid.Column="1" Background="{Binding MainColor}" IsEnabled="{Binding CurrentWindowSettings}" IsVisible="{Binding CurrentWindowSettings}"> <!-- Settings  -->
-            <ComboBox ItemsSource="{Binding ThemeNames}" SelectedItem="{Binding CurrentTheme}" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,5,0,5" Foreground="{Binding TextColor}" />
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,5,0,5" Spacing="5">
+                <TextBlock Text="{Binding Localization.SettingsLanguageLabel}" Foreground="{Binding TextColor}" />
+                <ComboBox ItemsSource="{Binding Localization.SupportedCultures}" SelectedItem="{Binding Localization.SelectedCulture, Mode=TwoWay}" AutomationProperties.Name="{Binding Localization.SettingsLanguageLabel}" />
+                <TextBlock Text="{Binding Localization.SettingsThemeLabel}" Foreground="{Binding TextColor}" Margin="0,10,0,0" />
+                <ComboBox ItemsSource="{Binding ThemeNames}" SelectedItem="{Binding CurrentTheme}" Foreground="{Binding TextColor}" AutomationProperties.Name="{Binding Localization.SettingsThemeLabel}" />
+            </StackPanel>
             <TextBlock Text="{Binding CurrentTheme}" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{Binding TextColor}" />
         </Panel>
     </Grid>

--- a/tests/Borea.App.Tests/Borea.App.Tests.csproj
+++ b/tests/Borea.App.Tests/Borea.App.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Borea.App\Borea.App.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Borea.App.Tests/Localization/LocalizationServiceTests.cs
+++ b/tests/Borea.App.Tests/Localization/LocalizationServiceTests.cs
@@ -1,0 +1,99 @@
+using System.ComponentModel;
+using System.Globalization;
+using Borea.App.Localization;
+
+namespace Borea.App.Tests.Localization;
+
+public sealed class LocalizationServiceTests : IDisposable
+{
+    private readonly CultureInfo _originalCulture = CultureInfo.CurrentCulture;
+    private readonly CultureInfo _originalUiCulture = CultureInfo.CurrentUICulture;
+
+    [Fact]
+    public void Constructor_EnglishCulture_UsesNeutralEnglishResources()
+    {
+        var service = new LocalizationService(CultureInfo.GetCultureInfo("en-US"));
+
+        Assert.Equal("en", service.SelectedCultureName);
+        Assert.Equal("Home", service.NavigationHome);
+    }
+
+    [Fact]
+    public void Constructor_GermanRegionalCulture_UsesGermanResources()
+    {
+        var service = new LocalizationService(CultureInfo.GetCultureInfo("de-DE"));
+
+        Assert.Equal("de", service.SelectedCultureName);
+        Assert.Equal("Startseite", service.NavigationHome);
+        Assert.Equal("Sprache", service.SettingsLanguageLabel);
+    }
+
+    [Fact]
+    public void TrySetCulture_SupportedCulture_NotifiesAndChangesActiveValues()
+    {
+        var service = new LocalizationService(CultureInfo.GetCultureInfo("en"));
+        var notifications = new List<PropertyChangedEventArgs>();
+        service.PropertyChanged += (_, args) => notifications.Add(args);
+
+        var changed = service.TrySetCulture("de");
+
+        Assert.True(changed);
+        Assert.Equal("Startseite", service.NavigationHome);
+        Assert.Contains(notifications, notification => notification.PropertyName == string.Empty);
+    }
+
+    [Theory]
+    [InlineData("not-a-culture")]
+    [InlineData("fr-FR")]
+    [InlineData("")]
+    public void TrySetCulture_UnsupportedCulture_FallsBackToEnglish(string cultureName)
+    {
+        var service = new LocalizationService(CultureInfo.GetCultureInfo("de"));
+
+        var changed = service.TrySetCulture(cultureName);
+
+        Assert.False(changed);
+        Assert.Equal("en", service.SelectedCultureName);
+        Assert.Equal("Home", service.NavigationHome);
+    }
+
+    [Fact]
+    public void TrySetCulture_ChangesUiCultureWithoutChangingRegionalCulture()
+    {
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+        var service = new LocalizationService(CultureInfo.GetCultureInfo("en"));
+
+        service.TrySetCulture("de");
+
+        Assert.Equal("de", CultureInfo.CurrentUICulture.Name);
+        Assert.Equal("fr-FR", CultureInfo.CurrentCulture.Name);
+    }
+
+    [Fact]
+    public void SupportedCultures_ListsEnglishAndGerman()
+    {
+        var service = new LocalizationService(CultureInfo.GetCultureInfo("en"));
+
+        Assert.Collection(
+            service.SupportedCultures,
+            culture => Assert.Equal("en", culture.Name),
+            culture => Assert.Equal("de", culture.Name));
+    }
+
+    [Fact]
+    public void FormatViewNotFound_UsesOneFormattedResourceInTheSelectedLanguage()
+    {
+        var service = new LocalizationService(CultureInfo.GetCultureInfo("de"));
+
+        var message = service.FormatViewNotFound("Borea.App.Views.UnknownView");
+
+        Assert.Equal("Ansicht nicht gefunden: Borea.App.Views.UnknownView", message);
+    }
+
+    public void Dispose()
+    {
+        CultureInfo.CurrentCulture = _originalCulture;
+        CultureInfo.CurrentUICulture = _originalUiCulture;
+        Resources.Culture = _originalUiCulture;
+    }
+}

--- a/tests/Borea.App.Tests/Localization/ResourceParityTests.cs
+++ b/tests/Borea.App.Tests/Localization/ResourceParityTests.cs
@@ -1,0 +1,26 @@
+using System.Xml.Linq;
+
+namespace Borea.App.Tests.Localization;
+
+public sealed class ResourceParityTests
+{
+    [Fact]
+    public void GermanResources_HaveTheSameKeysAsNeutralResources()
+    {
+        var localizationDirectory = Path.GetFullPath(
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "src", "Borea.App", "Localization", "Resources"));
+
+        var neutralKeys = ReadKeys(Path.Combine(localizationDirectory, "Resources.resx"));
+        var germanKeys = ReadKeys(Path.Combine(localizationDirectory, "Resources.de.resx"));
+
+        Assert.Equal(neutralKeys, germanKeys);
+    }
+
+    private static string[] ReadKeys(string path)
+        => XDocument.Load(path)
+            .Root!
+            .Elements("data")
+            .Select(element => (string)element.Attribute("name")!)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+}

--- a/tests/Borea.App.Tests/TestAssembly.cs
+++ b/tests/Borea.App.Tests/TestAssembly.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Summary

This adds ResX-based localization to the Borea desktop App. The current interface is available in English and German, and the language can change while the App is running.

The App uses the operating system UI language when it starts. An English or German regional culture, such as `en-US` or `de-DE`, selects its supported parent language. Any other or invalid language falls back to English.

Changing the UI language does not change the regional culture that formats dates, numbers, or other regional values. Only `CurrentUICulture` changes.

## User interface

The navigation labels, page headings, settings labels, logo placeholder, accessibility names, and missing-view message now come from the localization resources. The Settings page contains a language selector for English and German.

The UI binds to one observable localization service. When the user selects another language, the service notifies the active bindings and the visible text updates without an App restart. The missing-view fallback also listens for this notification while it is visible.

## Why this design

Avalonia documents ResX as its standard resource-based localization approach in [Localizing using ResX](https://docs.avaloniaui.net/docs/app-development/localizing). The guide also explains how the build generates a public, strongly typed `Resources` class. This change uses the cross-platform MSBuild generator described there, so the generated file stays under `obj` and does not depend on Visual Studio writing a source file into the repository.

.NET uses `CurrentUICulture` to select translated resources, while `CurrentCulture` controls regional formatting. The [.NET resources overview](https://learn.microsoft.com/en-us/dotnet/core/extensions/resources) explains this separation and how `ResourceManager` retrieves the correct resource set. Keeping these values separate lets a user select German interface text without unexpectedly changing number or date formatting.

The [.NET localization guide](https://learn.microsoft.com/en-us/dotnet/core/extensions/localization) explains the parent-culture and neutral-resource fallback rules. Borea first reduces a regional UI culture such as `de-DE` to the supported `de` language. It then uses the neutral English resource when no supported language matches, so the UI always has usable text.

The Avalonia guide shows static XAML resource references, but static references do not notify existing controls after a runtime language change. Borea instead exposes localized values through an observable service. Avalonia describes this update mechanism in [How to use INotifyPropertyChanged](https://docs.avaloniaui.net/docs/data-binding/inotifypropertychanged). One notification refreshes all localization bindings after the selected language changes.

The language and theme selectors also receive localized `AutomationProperties.Name` values. Avalonia explains in its [Accessibility guide](https://docs.avaloniaui.net/docs/app-development/accessibility) that these properties provide metadata to assistive technologies without changing the visual layout.

## Resource structure

The source resource files are under `Localization/Resources/`. The project generates one strongly typed `Resources` class during the build, so generated code is not committed.

The neutral resource contains English text. `Resources.de.resx` contains the German translation. A parity test requires both files to contain the same resource keys.

## Scope and preference storage

This change localizes `Borea.App` only. It does not change the CLI because issue #95 identifies the graphical interface as the required scope.

The selected language applies for the current App run. Persistent storage remains part of issue #90. This change exposes the canonical `SelectedCultureName` value and `TrySetCulture` method so the preference work can load and save `en` or `de` without duplicating localization rules.

Closes #95