### PR TITLE
Add a separate regional format preference

### DIFF
--- a/src/Borea.App/App.axaml.cs
+++ b/src/Borea.App/App.axaml.cs
@@ -2,10 +2,12 @@ using System;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Borea.App.Formatting;
 using Borea.App.Localization;
 using Borea.App.ViewModels;
 using Borea.App.Views;
 using Borea.Composition;
+using Borea.Core.Preferences;
 
 namespace Borea.App;
 
@@ -19,15 +21,30 @@ public partial class App : Application
 
     public LocalizationService Localization { get; }
 
+    public RegionalFormatService RegionalFormat { get; }
+
+    private readonly AppPreferences _preferences;
+
     public App()
     {
         Localization = new LocalizationService();
+        RegionalFormat = new RegionalFormatService(Localization);
+        _preferences = AppPreferences.Empty;
     }
 
     public App(BoreaServices services)
     {
         Services = services ?? throw new ArgumentNullException(nameof(services));
         Localization = new LocalizationService();
+        var loadResult = Services.AppPreferences
+            .GetAsync(MainViewModel.BundledThemeNames)
+            .GetAwaiter()
+            .GetResult();
+        _preferences = loadResult.Preferences;
+        RegionalFormat = new RegionalFormatService(
+            Localization,
+            System.Globalization.CultureInfo.CurrentCulture,
+            _preferences.RegionalCultureName);
     }
 
     public override void Initialize()
@@ -41,7 +58,11 @@ public partial class App : Application
         {
             desktop.MainWindow = new MainWindow
             {
-                DataContext = new MainViewModel(Localization),
+                DataContext = new MainViewModel(
+                    Localization,
+                    RegionalFormat,
+                    Services?.AppPreferences,
+                    _preferences),
             };
         }
 

--- a/src/Borea.App/Formatting/RegionalFormatOption.cs
+++ b/src/Borea.App/Formatting/RegionalFormatOption.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+
+namespace Borea.App.Formatting;
+
+public sealed class RegionalFormatOption
+{
+    public string? CultureName { get; }
+
+    public string DisplayName { get; }
+
+    internal CultureInfo Culture { get; }
+
+    internal RegionalFormatOption(string? cultureName, string displayName, CultureInfo culture)
+    {
+        CultureName = cultureName;
+        DisplayName = displayName;
+        Culture = culture;
+    }
+
+    public override string ToString() => DisplayName;
+}

--- a/src/Borea.App/Formatting/RegionalFormatService.cs
+++ b/src/Borea.App/Formatting/RegionalFormatService.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Borea.App.Localization;
+
+namespace Borea.App.Formatting;
+
+public sealed class RegionalFormatService : INotifyPropertyChanged
+{
+    private readonly LocalizationService _localization;
+    private readonly CultureInfo _systemCulture;
+
+    private IReadOnlyList<RegionalFormatOption> _supportedFormats;
+    private RegionalFormatOption _selectedFormat;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public IReadOnlyList<RegionalFormatOption> SupportedFormats => _supportedFormats;
+
+    public RegionalFormatOption SelectedFormat
+    {
+        get => _selectedFormat;
+        set
+        {
+            if (value is null)
+                return;
+
+            SetFormat(ResolveFormat(value.CultureName));
+        }
+    }
+
+    public string? SelectedCultureName => SelectedFormat.CultureName;
+
+    public RegionalFormatService(LocalizationService localization)
+        : this(localization, CultureInfo.CurrentCulture, selectedCultureName: null)
+    {
+    }
+
+    public RegionalFormatService(
+        LocalizationService localization,
+        CultureInfo systemCulture,
+        string? selectedCultureName)
+    {
+        _localization = localization ?? throw new ArgumentNullException(nameof(localization));
+        _systemCulture = systemCulture ?? throw new ArgumentNullException(nameof(systemCulture));
+        _supportedFormats = BuildSupportedFormats();
+        _selectedFormat = _supportedFormats[0];
+        TrySetCulture(selectedCultureName);
+        _localization.PropertyChanged += OnLocalizationChanged;
+    }
+
+    public bool TrySetCulture(string? cultureName)
+    {
+        if (cultureName is null)
+        {
+            SetFormat(_supportedFormats[0]);
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(cultureName))
+        {
+            SetFormat(_supportedFormats[0]);
+            return false;
+        }
+
+        var format = _supportedFormats.FirstOrDefault(candidate =>
+            string.Equals(candidate.CultureName, cultureName, StringComparison.OrdinalIgnoreCase));
+        SetFormat(format ?? _supportedFormats[0]);
+        return format is not null;
+    }
+
+    private IReadOnlyList<RegionalFormatOption> BuildSupportedFormats()
+    {
+        var systemDefault = new RegionalFormatOption(
+            cultureName: null,
+            $"{_localization.SystemDefaultRegionalFormat} ({_systemCulture.NativeName})",
+            _systemCulture);
+
+        var specificFormats = CultureInfo.GetCultures(CultureTypes.SpecificCultures)
+            .Where(culture => !string.IsNullOrEmpty(culture.Name))
+            .GroupBy(culture => culture.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .Select(culture => new RegionalFormatOption(
+                culture.Name,
+                $"{culture.NativeName} ({culture.Name})",
+                culture))
+            .OrderBy(format => format.DisplayName, StringComparer.OrdinalIgnoreCase);
+
+        return [systemDefault, .. specificFormats];
+    }
+
+    private RegionalFormatOption ResolveFormat(string? cultureName)
+        => cultureName is null
+            ? _supportedFormats[0]
+            : _supportedFormats.FirstOrDefault(candidate =>
+                string.Equals(candidate.CultureName, cultureName, StringComparison.OrdinalIgnoreCase))
+                ?? _supportedFormats[0];
+
+    private void SetFormat(RegionalFormatOption format)
+    {
+        CultureInfo.CurrentCulture = format.Culture;
+
+        if (string.Equals(_selectedFormat.CultureName, format.CultureName, StringComparison.Ordinal))
+            return;
+
+        _selectedFormat = format;
+        OnPropertyChanged(nameof(SelectedFormat));
+        OnPropertyChanged(nameof(SelectedCultureName));
+    }
+
+    private void OnLocalizationChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        var selectedCultureName = SelectedCultureName;
+        _supportedFormats = BuildSupportedFormats();
+        _selectedFormat = ResolveFormat(selectedCultureName);
+        OnPropertyChanged(nameof(SupportedFormats));
+        OnPropertyChanged(nameof(SelectedFormat));
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/src/Borea.App/Localization/LocalizationService.cs
+++ b/src/Borea.App/Localization/LocalizationService.cs
@@ -51,7 +51,11 @@ public sealed class LocalizationService : INotifyPropertyChanged
 
     public string SettingsLanguageLabel => Resources.SettingsLanguageLabel;
 
+    public string SettingsRegionalFormatLabel => Resources.SettingsRegionalFormatLabel;
+
     public string SettingsThemeLabel => Resources.SettingsThemeLabel;
+
+    public string SystemDefaultRegionalFormat => Resources.SystemDefaultRegionalFormat;
 
     public LocalizationService()
         : this(CultureInfo.CurrentUICulture)
@@ -87,6 +91,12 @@ public sealed class LocalizationService : INotifyPropertyChanged
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(viewName);
         return string.Format(CultureInfo.CurrentCulture, Resources.ViewNotFoundFormat, viewName);
+    }
+
+    public string FormatPreferenceSaveError(string error)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(error);
+        return string.Format(CultureInfo.CurrentCulture, Resources.PreferenceSaveErrorFormat, error);
     }
 
     private static SupportedCulture? ResolveSupportedCulture(CultureInfo culture)

--- a/src/Borea.App/Localization/Resources/Resources.de.resx
+++ b/src/Borea.App/Localization/Resources/Resources.de.resx
@@ -36,11 +36,20 @@
   <data name="PageLibraryHeading" xml:space="preserve">
     <value>Bibliothek</value>
   </data>
+  <data name="PreferenceSaveErrorFormat" xml:space="preserve">
+    <value>Die Einstellung konnte nicht gespeichert werden: {0}</value>
+  </data>
   <data name="SettingsLanguageLabel" xml:space="preserve">
     <value>Sprache</value>
   </data>
+  <data name="SettingsRegionalFormatLabel" xml:space="preserve">
+    <value>Regionales Format</value>
+  </data>
   <data name="SettingsThemeLabel" xml:space="preserve">
     <value>Design</value>
+  </data>
+  <data name="SystemDefaultRegionalFormat" xml:space="preserve">
+    <value>Systemstandard</value>
   </data>
   <data name="ViewNotFoundFormat" xml:space="preserve">
     <value>Ansicht nicht gefunden: {0}</value>

--- a/src/Borea.App/Localization/Resources/Resources.resx
+++ b/src/Borea.App/Localization/Resources/Resources.resx
@@ -36,11 +36,20 @@
   <data name="PageLibraryHeading" xml:space="preserve">
     <value>Library</value>
   </data>
+  <data name="PreferenceSaveErrorFormat" xml:space="preserve">
+    <value>The preference could not be saved: {0}</value>
+  </data>
   <data name="SettingsLanguageLabel" xml:space="preserve">
     <value>Language</value>
   </data>
+  <data name="SettingsRegionalFormatLabel" xml:space="preserve">
+    <value>Regional format</value>
+  </data>
   <data name="SettingsThemeLabel" xml:space="preserve">
     <value>Theme</value>
+  </data>
+  <data name="SystemDefaultRegionalFormat" xml:space="preserve">
+    <value>System default</value>
   </data>
   <data name="ViewNotFoundFormat" xml:space="preserve">
     <value>View not found: {0}</value>

--- a/src/Borea.App/ViewModels/MainViewModel.cs
+++ b/src/Borea.App/ViewModels/MainViewModel.cs
@@ -1,17 +1,47 @@
 using System;
+using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Borea.App.Formatting;
 using Borea.App.Localization;
+using Borea.Core.Preferences;
 
 namespace Borea.App.ViewModels;
 
 public partial class MainViewModel : ViewModelBase
 {
+    internal static IReadOnlyCollection<string> BundledThemeNames { get; } = ["Borealis", "Light", "Dark"];
+
+    private readonly IAppPreferencesRepository? _appPreferencesRepository;
+    private readonly SemaphoreSlim _preferenceSaveLock = new(1, 1);
+    private AppPreferences _appPreferences;
+
     public LocalizationService Localization { get; }
+
+    public RegionalFormatService RegionalFormat { get; }
+
+    public RegionalFormatOption SelectedRegionalFormat
+    {
+        get => RegionalFormat.SelectedFormat;
+        set
+        {
+            if (value is null)
+                return;
+
+            RegionalFormat.SelectedFormat = value;
+            OnPropertyChanged();
+            _ = SaveRegionalFormatAsync();
+        }
+    }
+
+    [ObservableProperty]
+    private string? _preferenceSaveError;
 
     [ObservableProperty]
     private string _mainColor = "#248cc0";
@@ -71,7 +101,7 @@ public partial class MainViewModel : ViewModelBase
 
     //themes
     [ObservableProperty]
-    private string[] _themeNames = new string[] { "Borealis", "Light", "Dark" };
+    private string[] _themeNames = BundledThemeNames.ToArray();
     [ObservableProperty]
     private Dictionary<string, string[]> _themes = new Dictionary<string, string[]>();
     [ObservableProperty]
@@ -83,15 +113,68 @@ public partial class MainViewModel : ViewModelBase
     }
 
     public MainViewModel(LocalizationService localization)
+        : this(
+            localization,
+            new RegionalFormatService(localization),
+            appPreferencesRepository: null,
+            AppPreferences.Empty)
+    {
+    }
+
+    public MainViewModel(
+        LocalizationService localization,
+        RegionalFormatService regionalFormat,
+        IAppPreferencesRepository? appPreferencesRepository,
+        AppPreferences appPreferences)
     {
         Localization = localization ?? throw new ArgumentNullException(nameof(localization));
+        RegionalFormat = regionalFormat ?? throw new ArgumentNullException(nameof(regionalFormat));
+        _appPreferencesRepository = appPreferencesRepository;
+        _appPreferences = appPreferences ?? throw new ArgumentNullException(nameof(appPreferences));
+        RegionalFormat.PropertyChanged += OnRegionalFormatChanged;
+    }
+
+    private async Task SaveRegionalFormatAsync()
+    {
+        if (_appPreferencesRepository is null)
+            return;
+
+        await _preferenceSaveLock.WaitAsync();
+        try
+        {
+            var regionalCultureName = RegionalFormat.SelectedCultureName;
+            if (string.Equals(_appPreferences.RegionalCultureName, regionalCultureName, StringComparison.Ordinal))
+            {
+                PreferenceSaveError = null;
+                return;
+            }
+
+            var updatedPreferences = _appPreferences.WithRegionalCultureName(regionalCultureName);
+            await _appPreferencesRepository.SaveAsync(updatedPreferences, BundledThemeNames);
+            _appPreferences = updatedPreferences;
+            PreferenceSaveError = null;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            PreferenceSaveError = Localization.FormatPreferenceSaveError(exception.Message);
+        }
+        finally
+        {
+            _preferenceSaveLock.Release();
+        }
+    }
+
+    private void OnRegionalFormatChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(RegionalFormatService.SelectedFormat))
+            OnPropertyChanged(nameof(SelectedRegionalFormat));
     }
 
     [RelayCommand]
     public void GetThemes() // used to get the themes from the json files
     {
         Themes = new Dictionary<string, string[]>();
-        ThemeNames = new string[] { "Borealis", "Light", "Dark" };
+        ThemeNames = BundledThemeNames.ToArray();
         string themesJson = File.ReadAllText("client/BoreaDefaultThemes.json");
         var themes = JsonSerializer.Deserialize<Dictionary<string, string[]>>(themesJson);
         if (themes != null)

--- a/src/Borea.App/Views/MainWindow.axaml
+++ b/src/Borea.App/Views/MainWindow.axaml
@@ -1,5 +1,6 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:formatting="using:Borea.App.Formatting"
         xmlns:vm="using:Borea.App.ViewModels"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -63,6 +64,15 @@
             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,5,0,5" Spacing="5">
                 <TextBlock Text="{Binding Localization.SettingsLanguageLabel}" Foreground="{Binding TextColor}" />
                 <ComboBox ItemsSource="{Binding Localization.SupportedCultures}" SelectedItem="{Binding Localization.SelectedCulture, Mode=TwoWay}" AutomationProperties.Name="{Binding Localization.SettingsLanguageLabel}" />
+                <TextBlock Text="{Binding Localization.SettingsRegionalFormatLabel}" Foreground="{Binding TextColor}" Margin="0,10,0,0" />
+                <ComboBox ItemsSource="{Binding RegionalFormat.SupportedFormats}" SelectedItem="{Binding SelectedRegionalFormat, Mode=TwoWay}" AutomationProperties.Name="{Binding Localization.SettingsRegionalFormatLabel}" MaxDropDownHeight="300" MinWidth="280">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate x:DataType="formatting:RegionalFormatOption">
+                            <TextBlock Text="{Binding DisplayName}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+                <TextBlock Text="{Binding PreferenceSaveError}" Foreground="{Binding TextColor}" TextWrapping="Wrap" MaxWidth="360" />
                 <TextBlock Text="{Binding Localization.SettingsThemeLabel}" Foreground="{Binding TextColor}" Margin="0,10,0,0" />
                 <ComboBox ItemsSource="{Binding ThemeNames}" SelectedItem="{Binding CurrentTheme}" Foreground="{Binding TextColor}" AutomationProperties.Name="{Binding Localization.SettingsThemeLabel}" />
             </StackPanel>

--- a/src/Borea.Core/Preferences/AppPreferences.cs
+++ b/src/Borea.Core/Preferences/AppPreferences.cs
@@ -6,16 +6,28 @@ public sealed class AppPreferences
 
     public string? SelectedThemeName { get; }
 
+    public string? RegionalCultureName { get; }
+
     public IReadOnlyList<CustomThemePreference> CustomThemes { get; }
 
-    public AppPreferences(string? selectedThemeName, IEnumerable<CustomThemePreference>? customThemes = null)
+    public AppPreferences(
+        string? selectedThemeName,
+        IEnumerable<CustomThemePreference>? customThemes = null,
+        string? regionalCultureName = null)
     {
         if (selectedThemeName is not null && string.IsNullOrWhiteSpace(selectedThemeName))
             throw new ArgumentException("Selected theme name, if provided, cannot be whitespace.", nameof(selectedThemeName));
 
+        if (regionalCultureName is not null && string.IsNullOrWhiteSpace(regionalCultureName))
+            throw new ArgumentException("Regional culture name, if provided, cannot be whitespace.", nameof(regionalCultureName));
+
         SelectedThemeName = selectedThemeName;
+        RegionalCultureName = regionalCultureName;
         CustomThemes = BuildCustomThemes(customThemes, nameof(customThemes));
     }
+
+    public AppPreferences WithRegionalCultureName(string? regionalCultureName)
+        => new(SelectedThemeName, CustomThemes, regionalCultureName);
 
     public string ResolveSelectedThemeName(IReadOnlyCollection<string> bundledThemeNames, string defaultThemeName)
     {

--- a/src/Borea.Storage/Preferences/AppPreferencesDocumentDto.cs
+++ b/src/Borea.Storage/Preferences/AppPreferencesDocumentDto.cs
@@ -6,6 +6,8 @@ internal sealed class AppPreferencesDocumentDto
 
     public string? SelectedTheme { get; set; }
 
+    public string? RegionalCulture { get; set; }
+
     public List<CustomThemePreferenceDto?>? CustomThemes { get; set; }
 }
 

--- a/src/Borea.Storage/Preferences/AppPreferencesMapper.cs
+++ b/src/Borea.Storage/Preferences/AppPreferencesMapper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Borea.Core.Preferences;
 
 namespace Borea.Storage.Preferences;
@@ -8,11 +9,28 @@ internal static class AppPreferencesMapper
     {
         FormatVersion = FileAppPreferencesRepository.CurrentFormatVersion,
         SelectedTheme = preferences.SelectedThemeName,
+        RegionalCulture = preferences.RegionalCultureName,
         CustomThemes = preferences.CustomThemes.Select(theme => (CustomThemePreferenceDto?)ToDto(theme)).ToList(),
     };
 
     public static AppPreferences FromDto(AppPreferencesDocumentDto dto)
-        => new(dto.SelectedTheme, dto.CustomThemes?.Select(FromDto));
+        => new(dto.SelectedTheme, dto.CustomThemes?.Select(FromDto), NormalizeRegionalCulture(dto.RegionalCulture));
+
+    private static string? NormalizeRegionalCulture(string? cultureName)
+    {
+        if (string.IsNullOrWhiteSpace(cultureName))
+            return null;
+
+        try
+        {
+            var culture = CultureInfo.GetCultureInfo(cultureName);
+            return culture.IsNeutralCulture ? null : culture.Name;
+        }
+        catch (CultureNotFoundException)
+        {
+            return null;
+        }
+    }
 
     private static CustomThemePreferenceDto ToDto(CustomThemePreference theme) => new()
     {

--- a/tests/Borea.App.Tests/Formatting/RegionalFormatPersistenceTests.cs
+++ b/tests/Borea.App.Tests/Formatting/RegionalFormatPersistenceTests.cs
@@ -1,0 +1,93 @@
+using System.Globalization;
+using Borea.App.Formatting;
+using Borea.App.Localization;
+using Borea.App.ViewModels;
+using Borea.Core.Preferences;
+
+namespace Borea.App.Tests.Formatting;
+
+public sealed class RegionalFormatPersistenceTests : IDisposable
+{
+    private readonly CultureInfo _originalCulture = CultureInfo.CurrentCulture;
+    private readonly CultureInfo _originalUiCulture = CultureInfo.CurrentUICulture;
+
+    [Fact]
+    public void SelectedRegionalFormat_PreservesOtherPreferencesWhenItSaves()
+    {
+        var localization = new LocalizationService(CultureInfo.GetCultureInfo("en"));
+        var formatService = new RegionalFormatService(
+            localization,
+            CultureInfo.GetCultureInfo("fr-FR"),
+            "en-US");
+        var customTheme = new CustomThemePreference("Mission", "#102030", "#405060", "#708090", "#abcdef");
+        var preferences = new AppPreferences("Mission", [customTheme], "en-US");
+        var repository = new RecordingAppPreferencesRepository();
+        var viewModel = new MainViewModel(localization, formatService, repository, preferences);
+        viewModel.SelectedRegionalFormat = Assert.Single(
+            formatService.SupportedFormats,
+            format => format.CultureName == "de-DE");
+
+        Assert.NotNull(repository.SavedPreferences);
+        Assert.Equal("de-DE", repository.SavedPreferences.RegionalCultureName);
+        Assert.Equal("Mission", repository.SavedPreferences.SelectedThemeName);
+        Assert.Single(repository.SavedPreferences.CustomThemes);
+        Assert.Equal("en", CultureInfo.CurrentUICulture.Name);
+        Assert.Null(viewModel.PreferenceSaveError);
+    }
+
+    [Fact]
+    public void SelectedRegionalFormat_WriteFailure_ReportsTheError()
+    {
+        var localization = new LocalizationService(CultureInfo.GetCultureInfo("en"));
+        var formatService = new RegionalFormatService(
+            localization,
+            CultureInfo.GetCultureInfo("fr-FR"),
+            selectedCultureName: null);
+        var repository = new RecordingAppPreferencesRepository
+        {
+            SaveException = new IOException("Disk unavailable."),
+        };
+        var viewModel = new MainViewModel(localization, formatService, repository, AppPreferences.Empty);
+        viewModel.SelectedRegionalFormat = Assert.Single(
+            formatService.SupportedFormats,
+            format => format.CultureName == "de-DE");
+
+        Assert.Equal("The preference could not be saved: Disk unavailable.", viewModel.PreferenceSaveError);
+
+        repository.SaveException = null;
+        viewModel.SelectedRegionalFormat = formatService.SupportedFormats[0];
+
+        Assert.Null(viewModel.PreferenceSaveError);
+    }
+
+    public void Dispose()
+    {
+        CultureInfo.CurrentCulture = _originalCulture;
+        CultureInfo.CurrentUICulture = _originalUiCulture;
+        Resources.Culture = _originalUiCulture;
+    }
+
+    private sealed class RecordingAppPreferencesRepository : IAppPreferencesRepository
+    {
+        public AppPreferences? SavedPreferences { get; private set; }
+
+        public Exception? SaveException { get; set; }
+
+        public Task<AppPreferencesLoadResult> GetAsync(
+            IReadOnlyCollection<string> bundledThemeNames,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new AppPreferencesLoadResult(AppPreferencesLoadStatus.NotFound, AppPreferences.Empty));
+
+        public Task SaveAsync(
+            AppPreferences preferences,
+            IReadOnlyCollection<string> bundledThemeNames,
+            CancellationToken cancellationToken = default)
+        {
+            if (SaveException is not null)
+                throw SaveException;
+
+            SavedPreferences = preferences;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Borea.App.Tests/Formatting/RegionalFormatServiceTests.cs
+++ b/tests/Borea.App.Tests/Formatting/RegionalFormatServiceTests.cs
@@ -1,0 +1,130 @@
+using System.Globalization;
+using System.Text.Json;
+using Borea.App.Formatting;
+using Borea.App.Localization;
+using Borea.Core.Game;
+
+namespace Borea.App.Tests.Formatting;
+
+public sealed class RegionalFormatServiceTests : IDisposable
+{
+    private readonly CultureInfo _originalCulture = CultureInfo.CurrentCulture;
+    private readonly CultureInfo _originalUiCulture = CultureInfo.CurrentUICulture;
+
+    [Fact]
+    public void Constructor_NoSavedCulture_UsesTheSystemFormat()
+    {
+        var localization = new LocalizationService(CultureInfo.GetCultureInfo("en"));
+        var service = new RegionalFormatService(
+            localization,
+            CultureInfo.GetCultureInfo("fr-FR"),
+            selectedCultureName: null);
+
+        Assert.Null(service.SelectedCultureName);
+        Assert.Equal("fr-FR", CultureInfo.CurrentCulture.Name);
+        Assert.StartsWith("System default", service.SelectedFormat.DisplayName, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Constructor_SavedSpecificCulture_RestoresTheFormat()
+    {
+        var localization = new LocalizationService(CultureInfo.GetCultureInfo("en"));
+        var service = new RegionalFormatService(
+            localization,
+            CultureInfo.GetCultureInfo("fr-FR"),
+            "de-DE");
+
+        Assert.Equal("de-DE", service.SelectedCultureName);
+        Assert.Equal("de-DE", CultureInfo.CurrentCulture.Name);
+    }
+
+    [Theory]
+    [InlineData("not-a-culture")]
+    [InlineData("de")]
+    [InlineData("")]
+    public void Constructor_InvalidOrNeutralCulture_FallsBackToTheSystemFormat(string cultureName)
+    {
+        var localization = new LocalizationService(CultureInfo.GetCultureInfo("en"));
+        var service = new RegionalFormatService(
+            localization,
+            CultureInfo.GetCultureInfo("fr-FR"),
+            cultureName);
+
+        Assert.Null(service.SelectedCultureName);
+        Assert.Equal("fr-FR", CultureInfo.CurrentCulture.Name);
+    }
+
+    [Fact]
+    public void SelectedFormat_ChangesRegionalCultureWithoutChangingUiCulture()
+    {
+        var localization = new LocalizationService(CultureInfo.GetCultureInfo("en"));
+        var service = new RegionalFormatService(
+            localization,
+            CultureInfo.GetCultureInfo("fr-FR"),
+            selectedCultureName: null);
+
+        service.SelectedFormat = Assert.Single(
+            service.SupportedFormats,
+            format => format.CultureName == "de-DE");
+
+        Assert.Equal("de-DE", CultureInfo.CurrentCulture.Name);
+        Assert.Equal("en", CultureInfo.CurrentUICulture.Name);
+    }
+
+    [Fact]
+    public void SelectedFormat_ChangesDisplayValuesWithoutChangingMachineValues()
+    {
+        var localization = new LocalizationService(CultureInfo.GetCultureInfo("en"));
+        var service = new RegionalFormatService(
+            localization,
+            CultureInfo.GetCultureInfo("en-US"),
+            selectedCultureName: null);
+
+        service.SelectedFormat = Assert.Single(
+            service.SupportedFormats,
+            format => format.CultureName == "de-DE");
+
+        Assert.Equal("1.234,5", 1234.5m.ToString("N1"));
+        Assert.Equal("31.12.2026", new DateOnly(2026, 12, 31).ToString("d"));
+        Assert.Equal("2026.9.7.5402", new GameVersion(2026, 9, 7, 5402).ToString());
+        Assert.Equal("{\"Value\":1234.5}", JsonSerializer.Serialize(new { Value = 1234.5m }));
+    }
+
+    [Fact]
+    public void SelectedFormat_SystemDefault_RestoresTheCapturedSystemCulture()
+    {
+        var localization = new LocalizationService(CultureInfo.GetCultureInfo("en"));
+        var service = new RegionalFormatService(
+            localization,
+            CultureInfo.GetCultureInfo("fr-FR"),
+            "de-DE");
+
+        service.SelectedFormat = service.SupportedFormats[0];
+
+        Assert.Null(service.SelectedCultureName);
+        Assert.Equal("fr-FR", CultureInfo.CurrentCulture.Name);
+    }
+
+    [Fact]
+    public void LanguageChange_UpdatesTheSystemOptionWithoutChangingTheFormat()
+    {
+        var localization = new LocalizationService(CultureInfo.GetCultureInfo("en"));
+        var service = new RegionalFormatService(
+            localization,
+            CultureInfo.GetCultureInfo("fr-FR"),
+            selectedCultureName: null);
+
+        localization.TrySetCulture("de");
+
+        Assert.StartsWith("Systemstandard", service.SelectedFormat.DisplayName, StringComparison.Ordinal);
+        Assert.Null(service.SelectedCultureName);
+        Assert.Equal("fr-FR", CultureInfo.CurrentCulture.Name);
+    }
+
+    public void Dispose()
+    {
+        CultureInfo.CurrentCulture = _originalCulture;
+        CultureInfo.CurrentUICulture = _originalUiCulture;
+        Resources.Culture = _originalUiCulture;
+    }
+}

--- a/tests/Borea.Storage.Tests/Preferences/FileAppPreferencesRepositoryTests.cs
+++ b/tests/Borea.Storage.Tests/Preferences/FileAppPreferencesRepositoryTests.cs
@@ -60,6 +60,20 @@ public sealed class FileAppPreferencesRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task SaveThenGet_SavedRegionalCulture_RestoresTheSelection()
+    {
+        await _repository.SaveAsync(
+            new AppPreferences("Dark", regionalCultureName: "de-DE"),
+            BundledThemeNames);
+
+        var result = await _repository.GetAsync(BundledThemeNames);
+
+        Assert.Equal(AppPreferencesLoadStatus.Loaded, result.Status);
+        Assert.Equal("de-DE", result.Preferences.RegionalCultureName);
+        Assert.Equal("Dark", result.Preferences.SelectedThemeName);
+    }
+
+    [Fact]
     public async Task GetAsync_InvalidJson_ReturnsInvalidAndTheDefaultThemeSafely()
     {
         await WriteAsync("{ not-json }");
@@ -86,7 +100,33 @@ public sealed class FileAppPreferencesRepositoryTests : IDisposable
 
         Assert.Equal(AppPreferencesLoadStatus.Loaded, result.Status);
         Assert.Equal("Removed Theme", result.Preferences.SelectedThemeName);
+        Assert.Null(result.Preferences.RegionalCultureName);
         Assert.Equal("Borealis", result.Preferences.ResolveSelectedThemeName(BundledThemeNames, "Borealis"));
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("de")]
+    [InlineData("not-a-culture")]
+    public async Task GetAsync_InvalidRegionalCulture_KeepsOtherPreferences(string regionalCulture)
+    {
+        await WriteAsync($$"""
+            {
+              "formatVersion": 1,
+              "selectedTheme": "Mission",
+              "regionalCulture": "{{regionalCulture}}",
+              "customThemes": [
+                { "name": "Mission", "mainColor": "#102030", "secondaryColor": "#405060", "globalPanelsColor": "#708090", "textColor": "#abcdef" }
+              ]
+            }
+            """);
+
+        var result = await _repository.GetAsync(BundledThemeNames);
+
+        Assert.Equal(AppPreferencesLoadStatus.Loaded, result.Status);
+        Assert.Null(result.Preferences.RegionalCultureName);
+        Assert.Equal("Mission", result.Preferences.SelectedThemeName);
+        Assert.Equal("Mission", Assert.Single(result.Preferences.CustomThemes).Name);
     }
 
     [Fact]
@@ -117,12 +157,15 @@ public sealed class FileAppPreferencesRepositoryTests : IDisposable
     public async Task SaveAsync_WritesTheVersionedExplicitFormat()
     {
         var customTheme = new CustomThemePreference("Mission", "#102030", "#405060", "#708090", "#abcdef");
-        await _repository.SaveAsync(new AppPreferences("Mission", [customTheme]), BundledThemeNames);
+        await _repository.SaveAsync(
+            new AppPreferences("Mission", [customTheme], regionalCultureName: "en-GB"),
+            BundledThemeNames);
 
         using var document = JsonDocument.Parse(await File.ReadAllTextAsync(_pathProvider.GetAppPreferencesPath()));
         var root = document.RootElement;
         Assert.Equal(1, root.GetProperty("formatVersion").GetInt32());
         Assert.Equal("Mission", root.GetProperty("selectedTheme").GetString());
+        Assert.Equal("en-GB", root.GetProperty("regionalCulture").GetString());
         var savedTheme = Assert.Single(root.GetProperty("customThemes").EnumerateArray());
         Assert.Equal("Mission", savedTheme.GetProperty("name").GetString());
         Assert.Equal("#102030", savedTheme.GetProperty("mainColor").GetString());

--- a/tests/Borea.Storage.Tests/Toml/TomlFileStoreTests.cs
+++ b/tests/Borea.Storage.Tests/Toml/TomlFileStoreTests.cs
@@ -1,4 +1,6 @@
-﻿using Borea.Storage.Toml;
+using Borea.Storage.Toml;
+
+using System.Globalization;
 
 namespace Borea.Storage.Tests.Toml;
 
@@ -15,6 +17,12 @@ public sealed class TomlFileStoreTests : IDisposable
     {
         public string Name { get; set; } = string.Empty;
         public int Count { get; set; }
+    }
+
+    private sealed class MachineValuesDto
+    {
+        public double Ratio { get; set; }
+        public DateTimeOffset Timestamp { get; set; }
     }
 
     [Fact]
@@ -62,6 +70,31 @@ public sealed class TomlFileStoreTests : IDisposable
         Assert.NotNull(reloaded);
         Assert.Equal("hello", reloaded!.Name);
         Assert.Equal(42, reloaded.Count);
+    }
+
+    [Fact]
+    public async Task WriteAsync_DifferentCurrentCulture_KeepsMachineValuesInvariant()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+            var path = Path.Combine(_tempRoot, "machine-values.toml");
+            var timestamp = new DateTimeOffset(2026, 9, 11, 14, 30, 0, TimeSpan.FromHours(2));
+
+            await TomlFileStore.WriteAsync(path, new MachineValuesDto { Ratio = 1.5, Timestamp = timestamp });
+            var text = await File.ReadAllTextAsync(path);
+            var reloaded = await TomlFileStore.ReadAsync<MachineValuesDto>(path);
+
+            Assert.Contains("Ratio = 1.5", text, StringComparison.Ordinal);
+            Assert.Contains("Timestamp = \"2026-09-11T14:30:00.0000000+02:00\"", text, StringComparison.Ordinal);
+            Assert.Equal(1.5, reloaded!.Ratio);
+            Assert.Equal(timestamp, reloaded.Timestamp);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
     }
 
     [Fact]


### PR DESCRIPTION
### What changed

This adds a `Regional format` setting to Borea.App.

The setting is separate from the display-language setting. A user can now use German interface text with United States formatting, or English interface text with German formatting.

The list contains `System default` and every specific culture that the installed .NET runtime provides, such as `de-DE`, `en-GB`, and `en-US`. Borea stores the exact culture name in `app-preferences.json`.

### How the separation works

.NET uses [`CurrentUICulture`](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo.currentuiculture?view=net-10.0) to select translated resources. It uses [`CurrentCulture`](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo.currentculture?view=net-10.0) to format user-facing dates, numbers, and other regional values.

Borea now uses the same separation. Changing the display language changes only `CurrentUICulture`. Changing the regional format changes only `CurrentCulture`.

The available choices come from the .NET [`SpecificCultures`](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.culturetypes?view=net-10.0) list. Neutral cultures such as `de` are not regional formats because they do not select one exact set of date and number rules.

### Safe fallback behavior

`System default` restores the regional format that was active when Borea started.

If the saved value is absent, invalid, neutral, or not available on the current system, Borea uses the system format and continues to open. An invalid regional value does not discard a valid selected theme or valid custom themes.

If Borea cannot save a changed selection, the Settings page shows a localized error. The error disappears after a successful save or after the user returns to the value that is already stored.

### Machine-readable data

The regional setting is only for user-facing formatting. It does not change the formats of version identifiers, JSON, TOML, file paths, or network data.

Regression tests verify that German display formatting uses a decimal comma and a German date, while game versions and JSON still use their fixed formats. A Storage test also verifies that TOML numbers and timestamps stay unchanged under a German current culture.

This does not add measurement-unit settings, change CLI output, or add more interface translations.

Closes #100.
