### PR TITLE
Add contributor guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+Thank you for helping improve Borea.
+
+## Where to start
+
+- Report a reproducible bug through the [issue tracker](https://github.com/KSAModding/Borea/issues).
+- Discuss a larger feature or a change to the content-manager specification in [content-manager-design Discussions](https://github.com/KSAModding/content-manager-design/discussions).
+- Report a security problem through the private path in [SECURITY.md](SECURITY.md).
+
+## Pull requests
+
+Keep each pull request focused on one problem.
+Explain the user-visible change, the tests you ran, and any work that remains outside its scope.
+
+Run the relevant tests and formatting checks before you open a pull request.
+The continuous-integration checks run on Windows, Linux, and macOS.
+
+Changes to the content-manager format or snapshot contract must follow the accepted RFCs in [content-manager-design](https://github.com/KSAModding/content-manager-design).
+When an RFC does not answer the question, start a design discussion before implementing a private format extension.
+
+## Licensing your contribution
+
+By opening a pull request, you contribute your code and documentation under the repository's [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Borea
 Borea is a cross-platform complete general content manager for Kitten Space Agency. It manages mods, mod packs, vehicles, game saves, and more. It is intended to be modifiable by changing out `Borea.Storage`, `Borea.Network`, and `Borea.App` so user can customize Borea. This repository will contain all the offical Borea files and releases.
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) to contribute and [SECURITY.md](SECURITY.md) to report a security problem.
+
 # Downloads
 Each release has one build per platform.
 
@@ -77,7 +79,6 @@ gh attestation verify <archive> --repo KSAModding/Borea \
   --signer-workflow KSAModding/Borea/.github/workflows/release.yml \
   --predicate-type https://cyclonedx.org/bom
 ```
-
 # Credits
 - [MrJeranimo](https://github.com/MrJeranimo) - Original Creator and Developer
 


### PR DESCRIPTION
## Summary

- Add contributor guidance for bugs, design questions, pull requests, security reports, and licensing.
- Link the guide from the README.

## Why

A new contributor now has one repository-local entry point and is directed to content-manager-design for format and snapshot decisions.