### PR TITLE
Cancel stalled download bodies

### DIFF
--- a/src/Borea.Network/Downloads/HttpModDownloader.cs
+++ b/src/Borea.Network/Downloads/HttpModDownloader.cs
@@ -12,12 +12,18 @@ namespace Borea.Network.Downloads;
 public sealed class HttpModDownloader : IModDownloader
 {
     private const int BufferSize = 81920;
+    private static readonly TimeSpan DefaultBodyInactivityTimeout = TimeSpan.FromSeconds(30);
 
     private readonly HttpClient _httpClient;
+    private readonly TimeSpan _bodyInactivityTimeout;
 
-    public HttpModDownloader(HttpClient httpClient)
+    public HttpModDownloader(HttpClient httpClient, TimeSpan? bodyInactivityTimeout = null)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _bodyInactivityTimeout = bodyInactivityTimeout ?? DefaultBodyInactivityTimeout;
+
+        if (_bodyInactivityTimeout <= TimeSpan.Zero || _bodyInactivityTimeout.TotalMilliseconds > uint.MaxValue - 1)
+            throw new ArgumentOutOfRangeException(nameof(bodyInactivityTimeout), "Body inactivity timeout must be a positive finite timer interval.");
     }
 
     public async Task<DownloadResult> DownloadAsync(
@@ -85,12 +91,11 @@ public sealed class HttpModDownloader : IModDownloader
 
     /// <summary>
     /// A failure of one source, which says nothing about the next: the host is
-    /// down, answers with an error status, cuts the body short, or stalls until
-    /// HttpClient.Timeout ends the request. A cancellation the caller asked for
-    /// is not one.
+    /// down, answers with an error status, cuts the body short, or stops sending
+    /// body data. A cancellation the caller asked for is not one.
     /// </summary>
     private static bool IsSourceFailure(Exception ex, CancellationToken cancellationToken) =>
-        ex is HttpRequestException or HttpIOException ||
+        ex is HttpRequestException or HttpIOException or TimeoutException ||
         (ex is OperationCanceledException && !cancellationToken.IsCancellationRequested);
 
     private async Task<Fetched> FetchAsync(
@@ -120,7 +125,7 @@ public sealed class HttpModDownloader : IModDownloader
         {
             var buffer = new byte[BufferSize];
             int read;
-            while ((read = await content.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) > 0)
+            while ((read = await ReadBodyAsync(content, buffer, cancellationToken).ConfigureAwait(false)) > 0)
             {
                 bytesDownloaded += read;
                 if (sizeDecides is { } cap && bytesDownloaded > cap)
@@ -136,6 +141,21 @@ public sealed class HttpModDownloader : IModDownloader
         return Mismatch(download, bytesDownloaded, sha256) is { } mismatch
             ? Fetched.Rejected(mismatch)
             : Fetched.Served(bytesDownloaded, sha256);
+    }
+
+    private async ValueTask<int> ReadBodyAsync(Stream content, Memory<byte> buffer, CancellationToken cancellationToken)
+    {
+        using var inactivityCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        inactivityCancellation.CancelAfter(_bodyInactivityTimeout);
+
+        try
+        {
+            return await content.ReadAsync(buffer, inactivityCancellation.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested && inactivityCancellation.IsCancellationRequested)
+        {
+            throw new TimeoutException($"The response body transferred no data for {_bodyInactivityTimeout}.", ex);
+        }
     }
 
     /// <summary>

--- a/tests/Borea.Network.Tests/Downloads/HttpModDownloaderTests.cs
+++ b/tests/Borea.Network.Tests/Downloads/HttpModDownloaderTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Security.Cryptography;
 using Borea.Core.Dependencies;
@@ -134,6 +135,82 @@ public sealed class HttpModDownloaderTests : IDisposable
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 
+    private sealed class StalledStream : Stream
+    {
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("The delay cannot end on its own.");
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    private sealed class ProgressingStream(byte[] body, TimeSpan delay) : Stream
+    {
+        private int _position;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (_position == body.Length)
+                return 0;
+
+            await Task.Delay(delay, cancellationToken);
+            buffer.Span[0] = body[_position++];
+            return 1;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
     #region Sources
 
     [Theory]
@@ -211,6 +288,41 @@ public sealed class HttpModDownloaderTests : IDisposable
         Assert.Contains(MirrorUrl, ex.Message);
         Assert.IsAssignableFrom<OperationCanceledException>(ex.InnerException);
         Assert.False(File.Exists(_archivePath));
+    }
+
+    [Fact]
+    public async Task DownloadAsync_BodyStopsTransferring_ReportsAFailureWithinTheInactivityLimit()
+    {
+        var downloader = new HttpModDownloader(
+            Client(_ => Body(new LengthlessContent(new StalledStream())), new()),
+            TimeSpan.FromMilliseconds(200));
+        var stopwatch = Stopwatch.StartNew();
+
+        var download = downloader.DownloadAsync(StampedRelease(), _archivePath);
+        var completed = await Task.WhenAny(download, Task.Delay(TimeSpan.FromSeconds(5)));
+
+        Assert.Same(download, completed);
+        var ex = await Assert.ThrowsAsync<DownloadFailedException>(() => download);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2));
+        Assert.Contains("transferred no data", ex.Message);
+        Assert.IsType<TimeoutException>(ex.InnerException);
+        Assert.False(File.Exists(_archivePath));
+    }
+
+    [Fact]
+    public async Task DownloadAsync_BodyKeepsTransferring_DoesNotApplyTheLimitToTheWholeDownload()
+    {
+        var inactivityTimeout = TimeSpan.FromMilliseconds(500);
+        var downloader = new HttpModDownloader(
+            Client(_ => Body(new LengthlessContent(new ProgressingStream(Archive, TimeSpan.FromMilliseconds(50)))), new()),
+            inactivityTimeout);
+        var stopwatch = Stopwatch.StartNew();
+
+        var result = await downloader.DownloadAsync(StampedRelease(), _archivePath);
+
+        Assert.True(stopwatch.Elapsed > inactivityTimeout);
+        Assert.Equal(Archive.Length, result.BytesDownloaded);
+        Assert.Equal(Archive, await File.ReadAllBytesAsync(_archivePath));
     }
 
     [Fact]
@@ -440,6 +552,17 @@ public sealed class HttpModDownloaderTests : IDisposable
     public void Constructor_NullClient_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() => new HttpModDownloader(null!));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_NonPositiveBodyInactivityTimeout_ThrowsArgumentOutOfRangeException(int milliseconds)
+    {
+        using var client = new HttpClient();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new HttpModDownloader(client, TimeSpan.FromMilliseconds(milliseconds)));
     }
 
     #endregion


### PR DESCRIPTION
Give each response-body read a 30-second inactivity limit and report a stalled source through the existing download failure path.

Reset the limit after each successful read so large transfers can continue while they make progress.

Add tests for a body that stops and for a slow body that continues to transfer data.

Closes #105