### PR TITLE
Allow newer SDK patches for local builds

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.400",
-    "rollForward": "disable",
+    "version": "10.0.401",
+    "rollForward": "patch",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
Closes #82

Update the required .NET SDK from 10.0.400 to 10.0.401, the current .NET 10 security update.

Use the `patch` roll-forward policy. A local build can use a later 10.0.4xx patch when 10.0.401 is not installed.

GitHub Actions installs 10.0.401 from `global.json`, so CI and release builds remain reproducible.