### PR TITLE
Update loader configuration when the game path changes

### DIFF
--- a/src/Borea.Cli/CliServices.cs
+++ b/src/Borea.Cli/CliServices.cs
@@ -22,6 +22,8 @@ internal sealed class CliServices : IDisposable
 
     public required IBoreaSettingsRepository SettingsRepository { get; init; }
 
+    public required IGameDirectoryChanger GameDirectoryChanger { get; init; }
+
     public required IInstanceRepository Instances { get; init; }
 
     public required IModStateRepository ModState { get; init; }
@@ -61,6 +63,7 @@ internal sealed class CliServices : IDisposable
         {
             Settings = services.Settings,
             SettingsRepository = services.SettingsRepository,
+            GameDirectoryChanger = services.GameDirectoryChanger,
             Instances = services.Instances,
             ModState = services.ModState,
             LatestVersion = latestVersion ?? services.LatestVersion,

--- a/src/Borea.Cli/Commands/SettingsCommand.cs
+++ b/src/Borea.Cli/Commands/SettingsCommand.cs
@@ -55,7 +55,7 @@ internal static class SettingsCommand
         game.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, error, ct) =>
         {
             var fullPath = Path.GetFullPath(parseResult.GetRequiredValue(directory));
-            await cli.SettingsRepository.SaveAsync(cli.Settings.WithGameDirectory(fullPath), ct).ConfigureAwait(false);
+            await cli.GameDirectoryChanger.ChangeAsync(fullPath, ct).ConfigureAwait(false);
 
             output.WriteLine($"Game directory: {fullPath}");
             WarnWhenMissing(error, fullPath);

--- a/src/Borea.Composition/BoreaServices.cs
+++ b/src/Borea.Composition/BoreaServices.cs
@@ -64,6 +64,8 @@ public sealed class BoreaServices : IDisposable
 
     public required IBoreaSettingsRepository SettingsRepository { get; init; }
 
+    public required IGameDirectoryChanger GameDirectoryChanger { get; init; }
+
     public required IInstanceRepository Instances { get; init; }
 
     public required IModStateRepository ModState { get; init; }
@@ -175,6 +177,7 @@ public sealed class BoreaServices : IDisposable
             Settings = settings,
             Paths = paths,
             SettingsRepository = settingsRepository,
+            GameDirectoryChanger = new GameDirectoryChanger(settingsRepository, mods, loaderConfiguration),
             Instances = new FileInstanceRepository(paths),
             ModState = new FileModStateRepository(paths),
             ModFavorites = new FileModFavoritesRepository(paths),

--- a/src/Borea.Core/Settings/IGameDirectoryChanger.cs
+++ b/src/Borea.Core/Settings/IGameDirectoryChanger.cs
@@ -1,0 +1,6 @@
+namespace Borea.Core.Settings;
+
+public interface IGameDirectoryChanger
+{
+    Task ChangeAsync(string gameDirectory, CancellationToken cancellationToken = default);
+}

--- a/src/Borea.Storage/Files/AtomicFile.cs
+++ b/src/Borea.Storage/Files/AtomicFile.cs
@@ -32,6 +32,24 @@ internal static class AtomicFile
         }
     }
 
+    public static async Task WriteAllBytesAsync(string path, byte[] content, CancellationToken cancellationToken = default)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+
+        var tempPath = $"{path}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            await File.WriteAllBytesAsync(tempPath, content, cancellationToken).ConfigureAwait(false);
+            File.Move(tempPath, path, overwrite: true);
+        }
+        finally
+        {
+            TryDeleteLeftover(tempPath);
+        }
+    }
+
     /// <summary>
     /// Clears the temporary file without replacing the error that caused it.
     /// </summary>

--- a/src/Borea.Storage/Settings/GameDirectoryChanger.cs
+++ b/src/Borea.Storage/Settings/GameDirectoryChanger.cs
@@ -1,0 +1,174 @@
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+using Borea.Core.Settings;
+using Borea.Storage.Files;
+
+namespace Borea.Storage.Settings;
+
+public sealed class GameDirectoryChanger : IGameDirectoryChanger
+{
+    private readonly IBoreaSettingsRepository _settings;
+    private readonly IModRepository _mods;
+    private readonly ILoaderConfigurator _configurator;
+
+    public GameDirectoryChanger(
+        IBoreaSettingsRepository settings,
+        IModRepository mods,
+        ILoaderConfigurator configurator)
+    {
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _mods = mods ?? throw new ArgumentNullException(nameof(mods));
+        _configurator = configurator ?? throw new ArgumentNullException(nameof(configurator));
+    }
+
+    public async Task ChangeAsync(string gameDirectory, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(gameDirectory))
+            throw new ArgumentException("A game directory is required.", nameof(gameDirectory));
+
+        if (!Path.IsPathFullyQualified(gameDirectory))
+            throw new ArgumentException("The game directory must be absolute.", nameof(gameDirectory));
+
+        var fullGameDirectory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(gameDirectory));
+        var previousSettings = await _settings.GetAsync(cancellationToken).ConfigureAwait(false)
+            ?? new BoreaSettings(gameDirectoryPath: null);
+        var changedSettings = previousSettings.WithGameDirectory(fullGameDirectory);
+
+        if (previousSettings.LoaderInstallations.Count == 0)
+        {
+            await _settings.SaveAsync(changedSettings, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var listings = await _mods.GetAvailableModsAsync(cancellationToken).ConfigureAwait(false);
+        var changes = FindChanges(previousSettings, listings);
+        var snapshots = await SnapshotAsync(changes, cancellationToken).ConfigureAwait(false);
+        var settingsSaveStarted = false;
+
+        try
+        {
+            foreach (var change in changes)
+            {
+                await _configurator.ConfigureAsync(
+                    change.Loader,
+                    change.LoaderDirectory,
+                    fullGameDirectory,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            settingsSaveStarted = true;
+            await _settings.SaveAsync(changedSettings, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception failure)
+        {
+            var rollbackFailures = await RestoreAsync(snapshots).ConfigureAwait(false);
+            if (settingsSaveStarted)
+            {
+                var settingsFailure = await TryRestoreSettingsAsync(previousSettings).ConfigureAwait(false);
+                if (settingsFailure is not null)
+                    rollbackFailures.Add(settingsFailure);
+            }
+
+            if (rollbackFailures.Count > 0)
+            {
+                throw new AggregateException(
+                    "The game directory change failed, and rollback could not restore a consistent state.",
+                    new[] { failure }.Concat(rollbackFailures));
+            }
+
+            throw;
+        }
+    }
+
+    private static IReadOnlyList<ConfigurationChange> FindChanges(
+        BoreaSettings settings,
+        IReadOnlyList<ModMetadata> listings)
+    {
+        var changes = new List<ConfigurationChange>();
+        foreach (var (loaderId, installation) in settings.LoaderInstallations)
+        {
+            var loader = listings.FirstOrDefault(candidate =>
+                candidate.Type == ContentType.ModLoader &&
+                ModIds.Equals(candidate.ModId, loaderId));
+            var configure = loader?.Provides?.Configure;
+            if (configure?.GamePath is null)
+                continue;
+
+            if (!Path.IsPathFullyQualified(installation.DirectoryPath))
+                throw new InvalidOperationException($"The saved directory for loader '{loaderId}' is not absolute.");
+
+            var loaderDirectory = Path.GetFullPath(installation.DirectoryPath);
+            var configurationPath = Path.GetFullPath(Path.Combine(
+                loaderDirectory,
+                configure.File.Replace('/', Path.DirectorySeparatorChar)));
+            changes.Add(new ConfigurationChange(loader!, loaderDirectory, configurationPath));
+        }
+
+        return changes;
+    }
+
+    private static async Task<IReadOnlyList<ConfigurationSnapshot>> SnapshotAsync(
+        IReadOnlyList<ConfigurationChange> changes,
+        CancellationToken cancellationToken)
+    {
+        var snapshots = new List<ConfigurationSnapshot>();
+        foreach (var path in changes.Select(change => change.ConfigurationPath).Distinct(PathComparer))
+        {
+            var content = File.Exists(path)
+                ? await File.ReadAllBytesAsync(path, cancellationToken).ConfigureAwait(false)
+                : null;
+            snapshots.Add(new ConfigurationSnapshot(path, content));
+        }
+
+        return snapshots;
+    }
+
+    private async Task<Exception?> TryRestoreSettingsAsync(BoreaSettings settings)
+    {
+        try
+        {
+            await _settings.SaveAsync(settings, CancellationToken.None).ConfigureAwait(false);
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return new InvalidOperationException("Borea could not restore its previous settings.", exception);
+        }
+    }
+
+    private static async Task<List<Exception>> RestoreAsync(IReadOnlyList<ConfigurationSnapshot> snapshots)
+    {
+        var failures = new List<Exception>();
+        foreach (var snapshot in snapshots.Reverse())
+        {
+            try
+            {
+                if (snapshot.Content is null)
+                {
+                    if (File.Exists(snapshot.Path))
+                        File.Delete(snapshot.Path);
+                }
+                else
+                {
+                    await AtomicFile.WriteAllBytesAsync(snapshot.Path, snapshot.Content).ConfigureAwait(false);
+                }
+            }
+            catch (Exception exception)
+            {
+                failures.Add(new InvalidOperationException(
+                    $"Borea could not restore loader configuration '{snapshot.Path}'.",
+                    exception));
+            }
+        }
+
+        return failures;
+    }
+
+    private static StringComparer PathComparer => OperatingSystem.IsWindows()
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
+
+    private sealed record ConfigurationChange(ModMetadata Loader, string LoaderDirectory, string ConfigurationPath);
+
+    private sealed record ConfigurationSnapshot(string Path, byte[]? Content);
+}

--- a/tests/Borea.Cli.Tests/CliServicesTests.cs
+++ b/tests/Borea.Cli.Tests/CliServicesTests.cs
@@ -15,6 +15,7 @@ public sealed class CliServicesTests : IDisposable
 
         Assert.Same(graph.Settings, services.Settings);
         Assert.Same(graph.SettingsRepository, services.SettingsRepository);
+        Assert.Same(graph.GameDirectoryChanger, services.GameDirectoryChanger);
         Assert.Same(graph.Instances, services.Instances);
         Assert.Same(graph.ModState, services.ModState);
         Assert.Same(graph.LatestVersion, services.LatestVersion);
@@ -52,6 +53,7 @@ public sealed class CliServicesTests : IDisposable
         {
             Settings = graph.Settings,
             SettingsRepository = graph.SettingsRepository,
+            GameDirectoryChanger = graph.GameDirectoryChanger,
             Instances = graph.Instances,
             ModState = graph.ModState,
             LatestVersion = new FakeLatestVersionPing(),

--- a/tests/Borea.Composition.Tests/BoreaServicesTests.cs
+++ b/tests/Borea.Composition.Tests/BoreaServicesTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text;
+using System.Text.Json;
 using Borea.Core.Dependencies;
 using Borea.Core.Index;
 using Borea.Core.ModLoaders;
@@ -124,6 +125,7 @@ public sealed class BoreaServicesTests : IDisposable
         Assert.IsType<FileLoaderInstaller>(services.LoaderInstaller);
         Assert.IsType<FileLoaderAdopter>(services.LoaderAdopter);
         Assert.IsType<FileLoaderUninstaller>(services.LoaderUninstaller);
+        Assert.IsType<GameDirectoryChanger>(services.GameDirectoryChanger);
     }
 
     [Fact]
@@ -196,6 +198,59 @@ public sealed class BoreaServicesTests : IDisposable
         Assert.Equal(
             ["https://ksamodding.github.io/content-index-releases/v1/index.json"],
             handler.RequestUris.Select(uri => uri.AbsoluteUri));
+    }
+
+    [Fact]
+    public async Task GameDirectoryChanger_ControlledSnapshot_UpdatesStarMapAndSettings()
+    {
+        var oldGame = Path.Combine(_tempRoot, "OldGame");
+        var newGame = Path.Combine(_tempRoot, "NewGame");
+        var loaderDirectory = Path.Combine(_tempRoot, "StarMap");
+        var configurationPath = Path.Combine(loaderDirectory, "StarMapConfig.json");
+        Directory.CreateDirectory(loaderDirectory);
+        await File.WriteAllTextAsync(configurationPath, """
+            {
+              "GameLocation": "old",
+              "Keep": true
+            }
+            """);
+        await SaveAsync(new BoreaSettings(oldGame, LoaderAt(loaderDirectory)));
+        var snapshot = await File.ReadAllTextAsync(SnapshotFixturePath);
+
+        using var services = await BoreaServices.BuildAsync(
+            _tempRoot,
+            new ControlledHttpMessageHandler(snapshot),
+            new ConflictingStarMapRepository());
+        await services.GameDirectoryChanger.ChangeAsync(newGame);
+
+        using var configuration = JsonDocument.Parse(await File.ReadAllTextAsync(configurationPath));
+        Assert.Equal(newGame, configuration.RootElement.GetProperty("GameLocation").GetString());
+        Assert.True(configuration.RootElement.GetProperty("Keep").GetBoolean());
+        Assert.Equal(newGame, (await services.SettingsRepository.GetAsync())!.GameDirectoryPath);
+    }
+
+    [Fact]
+    public async Task GameDirectoryChanger_InvalidLoaderConfiguration_RestoresFileAndSettings()
+    {
+        var oldGame = Path.Combine(_tempRoot, "OldGame");
+        var newGame = Path.Combine(_tempRoot, "NewGame");
+        var loaderDirectory = Path.Combine(_tempRoot, "StarMap");
+        var configurationPath = Path.Combine(loaderDirectory, "StarMapConfig.json");
+        const string originalConfiguration = "[]";
+        Directory.CreateDirectory(loaderDirectory);
+        await File.WriteAllTextAsync(configurationPath, originalConfiguration);
+        await SaveAsync(new BoreaSettings(oldGame, LoaderAt(loaderDirectory)));
+        var snapshot = await File.ReadAllTextAsync(SnapshotFixturePath);
+
+        using var services = await BoreaServices.BuildAsync(
+            _tempRoot,
+            new ControlledHttpMessageHandler(snapshot),
+            new ConflictingStarMapRepository());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => services.GameDirectoryChanger.ChangeAsync(newGame));
+        Assert.Equal(originalConfiguration, await File.ReadAllTextAsync(configurationPath));
+        Assert.Equal(oldGame, (await services.SettingsRepository.GetAsync())!.GameDirectoryPath);
     }
 
     [Fact]

--- a/tests/Borea.Storage.Tests/Settings/GameDirectoryChangerTests.cs
+++ b/tests/Borea.Storage.Tests/Settings/GameDirectoryChangerTests.cs
@@ -1,0 +1,242 @@
+using System.Text.Json.Nodes;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+using Borea.Core.Settings;
+using Borea.Storage.ModLoaders;
+using Borea.Storage.Paths;
+using Borea.Storage.Settings;
+
+namespace Borea.Storage.Tests.Settings;
+
+public sealed class GameDirectoryChangerTests : IDisposable
+{
+    private static readonly IReadOnlyDictionary<string, string> Links = new Dictionary<string, string>
+    {
+        ["forums"] = "https://forums.ahwoo.com/threads/loader.1/",
+    };
+
+    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+
+    [Fact]
+    public async Task ChangeAsync_OneConfiguredLoader_UpdatesTheFileAndSettings()
+    {
+        var oldGame = Path.Combine(_tempRoot, "OldGame");
+        var newGame = Path.Combine(_tempRoot, "NewGame");
+        var loaderDirectory = Path.Combine(_tempRoot, "Loaders", "StarMap");
+        var configPath = Path.Combine(loaderDirectory, "loader.json");
+        Directory.CreateDirectory(loaderDirectory);
+        await File.WriteAllTextAsync(configPath, """
+            {
+              "Keep": true,
+              "GameLocation": "old"
+            }
+            """);
+
+        var settings = SettingsRepository();
+        await settings.SaveAsync(new BoreaSettings(oldGame, Installations(("StarMap", loaderDirectory))));
+        var changer = new GameDirectoryChanger(settings, new FakeModRepository(Loader("StarMap")), new LoaderConfigurator());
+
+        await changer.ChangeAsync(newGame);
+
+        var json = (JsonObject)JsonNode.Parse(await File.ReadAllTextAsync(configPath))!;
+        Assert.True(json["Keep"]!.GetValue<bool>());
+        Assert.Equal(newGame, json["GameLocation"]!.GetValue<string>());
+        Assert.Equal(newGame, (await settings.GetAsync())!.GameDirectoryPath);
+    }
+
+    [Fact]
+    public async Task ChangeAsync_LoaderWithoutGamePath_LeavesItsFileUnchanged()
+    {
+        var oldGame = Path.Combine(_tempRoot, "OldGame");
+        var newGame = Path.Combine(_tempRoot, "NewGame");
+        var loaderDirectory = Path.Combine(_tempRoot, "Loaders", "Other");
+        var configPath = Path.Combine(loaderDirectory, "loader.json");
+        const string original = "{ \"Keep\": true }";
+        Directory.CreateDirectory(loaderDirectory);
+        await File.WriteAllTextAsync(configPath, original);
+
+        var settings = SettingsRepository();
+        await settings.SaveAsync(new BoreaSettings(oldGame, Installations(("Other", loaderDirectory))));
+        var listing = Loader("Other", new LoaderConfigure("loader.json", ConfigureFormat.Json));
+        var changer = new GameDirectoryChanger(settings, new FakeModRepository(listing), new LoaderConfigurator());
+
+        await changer.ChangeAsync(newGame);
+
+        Assert.Equal(original, await File.ReadAllTextAsync(configPath));
+        Assert.Equal(newGame, (await settings.GetAsync())!.GameDirectoryPath);
+    }
+
+    [Fact]
+    public async Task ChangeAsync_SecondLoaderFails_RestoresEarlierFileAndSettings()
+    {
+        var oldGame = Path.Combine(_tempRoot, "OldGame");
+        var newGame = Path.Combine(_tempRoot, "NewGame");
+        var firstDirectory = Path.Combine(_tempRoot, "Loaders", "First");
+        var secondDirectory = Path.Combine(_tempRoot, "Loaders", "Second");
+        var firstConfig = Path.Combine(firstDirectory, "loader.json");
+        var secondConfig = Path.Combine(secondDirectory, "loader.json");
+        const string firstOriginal = "{ \"GameLocation\": \"old\", \"Keep\": 1 }";
+        const string secondOriginal = "[]";
+        Directory.CreateDirectory(firstDirectory);
+        Directory.CreateDirectory(secondDirectory);
+        await File.WriteAllTextAsync(firstConfig, firstOriginal);
+        await File.WriteAllTextAsync(secondConfig, secondOriginal);
+
+        var settings = SettingsRepository();
+        await settings.SaveAsync(new BoreaSettings(
+            oldGame,
+            Installations(("First", firstDirectory), ("Second", secondDirectory))));
+        var changer = new GameDirectoryChanger(
+            settings,
+            new FakeModRepository(Loader("First"), Loader("Second")),
+            new LoaderConfigurator());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => changer.ChangeAsync(newGame));
+
+        Assert.Equal(firstOriginal, await File.ReadAllTextAsync(firstConfig));
+        Assert.Equal(secondOriginal, await File.ReadAllTextAsync(secondConfig));
+        Assert.Equal(oldGame, (await settings.GetAsync())!.GameDirectoryPath);
+    }
+
+    [Fact]
+    public async Task ChangeAsync_SettingsSaveFails_RestoresTheLoaderAndSettings()
+    {
+        var oldGame = Path.Combine(_tempRoot, "OldGame");
+        var newGame = Path.Combine(_tempRoot, "NewGame");
+        var loaderDirectory = Path.Combine(_tempRoot, "Loaders", "StarMap");
+        var configPath = Path.Combine(loaderDirectory, "loader.json");
+        const string original = "{ \"GameLocation\": \"old\" }";
+        Directory.CreateDirectory(loaderDirectory);
+        await File.WriteAllTextAsync(configPath, original);
+
+        var previous = new BoreaSettings(oldGame, Installations(("StarMap", loaderDirectory)));
+        var settings = new FailingOnceSettingsRepository(previous);
+        var changer = new GameDirectoryChanger(settings, new FakeModRepository(Loader("StarMap")), new LoaderConfigurator());
+
+        await Assert.ThrowsAsync<IOException>(() => changer.ChangeAsync(newGame));
+
+        Assert.Equal(original, await File.ReadAllTextAsync(configPath));
+        Assert.Equal(oldGame, settings.Current.GameDirectoryPath);
+    }
+
+    [Fact]
+    public async Task ChangeAsync_SettingsRollbackFails_ReportsTheInconsistentState()
+    {
+        var oldGame = Path.Combine(_tempRoot, "OldGame");
+        var newGame = Path.Combine(_tempRoot, "NewGame");
+        var loaderDirectory = Path.Combine(_tempRoot, "Loaders", "StarMap");
+        var configPath = Path.Combine(loaderDirectory, "loader.json");
+        const string original = "{ \"GameLocation\": \"old\" }";
+        Directory.CreateDirectory(loaderDirectory);
+        await File.WriteAllTextAsync(configPath, original);
+
+        var previous = new BoreaSettings(oldGame, Installations(("StarMap", loaderDirectory)));
+        var settings = new FailingSettingsRepository(previous);
+        var changer = new GameDirectoryChanger(settings, new FakeModRepository(Loader("StarMap")), new LoaderConfigurator());
+
+        var exception = await Assert.ThrowsAsync<AggregateException>(() => changer.ChangeAsync(newGame));
+
+        Assert.Contains("rollback could not restore a consistent state", exception.Message);
+        Assert.Equal(2, exception.InnerExceptions.Count);
+        Assert.Equal(original, await File.ReadAllTextAsync(configPath));
+        Assert.Equal(newGame, settings.Current.GameDirectoryPath);
+    }
+
+    private FileBoreaSettingsRepository SettingsRepository() =>
+        new(new GamePathProvider(gameDirectory: null, boreaRoot: _tempRoot));
+
+    private static IReadOnlyDictionary<string, LoaderInstallation> Installations(
+        params (string Id, string Directory)[] loaders) =>
+        loaders.ToDictionary(
+            loader => loader.Id,
+            loader => new LoaderInstallation(loader.Directory, version: null, rawVersion: null, isAdopted: false),
+            ModIds.Comparer);
+
+    private static ModMetadata Loader(string id, LoaderConfigure? configure = null) => new(
+        specVersion: 1,
+        modId: id,
+        source: "index",
+        name: id,
+        authors: new[] { "Author" },
+        abstractText: "A loader.",
+        license: "MIT",
+        links: Links,
+        gameMin: "2026.8.3.5117",
+        type: ContentType.ModLoader,
+        install: new InstallDescriptor(target: InstallAnchor.Standalone),
+        provides: new LoaderProvides(
+            "loader.exe",
+            InstallAnchor.Mods,
+            configure: configure ?? new LoaderConfigure("loader.json", ConfigureFormat.Json, "GameLocation")));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+    }
+
+    private sealed class FakeModRepository(params ModMetadata[] listings) : IModRepository
+    {
+        public Task<IReadOnlyList<ModMetadata>> GetAvailableModsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<ModMetadata>>(listings);
+
+        public Task<ModVersionMetadata?> GetLatestReleaseAsync(string modId, CancellationToken cancellationToken = default) =>
+            Task.FromResult<ModVersionMetadata?>(null);
+
+        public Task<ModVersionMetadata?> GetReleaseAsync(
+            string modId,
+            ModVersion version,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<ModVersionMetadata?>(null);
+
+        public Task<IReadOnlyList<ModVersion>> GetAvailableVersionsAsync(
+            string modId,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<ModVersion>>(Array.Empty<ModVersion>());
+
+        public Task<IReadOnlyList<ModMetadata>> SearchAsync(
+            string query,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<ModMetadata>>(listings);
+    }
+
+    private sealed class FailingOnceSettingsRepository(BoreaSettings current) : IBoreaSettingsRepository
+    {
+        private bool _failed;
+
+        public BoreaSettings Current { get; private set; } = current;
+
+        public Task<BoreaSettings?> GetAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<BoreaSettings?>(Current);
+
+        public Task SaveAsync(BoreaSettings settings, CancellationToken cancellationToken = default)
+        {
+            Current = settings;
+            if (!_failed)
+            {
+                _failed = true;
+                throw new IOException("Settings save failed.");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FailingSettingsRepository(BoreaSettings current) : IBoreaSettingsRepository
+    {
+        private int _saveCount;
+
+        public BoreaSettings Current { get; private set; } = current;
+
+        public Task<BoreaSettings?> GetAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<BoreaSettings?>(Current);
+
+        public Task SaveAsync(BoreaSettings settings, CancellationToken cancellationToken = default)
+        {
+            _saveCount++;
+            if (_saveCount == 1)
+                Current = settings;
+            throw new IOException("Settings save failed.");
+        }
+    }
+}


### PR DESCRIPTION
Closes #104

Changing the game directory now updates installed loaders that declare a game-path configuration key.
Borea saves the new setting after those updates succeed and restores the prior files and settings when an update fails.
Rollback failures are reported explicitly.

Stacked on #110.
