### PR TITLE
Add loader management and instance launch commands

### DIFF
--- a/src/Borea.Cli/BoreaCli.cs
+++ b/src/Borea.Cli/BoreaCli.cs
@@ -26,6 +26,7 @@ internal static class BoreaCli
         root.Subcommands.Add(ModStateCommands.BuildEnable(services));
         root.Subcommands.Add(ModStateCommands.BuildDisable(services));
         root.Subcommands.Add(LoaderCommand.Build(services));
+        root.Subcommands.Add(LaunchCommand.Build(services));
         return root;
     }
 

--- a/src/Borea.Cli/BoreaCli.cs
+++ b/src/Borea.Cli/BoreaCli.cs
@@ -25,6 +25,7 @@ internal static class BoreaCli
         root.Subcommands.Add(InstanceCommand.Build(services));
         root.Subcommands.Add(ModStateCommands.BuildEnable(services));
         root.Subcommands.Add(ModStateCommands.BuildDisable(services));
+        root.Subcommands.Add(LoaderCommand.Build(services));
         return root;
     }
 

--- a/src/Borea.Cli/CliServices.cs
+++ b/src/Borea.Cli/CliServices.cs
@@ -2,6 +2,9 @@ using Borea.Composition;
 using Borea.Core.Game;
 using Borea.Core.Index;
 using Borea.Core.Instances;
+using Borea.Core.Launch;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
 using Borea.Core.Paths;
 using Borea.Core.Settings;
 using Borea.Core.State;
@@ -38,11 +41,23 @@ internal sealed class CliServices : IDisposable
 
     public required IGamePathProvider Paths { get; init; }
 
+    public required IModRepository Mods { get; init; }
+
+    public required ILoaderInstaller LoaderInstaller { get; init; }
+
+    public required ILoaderAdopter LoaderAdopter { get; init; }
+
+    public required ILoaderUninstaller LoaderUninstaller { get; init; }
+
+    public required ILauncher Launcher { get; init; }
+
     /// <summary>
     /// The graph the services came from, disposed with this instance. Null when
     /// nothing needs disposing.
     /// </summary>
     public IDisposable? Graph { get; init; }
+
+    public IDisposable? AdditionalDisposable { get; init; }
 
     /// <summary>
     /// The graph's services. <paramref name="latestVersion"/> replaces the
@@ -54,7 +69,12 @@ internal sealed class CliServices : IDisposable
         ILatestVersionPing? latestVersion = null,
         IInstalledGameVersionProvider? installedVersion = null,
         IContentIndexFetcher? indexFetcher = null,
-        IContentIndexReader? indexReader = null)
+        IContentIndexReader? indexReader = null,
+        IModRepository? mods = null,
+        ILoaderInstaller? loaderInstaller = null,
+        ILoaderAdopter? loaderAdopter = null,
+        ILoaderUninstaller? loaderUninstaller = null,
+        ILauncher? launcher = null)
     {
         if (services is null)
             throw new ArgumentNullException(nameof(services));
@@ -71,9 +91,21 @@ internal sealed class CliServices : IDisposable
             IndexFetcher = indexFetcher ?? services.IndexFetcher,
             IndexReader = indexReader ?? services.IndexReader,
             Paths = services.Paths,
+            Mods = mods ?? services.Mods,
+            LoaderInstaller = loaderInstaller ?? services.LoaderInstaller,
+            LoaderAdopter = loaderAdopter ?? services.LoaderAdopter,
+            LoaderUninstaller = loaderUninstaller ?? services.LoaderUninstaller,
+            Launcher = launcher ?? services.Launcher,
             Graph = services,
+            AdditionalDisposable = launcher is IDisposable disposable && !ReferenceEquals(launcher, services.Launcher)
+                ? disposable
+                : null,
         };
     }
 
-    public void Dispose() => Graph?.Dispose();
+    public void Dispose()
+    {
+        AdditionalDisposable?.Dispose();
+        Graph?.Dispose();
+    }
 }

--- a/src/Borea.Cli/Commands/CommandRunner.cs
+++ b/src/Borea.Cli/Commands/CommandRunner.cs
@@ -60,5 +60,6 @@ internal static class CommandRunner
             or IOException
             or UnauthorizedAccessException
             or HttpRequestException
+            or NotSupportedException
             or OperationCanceledException;
 }

--- a/src/Borea.Cli/Commands/LaunchCommand.cs
+++ b/src/Borea.Cli/Commands/LaunchCommand.cs
@@ -1,0 +1,39 @@
+using System.CommandLine;
+
+namespace Borea.Cli.Commands;
+
+internal static class LaunchCommand
+{
+    public static Command Build(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var instance = ArgumentRules.Text("instance", "The instance's name, or its id when two names differ only in case.");
+        var loaderId = ArgumentRules.ContentId("loader-id", "The installed mod loader to use.");
+        var launch = new Command("launch", "Start one instance through an installed mod loader.");
+        launch.Arguments.Add(instance);
+        launch.Arguments.Add(loaderId);
+
+        launch.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, error, ct) =>
+        {
+            var target = await InstanceLookup
+                .ResolveAsync(cli.Instances, parseResult.GetRequiredValue(instance))
+                .ConfigureAwait(false);
+            var loader = await LoaderLookup
+                .GetListingAsync(cli.Mods, parseResult.GetRequiredValue(loaderId), ct)
+                .ConfigureAwait(false);
+            ct.ThrowIfCancellationRequested();
+            var result = cli.Launcher.Launch(target, loader);
+
+            if (!result.Started)
+            {
+                error.WriteLine($"error: {result.Message}");
+                return ExitCodes.Failed;
+            }
+
+            output.WriteLine(result.Message);
+            output.WriteLine($"Process id: {result.ProcessId}");
+            return ExitCodes.Done;
+        }));
+
+        return launch;
+    }
+}

--- a/src/Borea.Cli/Commands/LoaderCommand.cs
+++ b/src/Borea.Cli/Commands/LoaderCommand.cs
@@ -1,0 +1,152 @@
+using System.CommandLine;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+
+namespace Borea.Cli.Commands;
+
+internal static class LoaderCommand
+{
+    public static Command Build(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var loader = new Command("loader", "Install, adopt, and uninstall mod loaders.");
+        loader.Subcommands.Add(BuildInstall(services));
+        loader.Subcommands.Add(BuildAdopt(services));
+        loader.Subcommands.Add(BuildUninstall(services));
+        return loader;
+    }
+
+    private static Command BuildInstall(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var loaderId = ArgumentRules.ContentId("loader-id", "The mod loader's content id.");
+        var version = VersionOption();
+        var directory = new Option<string?>("--directory")
+        {
+            Description = "The standalone install directory. Borea chooses one when this option is absent.",
+        };
+        directory.Validators.Add(result =>
+        {
+            if (string.IsNullOrWhiteSpace(result.GetValueOrDefault<string?>()))
+                result.AddError("The --directory value cannot be empty.");
+        });
+
+        var install = new Command("install", "Install one release of a mod loader and configure it for the game.");
+        install.Arguments.Add(loaderId);
+        install.Options.Add(version);
+        install.Options.Add(directory);
+
+        install.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, _, ct) =>
+        {
+            var id = parseResult.GetRequiredValue(loaderId);
+            var listing = await LoaderLookup.GetListingAsync(cli.Mods, id, ct).ConfigureAwait(false);
+            var rawVersion = parseResult.GetValue(version);
+            var release = rawVersion is null
+                ? await cli.Mods.GetLatestReleaseAsync(listing.ModId, ct).ConfigureAwait(false)
+                : await cli.Mods.GetReleaseAsync(listing.ModId, ModVersion.Parse(rawVersion), ct).ConfigureAwait(false);
+
+            if (release is null)
+                throw new InvalidOperationException(rawVersion is null
+                    ? $"Mod loader '{listing.ModId}' has no release that Borea can install."
+                    : $"Mod loader '{listing.ModId}' has no release '{rawVersion}'.");
+
+            if (release.Yanked)
+                throw new InvalidOperationException($"Release {release.Version} of {listing.ModId} is yanked and cannot be installed.");
+
+            var rawDirectory = parseResult.GetValue(directory);
+            var destination = rawDirectory is null ? null : Path.GetFullPath(rawDirectory);
+            var result = await cli.LoaderInstaller.InstallAsync(listing, release, destination, cancellationToken: ct).ConfigureAwait(false);
+
+            output.WriteLine($"Installed {result.LoaderId} {result.Version} in '{result.Directory}'.");
+            if (result.ConfigurationFile is not null)
+                output.WriteLine($"Configured game directory in '{result.ConfigurationFile}'.");
+            return ExitCodes.Done;
+        }));
+
+        return install;
+    }
+
+    private static Command BuildAdopt(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var loaderId = ArgumentRules.ContentId("loader-id", "The mod loader's content id.");
+        var directory = ArgumentRules.Text("directory", "The directory that holds the loader's launch file.");
+        var adopt = new Command("adopt", "Validate and record a mod loader that Borea did not install.");
+        adopt.Arguments.Add(loaderId);
+        adopt.Arguments.Add(directory);
+
+        adopt.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, (cli, output, error, ct) =>
+            AdoptAsync(
+                cli,
+                parseResult.GetRequiredValue(loaderId),
+                Path.GetFullPath(parseResult.GetRequiredValue(directory)),
+                output,
+                error,
+                ct)));
+
+        return adopt;
+    }
+
+    private static Command BuildUninstall(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var loaderId = ArgumentRules.ContentId("loader-id", "The mod loader's content id.");
+        var uninstall = new Command("uninstall", "Remove a mod loader record and delete its directory when Borea owns it.");
+        uninstall.Arguments.Add(loaderId);
+
+        uninstall.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, _, ct) =>
+        {
+            var result = await cli.LoaderUninstaller
+                .UninstallAsync(parseResult.GetRequiredValue(loaderId), ct)
+                .ConfigureAwait(false);
+
+            if (!result.RecordRemoved)
+            {
+                output.WriteLine($"Loader {result.LoaderId} was not recorded.");
+                return ExitCodes.Done;
+            }
+
+            output.WriteLine(result.DirectoryRemoved
+                ? $"Removed loader {result.LoaderId} and its directory '{result.Directory}'."
+                : $"Removed loader {result.LoaderId} from Borea. Its directory '{result.Directory}' remains.");
+            return ExitCodes.Done;
+        }));
+
+        return uninstall;
+    }
+
+    internal static async Task<int> AdoptAsync(
+        CliServices services,
+        string loaderId,
+        string directory,
+        TextWriter output,
+        TextWriter error,
+        CancellationToken cancellationToken)
+    {
+        var listing = await LoaderLookup.GetListingAsync(services.Mods, loaderId, cancellationToken).ConfigureAwait(false);
+        var releases = await LoaderLookup.GetReleasesAsync(services.Mods, listing.ModId, cancellationToken).ConfigureAwait(false);
+        var result = await services.LoaderAdopter
+            .AdoptAsync(listing, releases, directory, cancellationToken)
+            .ConfigureAwait(false);
+
+        output.WriteLine($"Adopted {result.LoaderId} in '{result.Directory}'.");
+        output.WriteLine(result.Version is null
+            ? "Loader version: unknown"
+            : $"Loader version: {result.Version}");
+        foreach (var warning in result.Warnings)
+            error.WriteLine($"warning: {warning}");
+
+        return ExitCodes.Done;
+    }
+
+    private static Option<string?> VersionOption()
+    {
+        var version = new Option<string?>("--version")
+        {
+            Description = "The release to install. The newest usable release when absent.",
+        };
+        version.Validators.Add(result =>
+        {
+            var value = result.GetValueOrDefault<string?>();
+            if (string.IsNullOrWhiteSpace(value) || !ModVersion.TryParse(value, out _))
+                result.AddError($"'{value}' is not a valid semantic version.");
+        });
+        return version;
+    }
+}

--- a/src/Borea.Cli/Commands/LoaderLookup.cs
+++ b/src/Borea.Cli/Commands/LoaderLookup.cs
@@ -1,0 +1,39 @@
+using Borea.Core.Mods;
+
+namespace Borea.Cli.Commands;
+
+internal static class LoaderLookup
+{
+    public static async Task<ModMetadata> GetListingAsync(
+        IModRepository repository,
+        string loaderId,
+        CancellationToken cancellationToken)
+    {
+        var listings = await repository.GetAvailableModsAsync(cancellationToken).ConfigureAwait(false);
+        var listing = listings.FirstOrDefault(candidate => ModIds.Equals(candidate.ModId, loaderId));
+        if (listing is null)
+            throw new InvalidOperationException($"Mod loader '{loaderId}' is not available from the configured sources.");
+
+        if (listing.Type != ContentType.ModLoader)
+            throw new InvalidOperationException($"'{listing.ModId}' is a {listing.Type}, not a mod loader.");
+
+        return listing;
+    }
+
+    public static async Task<IReadOnlyList<ModVersionMetadata>> GetReleasesAsync(
+        IModRepository repository,
+        string loaderId,
+        CancellationToken cancellationToken)
+    {
+        var versions = await repository.GetAvailableVersionsAsync(loaderId, cancellationToken).ConfigureAwait(false);
+        var releases = new List<ModVersionMetadata>(versions.Count);
+        foreach (var version in versions)
+        {
+            var release = await repository.GetReleaseAsync(loaderId, version, cancellationToken).ConfigureAwait(false);
+            if (release is not null)
+                releases.Add(release);
+        }
+
+        return releases;
+    }
+}

--- a/src/Borea.Cli/Commands/SettingsCommand.cs
+++ b/src/Borea.Cli/Commands/SettingsCommand.cs
@@ -1,6 +1,5 @@
 using System.CommandLine;
 using Borea.Cli.Output;
-using Borea.Core.ModLoaders;
 using Borea.Core.Mods;
 using Borea.Core.Settings;
 
@@ -77,12 +76,7 @@ internal static class SettingsCommand
         {
             var id = parseResult.GetRequiredValue(loaderId);
             var fullPath = Path.GetFullPath(parseResult.GetRequiredValue(directory));
-            var installation = new LoaderInstallation(fullPath, version: null, rawVersion: null, isAdopted: true);
-            await cli.SettingsRepository.SaveAsync(cli.Settings.WithLoaderInstallation(id, installation), ct).ConfigureAwait(false);
-
-            output.WriteLine($"Loader {id} directory: {fullPath}");
-            WarnWhenMissing(error, fullPath);
-            return ExitCodes.Done;
+            return await LoaderCommand.AdoptAsync(cli, id, fullPath, output, error, ct).ConfigureAwait(false);
         }));
 
         return loader;

--- a/src/Borea.Composition/Borea.Composition.csproj
+++ b/src/Borea.Composition/Borea.Composition.csproj
@@ -7,6 +7,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Borea.Cli.Tests" />
     <InternalsVisibleTo Include="Borea.Composition.Tests" />
   </ItemGroup>
 

--- a/src/Borea.Composition/BoreaServices.cs
+++ b/src/Borea.Composition/BoreaServices.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using Borea.Core.Game;
 using Borea.Core.Index;
 using Borea.Core.Instances;
+using Borea.Core.Launch;
 using Borea.Core.ModLoaders;
 using Borea.Core.ModPacks;
 using Borea.Core.Mods;
@@ -16,6 +17,7 @@ using Borea.Network.SpaceDock;
 using Borea.Storage.Game;
 using Borea.Storage.Instances;
 using Borea.Storage.Index;
+using Borea.Storage.Launch;
 using Borea.Storage.ModLoaders;
 using Borea.Storage.ModPacks;
 using Borea.Storage.Mods;
@@ -88,6 +90,8 @@ public sealed class BoreaServices : IDisposable
     public required ILoaderAdopter LoaderAdopter { get; init; }
 
     public required ILoaderUninstaller LoaderUninstaller { get; init; }
+
+    public required ILauncher Launcher { get; init; }
 
     public required ILatestVersionPing LatestVersion { get; init; }
 
@@ -188,6 +192,7 @@ public sealed class BoreaServices : IDisposable
             LoaderInstaller = new FileLoaderInstaller(paths, downloader, settingsRepository, loaderConfiguration),
             LoaderAdopter = new FileLoaderAdopter(settingsRepository, loaderConfiguration),
             LoaderUninstaller = new FileLoaderUninstaller(settingsRepository),
+            Launcher = new LoaderLauncher(paths, new ProcessStarter()),
             LatestVersion = new LatestVersionPing(http),
             InstalledVersion = new InstalledGameVersionProvider(paths),
             IndexFetcher = indexFetcher,
@@ -207,5 +212,11 @@ public sealed class BoreaServices : IDisposable
         return http;
     }
 
-    public void Dispose() => _http.Dispose();
+    public void Dispose()
+    {
+        if (Launcher is IDisposable disposable)
+            disposable.Dispose();
+
+        _http.Dispose();
+    }
 }

--- a/tests/Borea.Cli.Tests/Borea.Cli.Tests.csproj
+++ b/tests/Borea.Cli.Tests/Borea.Cli.Tests.csproj
@@ -25,4 +25,8 @@
     <ProjectReference Include="..\..\src\Borea.Storage\Borea.Storage.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="..\Borea.Storage.Tests\Index\Fixtures\current-snapshot.json" Link="Index\Fixtures\current-snapshot.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Borea.Cli.Tests/CliHost.cs
+++ b/tests/Borea.Cli.Tests/CliHost.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using Borea.Composition;
+using Borea.Core.ModLoaders;
+using Borea.Storage.Launch;
 using Borea.Storage.Paths;
 
 namespace Borea.Cli.Tests;
@@ -22,6 +24,16 @@ internal sealed class CliHost : IDisposable
 
     public FakeContentIndexReader IndexReader { get; } = new();
 
+    public FakeModRepository Mods { get; } = new();
+
+    public FakeProcessStarter ProcessStarter { get; } = new();
+
+    public ILoaderInstaller? LoaderInstaller { get; set; }
+
+    public ILoaderAdopter? LoaderAdopter { get; set; }
+
+    public ILoaderUninstaller? LoaderUninstaller { get; set; }
+
     /// <summary>How many times a command built its services.</summary>
     public int Builds { get; private set; }
 
@@ -43,12 +55,18 @@ internal sealed class CliHost : IDisposable
     private async Task<CliServices> BuildAsync(CancellationToken cancellationToken)
     {
         Builds++;
+        var graph = await BoreaServices.BuildAsync(Root, cancellationToken);
         return CliServices.From(
-            await BoreaServices.BuildAsync(Root, cancellationToken),
-            LatestVersion,
-            InstalledVersion,
-            IndexFetcher,
-            IndexReader);
+            graph,
+            latestVersion: LatestVersion,
+            installedVersion: InstalledVersion,
+            indexFetcher: IndexFetcher,
+            indexReader: IndexReader,
+            mods: Mods,
+            loaderInstaller: LoaderInstaller,
+            loaderAdopter: LoaderAdopter,
+            loaderUninstaller: LoaderUninstaller,
+            launcher: new LoaderLauncher(graph.Paths, ProcessStarter));
     }
 
     public void Dispose()

--- a/tests/Borea.Cli.Tests/CliServicesTests.cs
+++ b/tests/Borea.Cli.Tests/CliServicesTests.cs
@@ -23,6 +23,11 @@ public sealed class CliServicesTests : IDisposable
         Assert.Same(graph.IndexFetcher, services.IndexFetcher);
         Assert.Same(graph.IndexReader, services.IndexReader);
         Assert.Same(graph.Paths, services.Paths);
+        Assert.Same(graph.Mods, services.Mods);
+        Assert.Same(graph.LoaderInstaller, services.LoaderInstaller);
+        Assert.Same(graph.LoaderAdopter, services.LoaderAdopter);
+        Assert.Same(graph.LoaderUninstaller, services.LoaderUninstaller);
+        Assert.Same(graph.Launcher, services.Launcher);
         Assert.Same(graph, services.Graph);
     }
 
@@ -61,6 +66,11 @@ public sealed class CliServicesTests : IDisposable
             IndexFetcher = new FakeContentIndexFetcher(),
             IndexReader = new FakeContentIndexReader(),
             Paths = graph.Paths,
+            Mods = graph.Mods,
+            LoaderInstaller = graph.LoaderInstaller,
+            LoaderAdopter = graph.LoaderAdopter,
+            LoaderUninstaller = graph.LoaderUninstaller,
+            Launcher = graph.Launcher,
             Graph = owner,
         };
 

--- a/tests/Borea.Cli.Tests/FakeModRepository.cs
+++ b/tests/Borea.Cli.Tests/FakeModRepository.cs
@@ -1,0 +1,38 @@
+using Borea.Core.Mods;
+
+namespace Borea.Cli.Tests;
+
+internal sealed class FakeModRepository : IModRepository
+{
+    public List<ModMetadata> Listings { get; } = new();
+
+    public List<ModVersionMetadata> Releases { get; } = new();
+
+    public Func<CancellationToken, Task<IReadOnlyList<ModMetadata>>>? AvailableMods { get; set; }
+
+    public Task<IReadOnlyList<ModMetadata>> GetAvailableModsAsync(CancellationToken cancellationToken = default)
+        => AvailableMods?.Invoke(cancellationToken) ?? Task.FromResult<IReadOnlyList<ModMetadata>>(Listings);
+
+    public Task<ModVersionMetadata?> GetLatestReleaseAsync(string modId, CancellationToken cancellationToken = default)
+        => Task.FromResult(Releases
+            .Where(release => ModIds.Equals(release.ModId, modId) && !release.Yanked)
+            .OrderByDescending(release => release.Version)
+            .FirstOrDefault());
+
+    public Task<ModVersionMetadata?> GetReleaseAsync(string modId, ModVersion version, CancellationToken cancellationToken = default)
+        => Task.FromResult(Releases.FirstOrDefault(release =>
+            ModIds.Equals(release.ModId, modId) && release.Version == version));
+
+    public Task<IReadOnlyList<ModVersion>> GetAvailableVersionsAsync(string modId, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<ModVersion>>(Releases
+            .Where(release => ModIds.Equals(release.ModId, modId))
+            .Select(release => release.Version)
+            .Distinct()
+            .OrderByDescending(version => version)
+            .ToList());
+
+    public Task<IReadOnlyList<ModMetadata>> SearchAsync(string query, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<ModMetadata>>(Listings
+            .Where(listing => listing.Name.Contains(query, StringComparison.OrdinalIgnoreCase))
+            .ToList());
+}

--- a/tests/Borea.Cli.Tests/FakeProcessStarter.cs
+++ b/tests/Borea.Cli.Tests/FakeProcessStarter.cs
@@ -1,0 +1,26 @@
+using Borea.Core.Launch;
+using Borea.Storage.Launch;
+
+namespace Borea.Cli.Tests;
+
+internal sealed class FakeProcessStarter : IProcessStarter
+{
+    public List<LaunchPlan> Plans { get; } = new();
+
+    public IStartedProcess Start(LaunchPlan plan)
+    {
+        Plans.Add(plan);
+        return new FakeStartedProcess();
+    }
+
+    private sealed class FakeStartedProcess : IStartedProcess
+    {
+        public int Id => 42;
+
+        public bool HasExited => false;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/Borea.Cli.Tests/LaunchCommandTests.cs
+++ b/tests/Borea.Cli.Tests/LaunchCommandTests.cs
@@ -1,0 +1,75 @@
+namespace Borea.Cli.Tests;
+
+public sealed class LaunchCommandTests : IDisposable
+{
+    private readonly CliHost _host = new();
+
+    [Fact]
+    public async Task Launch_StarMapStartsWithItsExistingHandover()
+    {
+        _host.Mods.Listings.Add(LoaderFixtures.Listing());
+        var loaderDirectory = LoaderCommandTests.CreateLoaderDirectory("StarMap", "not a program", _host.Root);
+        await _host.RunAsync("settings", "set", "loader", "StarMap", loaderDirectory);
+        await _host.RunAsync("instance", "create", "Flight Test");
+
+        var run = await _host.RunAsync("launch", "Flight Test", "StarMap");
+
+        Assert.Equal(0, run.ExitCode);
+        var plan = Assert.Single(_host.ProcessStarter.Plans);
+        Assert.Equal("-InstancePath", plan.Arguments[0]);
+        Assert.True(Path.IsPathFullyQualified(plan.Arguments[1]));
+        Assert.Equal(plan.Arguments[1], plan.EnvironmentVariables["STARMAP_INSTANCE_PATH"]);
+        Assert.Contains("Process id: 42", run.Output);
+    }
+
+    [Fact]
+    public async Task Launch_LoaderWithoutAnExistingHandover_FailsWithoutStarting()
+    {
+        _host.Mods.Listings.Add(LoaderFixtures.Listing("OtherLoader"));
+        var directory = LoaderCommandTests.CreateLoaderDirectory("OtherLoader", "not a program", _host.Root);
+        await _host.RunAsync("settings", "set", "loader", "OtherLoader", directory);
+        await _host.RunAsync("instance", "create", "Flight Test");
+
+        var run = await _host.RunAsync("launch", "Flight Test", "OtherLoader");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("does not know how OtherLoader takes an instance", run.Error);
+        Assert.Empty(_host.ProcessStarter.Plans);
+    }
+
+    [Fact]
+    public async Task Launch_UnknownInstance_Fails()
+    {
+        _host.Mods.Listings.Add(LoaderFixtures.Listing());
+
+        var run = await _host.RunAsync("launch", "Missing", "StarMap");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("No instance is named", run.Error);
+        Assert.Empty(_host.ProcessStarter.Plans);
+    }
+
+    [Fact]
+    public async Task Launch_CancelledAfterLoaderLookup_DoesNotStartAProcess()
+    {
+        var listing = LoaderFixtures.Listing();
+        _host.Mods.Listings.Add(listing);
+        var loaderDirectory = LoaderCommandTests.CreateLoaderDirectory("StarMap", "not a program", _host.Root);
+        await _host.RunAsync("settings", "set", "loader", "StarMap", loaderDirectory);
+        await _host.RunAsync("instance", "create", "Flight Test");
+        using var cancellation = new CancellationTokenSource();
+        _host.Mods.AvailableMods = _ =>
+        {
+            cancellation.Cancel();
+            return Task.FromResult<IReadOnlyList<Borea.Core.Mods.ModMetadata>>([listing]);
+        };
+
+        var run = await _host.RunAsync(cancellation.Token, "launch", "Flight Test", "StarMap");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("command was cancelled", run.Error);
+        Assert.Empty(_host.ProcessStarter.Plans);
+    }
+
+    public void Dispose() => _host.Dispose();
+}

--- a/tests/Borea.Cli.Tests/LoaderCommandTests.cs
+++ b/tests/Borea.Cli.Tests/LoaderCommandTests.cs
@@ -1,0 +1,197 @@
+using System.Text.Json;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+
+namespace Borea.Cli.Tests;
+
+public sealed class LoaderCommandTests : IDisposable
+{
+    private readonly CliHost _host = new();
+
+    [Fact]
+    public async Task Install_UsesTheNewestReleaseAndRequestedDirectory()
+    {
+        var installer = new FakeLoaderInstaller();
+        var directory = Path.Combine(_host.Root, "Loader");
+        _host.LoaderInstaller = installer;
+        _host.Mods.Listings.Add(LoaderFixtures.Listing());
+        _host.Mods.Releases.Add(LoaderFixtures.Release(version: "0.4.5"));
+        _host.Mods.Releases.Add(LoaderFixtures.Release(version: "0.4.6"));
+
+        var run = await _host.RunAsync("loader", "install", "StarMap", "--directory", directory);
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Equal("0.4.6", Assert.Single(installer.Calls).Release.Version.ToString());
+        Assert.Equal(directory, installer.Calls[0].Directory);
+        Assert.Contains("Installed StarMap 0.4.6", run.Output);
+    }
+
+    [Fact]
+    public async Task Install_RequestedReleaseThatDoesNotExist_Fails()
+    {
+        _host.LoaderInstaller = new FakeLoaderInstaller();
+        _host.Mods.Listings.Add(LoaderFixtures.Listing());
+        _host.Mods.Releases.Add(LoaderFixtures.Release());
+
+        var run = await _host.RunAsync("loader", "install", "StarMap", "--version", "0.4.5");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("has no release '0.4.5'", run.Error);
+    }
+
+    [Fact]
+    public async Task Install_InvalidVersion_IsAUsageError()
+    {
+        var run = await _host.RunAsync("loader", "install", "StarMap", "--version", "latest");
+
+        Assert.Equal(2, run.ExitCode);
+        Assert.Contains("not a valid semantic version", run.Error);
+        Assert.Equal(0, _host.Builds);
+    }
+
+    [Fact]
+    public async Task Install_ServiceFailure_IsReportedAsAnOperationFailure()
+    {
+        _host.LoaderInstaller = new FakeLoaderInstaller { Failure = new InvalidOperationException("Destination has foreign files.") };
+        _host.Mods.Listings.Add(LoaderFixtures.Listing());
+        _host.Mods.Releases.Add(LoaderFixtures.Release());
+
+        var run = await _host.RunAsync("loader", "install", "StarMap");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("Destination has foreign files", run.Error);
+    }
+
+    [Fact]
+    public async Task Install_ExplicitYankedRelease_FailsBeforeTheInstallerRuns()
+    {
+        var installer = new FakeLoaderInstaller();
+        _host.LoaderInstaller = installer;
+        _host.Mods.Listings.Add(LoaderFixtures.Listing());
+        _host.Mods.Releases.Add(LoaderFixtures.Release(yanked: true));
+
+        var run = await _host.RunAsync("loader", "install", "StarMap", "--version", "0.4.6");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("is yanked and cannot be installed", run.Error);
+        Assert.Empty(installer.Calls);
+    }
+
+    [Fact]
+    public async Task Adopt_MissingLaunchFile_FailsWithoutARecord()
+    {
+        var directory = Directory.CreateDirectory(Path.Combine(_host.Root, "Loader")).FullName;
+        _host.Mods.Listings.Add(LoaderFixtures.Listing());
+        _host.Mods.Releases.Add(LoaderFixtures.Release());
+
+        var run = await _host.RunAsync("loader", "adopt", "StarMap", directory);
+        var show = await _host.RunAsync("settings", "show", "--json");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("does not hold the listed launch file", run.Error);
+        Assert.Empty(show.Json.GetProperty("loaderDirectories").EnumerateObject());
+    }
+
+    [Fact]
+    public async Task Adopt_UnreadableVersion_RecordsTheLoaderAndWarns()
+    {
+        var directory = CreateLoaderDirectory("StarMap", "not a program", _host.Root);
+        _host.Mods.Listings.Add(LoaderFixtures.Listing());
+        _host.Mods.Releases.Add(LoaderFixtures.Release());
+
+        var run = await _host.RunAsync("loader", "adopt", "StarMap", directory);
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("Loader version: unknown", run.Output);
+        Assert.Contains("could not read a file version", run.Error);
+    }
+
+    [Fact]
+    public async Task Adopt_MismatchedGamePath_RecordsTheLoaderAndWarnsWithoutChangingIt()
+    {
+        var managedGame = Directory.CreateDirectory(Path.Combine(_host.Root, "ManagedGame")).FullName;
+        var otherGame = Directory.CreateDirectory(Path.Combine(_host.Root, "OtherGame")).FullName;
+        var directory = CreateLoaderDirectory("StarMap", "not a program", _host.Root, otherGame);
+        _host.Mods.Listings.Add(LoaderFixtures.Listing());
+
+        await _host.RunAsync("settings", "set", "game", managedGame);
+        var run = await _host.RunAsync("loader", "adopt", "StarMap", directory);
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("not the game directory Borea manages", run.Error);
+        using var configuration = JsonDocument.Parse(await File.ReadAllTextAsync(Path.Combine(directory, "StarMapConfig.json")));
+        Assert.Equal(otherGame, configuration.RootElement.GetProperty("GameLocation").GetString());
+    }
+
+    [Fact]
+    public async Task Uninstall_ReportsWhetherTheDirectoryWasRemoved()
+    {
+        var uninstaller = new FakeLoaderUninstaller
+        {
+            Result = new LoaderUninstallResult("StarMap", "C:\\Loaders\\StarMap", RecordRemoved: true, DirectoryRemoved: false),
+        };
+        _host.LoaderUninstaller = uninstaller;
+
+        var run = await _host.RunAsync("loader", "uninstall", "StarMap");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Equal("StarMap", Assert.Single(uninstaller.LoaderIds));
+        Assert.Contains("remains", run.Output);
+    }
+
+    internal static string CreateLoaderDirectory(string loaderId, string executableContents, string root, string? gameDirectory = null)
+    {
+        var directory = Directory.CreateDirectory(Path.Combine(root, loaderId)).FullName;
+        File.WriteAllText(Path.Combine(directory, "StarMap.exe"), executableContents);
+        File.WriteAllText(
+            Path.Combine(directory, "StarMapConfig.json"),
+            $$"""
+            {
+              "GameLocation": "{{(gameDirectory ?? Path.Combine(root, "Game")).Replace("\\", "\\\\")}}"
+            }
+            """);
+        return directory;
+    }
+
+    public void Dispose() => _host.Dispose();
+
+    private sealed class FakeLoaderInstaller : ILoaderInstaller
+    {
+        public List<(ModMetadata Listing, ModVersionMetadata Release, string? Directory)> Calls { get; } = new();
+
+        public Exception? Failure { get; init; }
+
+        public Task<LoaderInstallResult> InstallAsync(
+            ModMetadata loader,
+            ModVersionMetadata release,
+            string? directory = null,
+            IProgress<DownloadProgress>? progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (Failure is not null)
+                throw Failure;
+
+            Calls.Add((loader, release, directory));
+            return Task.FromResult(new LoaderInstallResult(
+                loader.ModId,
+                release.Version,
+                directory ?? "C:\\Loaders\\StarMap",
+                new DownloadResult(release.Download.Url, 100, "ABC"),
+                "StarMapConfig.json",
+                Replaced: false));
+        }
+    }
+
+    private sealed class FakeLoaderUninstaller : ILoaderUninstaller
+    {
+        public List<string> LoaderIds { get; } = new();
+
+        public required LoaderUninstallResult Result { get; init; }
+
+        public Task<LoaderUninstallResult> UninstallAsync(string loaderId, CancellationToken cancellationToken = default)
+        {
+            LoaderIds.Add(loaderId);
+            return Task.FromResult(Result);
+        }
+    }
+}

--- a/tests/Borea.Cli.Tests/LoaderFixtures.cs
+++ b/tests/Borea.Cli.Tests/LoaderFixtures.cs
@@ -1,0 +1,41 @@
+using Borea.Core.Dependencies;
+using Borea.Core.Game;
+using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
+
+namespace Borea.Cli.Tests;
+
+internal static class LoaderFixtures
+{
+    public static ModMetadata Listing(string id = "StarMap", string launch = "StarMap.exe") => new(
+        specVersion: 1,
+        modId: id,
+        source: "index",
+        name: id,
+        authors: new[] { "Loader author" },
+        abstractText: "A mod loader.",
+        license: "MIT",
+        links: new Dictionary<string, string> { ["forums"] = "https://example.invalid/forums" },
+        gameMin: "2026.9.7.5402",
+        type: ContentType.ModLoader,
+        install: new InstallDescriptor(target: InstallAnchor.Standalone),
+        provides: new LoaderProvides(
+            launch: launch,
+            configure: new LoaderConfigure("StarMapConfig.json", ConfigureFormat.Json, "GameLocation")));
+
+    public static ModVersionMetadata Release(string id = "StarMap", string version = "0.4.6", bool yanked = false) => new(
+        specVersion: 1,
+        modId: id,
+        version: ModVersion.Parse(version),
+        releaseStatus: ReleaseStatus.Stable,
+        releaseDate: new DateTimeOffset(2026, 9, 1, 12, 0, 0, TimeSpan.Zero),
+        gameMin: "2026.9.7.5402",
+        gameMinRevision: 5402,
+        download: new DownloadInfo("https://example.invalid/loader.zip", null, 100, "application/zip"),
+        installSizeBytes: 200,
+        dependencies: Array.Empty<ModDependency>(),
+        type: ContentType.ModLoader,
+        install: new InstallInfo(root: null, derived: true, target: InstallAnchor.Standalone),
+        yanked: yanked,
+        source: "index");
+}

--- a/tests/Borea.Cli.Tests/LoaderIntegrationTests.cs
+++ b/tests/Borea.Cli.Tests/LoaderIntegrationTests.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Borea.Composition;
+using Borea.Core.Mods;
+using Borea.Storage.Launch;
+
+namespace Borea.Cli.Tests;
+
+public sealed class LoaderIntegrationTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+    private readonly FakeProcessStarter _processStarter = new();
+
+    [Fact]
+    public async Task Commands_UseTheIndexLoaderContractToAdoptUpdateAndLaunch()
+    {
+        var oldGame = Directory.CreateDirectory(Path.Combine(_root, "OldGame")).FullName;
+        var newGame = Directory.CreateDirectory(Path.Combine(_root, "NewGame")).FullName;
+        var loaderDirectory = LoaderCommandTests.CreateLoaderDirectory("StarMap", "not a program", _root, oldGame);
+
+        Assert.Equal(0, (await RunAsync("settings", "set", "game", oldGame)).ExitCode);
+        var adopt = await RunAsync("settings", "set", "loader", "StarMap", loaderDirectory);
+        var change = await RunAsync("settings", "set", "game", newGame);
+        Assert.Equal(0, (await RunAsync("instance", "create", "Flight Test")).ExitCode);
+        var launch = await RunAsync("launch", "Flight Test", "StarMap");
+
+        Assert.Equal(0, adopt.ExitCode);
+        Assert.Contains("Adopted StarMap", adopt.Output);
+        Assert.Equal(0, change.ExitCode);
+        using var configuration = JsonDocument.Parse(
+            await File.ReadAllTextAsync(Path.Combine(loaderDirectory, "StarMapConfig.json")));
+        Assert.Equal(newGame, configuration.RootElement.GetProperty("GameLocation").GetString());
+        Assert.Equal(0, launch.ExitCode);
+        var plan = Assert.Single(_processStarter.Plans);
+        Assert.Equal("-InstancePath", plan.Arguments[0]);
+        Assert.Equal(plan.Arguments[1], plan.EnvironmentVariables["STARMAP_INSTANCE_PATH"]);
+    }
+
+    private async Task<CliRun> RunAsync(params string[] args)
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var snapshot = await File.ReadAllTextAsync(Path.Combine(
+            AppContext.BaseDirectory,
+            "Index",
+            "Fixtures",
+            "current-snapshot.json"));
+
+        async Task<CliServices> BuildAsync(CancellationToken cancellationToken)
+        {
+            var graph = await BoreaServices.BuildAsync(
+                _root,
+                new ControlledHttpMessageHandler(snapshot),
+                new EmptyModRepository(),
+                cancellationToken);
+            return CliServices.From(
+                graph,
+                launcher: new LoaderLauncher(graph.Paths, _processStarter));
+        }
+
+        var exitCode = await BoreaCli.RunAsync(args, BuildAsync, output, error, CancellationToken.None);
+        return new CliRun(exitCode, output.ToString(), error.ToString());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    private sealed class ControlledHttpMessageHandler(string snapshot) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.RequestUri?.AbsoluteUri != "https://ksamodding.github.io/content-index-releases/v1/index.json")
+                throw new InvalidOperationException($"Unexpected request to {request.RequestUri}.");
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(snapshot, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class EmptyModRepository : IModRepository
+    {
+        public Task<IReadOnlyList<ModMetadata>> GetAvailableModsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<ModMetadata>>([]);
+
+        public Task<ModVersionMetadata?> GetLatestReleaseAsync(
+            string modId,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<ModVersionMetadata?>(null);
+
+        public Task<ModVersionMetadata?> GetReleaseAsync(
+            string modId,
+            ModVersion version,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<ModVersionMetadata?>(null);
+
+        public Task<IReadOnlyList<ModVersion>> GetAvailableVersionsAsync(
+            string modId,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<ModVersion>>([]);
+
+        public Task<IReadOnlyList<ModMetadata>> SearchAsync(
+            string query,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<ModMetadata>>([]);
+    }
+}

--- a/tests/Borea.Cli.Tests/SettingsCommandTests.cs
+++ b/tests/Borea.Cli.Tests/SettingsCommandTests.cs
@@ -67,45 +67,43 @@ public sealed class SettingsCommandTests : IDisposable
     }
 
     [Fact]
-    public async Task SetLoader_AddsTheLoader_AndKeepsTheRest()
+    public async Task SetLoader_AdoptsTheLoader_AndKeepsTheGame()
     {
         var game = Path.Combine(_host.Root, "Game");
-        var starMap = Path.Combine(_host.Root, "StarMap");
-        var other = Path.Combine(_host.Root, "Other");
+        var starMap = LoaderCommandTests.CreateLoaderDirectory("StarMap", "not a program", _host.Root, game);
+        _host.Mods.Listings.Add(LoaderFixtures.Listing());
+        _host.Mods.Releases.Add(LoaderFixtures.Release());
 
         await _host.RunAsync("settings", "set", "game", game);
-        var first = await _host.RunAsync("settings", "set", "loader", "StarMap", starMap);
-        var second = await _host.RunAsync("settings", "set", "loader", "Other-Loader", other);
+        var set = await _host.RunAsync("settings", "set", "loader", "StarMap", starMap);
         var show = await _host.RunAsync("settings", "show", "--json");
 
-        Assert.Equal(0, first.ExitCode);
-        Assert.Equal(0, second.ExitCode);
+        Assert.Equal(0, set.ExitCode);
+        Assert.Contains("Adopted StarMap", set.Output);
         Assert.Equal(game, show.Json.GetProperty("gameDirectory").GetString());
         var loaders = show.Json.GetProperty("loaderDirectories");
         Assert.Equal(starMap, loaders.GetProperty("StarMap").GetString());
-        Assert.Equal(other, loaders.GetProperty("Other-Loader").GetString());
     }
 
     [Fact]
-    public async Task SetLoader_SameIdInAnotherCase_ReplacesTheEntry()
+    public async Task SetLoader_MissingLaunchFile_FailsWithoutWritingARecord()
     {
-        var first = Path.Combine(_host.Root, "First");
-        var second = Path.Combine(_host.Root, "Second");
+        var directory = Directory.CreateDirectory(Path.Combine(_host.Root, "StarMap")).FullName;
+        _host.Mods.Listings.Add(LoaderFixtures.Listing());
 
-        await _host.RunAsync("settings", "set", "loader", "StarMap", first);
-        await _host.RunAsync("settings", "set", "loader", "starmap", second);
+        var set = await _host.RunAsync("settings", "set", "loader", "StarMap", directory);
         var show = await _host.RunAsync("settings", "show", "--json");
 
-        var loaders = show.Json.GetProperty("loaderDirectories").EnumerateObject().ToList();
-        var loader = Assert.Single(loaders);
-        Assert.Equal("starmap", loader.Name);
-        Assert.Equal(second, loader.Value.GetString());
+        Assert.Equal(1, set.ExitCode);
+        Assert.Contains("does not hold the listed launch file", set.Error);
+        Assert.Empty(show.Json.GetProperty("loaderDirectories").EnumerateObject());
     }
 
     [Fact]
     public async Task Show_ListsTheLoaders()
     {
-        var starMap = Path.Combine(_host.Root, "StarMap");
+        var starMap = LoaderCommandTests.CreateLoaderDirectory("StarMap", "not a program", _host.Root);
+        _host.Mods.Listings.Add(LoaderFixtures.Listing());
 
         await _host.RunAsync("settings", "set", "loader", "StarMap", starMap);
         var show = await _host.RunAsync("settings", "show");

--- a/tests/Borea.Composition.Tests/BoreaServicesTests.cs
+++ b/tests/Borea.Composition.Tests/BoreaServicesTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Borea.Core.Dependencies;
 using Borea.Core.Index;
 using Borea.Core.ModLoaders;
+using Borea.Storage.Launch;
 using Borea.Core.Mods;
 using Borea.Core.Settings;
 using Borea.Network.Index;
@@ -126,6 +127,7 @@ public sealed class BoreaServicesTests : IDisposable
         Assert.IsType<FileLoaderAdopter>(services.LoaderAdopter);
         Assert.IsType<FileLoaderUninstaller>(services.LoaderUninstaller);
         Assert.IsType<GameDirectoryChanger>(services.GameDirectoryChanger);
+        Assert.IsType<LoaderLauncher>(services.Launcher);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #103

The CLI can now install, adopt and uninstall loaders, and launch an instance through an installed loader.
The loader setting uses the existing adoption service, including its warnings for an unreadable version and a different configured game path.
Explicit yanked releases are refused before installation, and cancellation is checked before process startup.

Stacked on #111.
