### PR TITLE
Adopt existing foreign mod installations

### DIFF
--- a/src/Borea.Composition/BoreaServices.cs
+++ b/src/Borea.Composition/BoreaServices.cs
@@ -78,6 +78,8 @@ public sealed class BoreaServices : IDisposable
 
     public required IModUninstaller Uninstaller { get; init; }
 
+    public required IForeignModAdopter ForeignModAdopter { get; init; }
+
     /// <summary>
     /// Every mod source behind one repository, each listing tagged with its source.
     /// </summary>
@@ -175,6 +177,7 @@ public sealed class BoreaServices : IDisposable
         var downloader = new HttpModDownloader(http);
         var settingsRepository = new FileBoreaSettingsRepository(paths);
         var loaderConfiguration = new LoaderConfigurator();
+        var instances = new FileInstanceRepository(paths);
 
         return new BoreaServices(http)
         {
@@ -182,11 +185,12 @@ public sealed class BoreaServices : IDisposable
             Paths = paths,
             SettingsRepository = settingsRepository,
             GameDirectoryChanger = new GameDirectoryChanger(settingsRepository, mods, loaderConfiguration),
-            Instances = new FileInstanceRepository(paths),
+            Instances = instances,
             ModState = new FileModStateRepository(paths),
             ModFavorites = new FileModFavoritesRepository(paths),
             ModPackFavorites = new FileModPackFavoritesRepository(paths),
-            Uninstaller = new FileModUninstaller(paths),
+            Uninstaller = new FileModUninstaller(paths, instances),
+            ForeignModAdopter = new FileForeignModAdopter(paths, instances, contentIndex),
             Mods = mods,
             Downloader = downloader,
             LoaderInstaller = new FileLoaderInstaller(paths, downloader, settingsRepository, loaderConfiguration),

--- a/src/Borea.Core/Dependencies/LocalDependencyEvaluation.cs
+++ b/src/Borea.Core/Dependencies/LocalDependencyEvaluation.cs
@@ -1,0 +1,8 @@
+using Borea.Core.Mods;
+
+namespace Borea.Core.Dependencies;
+
+public sealed record LocalDependencyEvaluation(
+    LocalModDependency Dependency,
+    DependencyOutcome Outcome,
+    string? InstalledModId = null);

--- a/src/Borea.Core/Dependencies/ModDependencyResolver.cs
+++ b/src/Borea.Core/Dependencies/ModDependencyResolver.cs
@@ -1,4 +1,4 @@
-﻿using Borea.Core.Instances;
+using Borea.Core.Instances;
 using Borea.Core.Mods;
 
 namespace Borea.Core.Dependencies;
@@ -35,6 +35,24 @@ public sealed class ModDependencyResolver
             .Select(e => e.Dependency)
             .ToList();
 
+    public IReadOnlyList<LocalDependencyEvaluation> EvaluateForeign(Instance instance, ForeignMod foreignMod)
+    {
+        ArgumentNullException.ThrowIfNull(instance);
+        ArgumentNullException.ThrowIfNull(foreignMod);
+
+        return foreignMod.Dependencies
+            .Select(dependency =>
+            {
+                var installedModId = FindLocalDependency(instance, foreignMod, dependency.ModId);
+                return installedModId is null
+                    ? new LocalDependencyEvaluation(
+                        dependency,
+                        dependency.Optional ? DependencyOutcome.Offer : DependencyOutcome.Install)
+                    : new LocalDependencyEvaluation(dependency, DependencyOutcome.Satisfied, installedModId);
+            })
+            .ToList();
+    }
+
     /// <summary>
     /// Checks if a mod can be uninstalled from an instance, returning the list of dependent mods that would be affected.
     /// </summary>
@@ -49,6 +67,11 @@ public sealed class ModDependencyResolver
             .Select(m => m.ModId)
             .ToList();
 
+        dependents.AddRange(instance.ForeignMods
+            .Where(mod => !ModIds.Equals(mod.ModId, modId))
+            .Where(mod => mod.Dependencies.Any(dependency => !dependency.Optional && ModIds.Equals(dependency.ModId, modId)))
+            .Select(mod => mod.ModId));
+
         return new UninstallCheck(instance.InstanceId, modId, version, dependents, isActive);
     }
 
@@ -59,17 +82,39 @@ public sealed class ModDependencyResolver
 
         if (dependency.IsAnyOf)
         {
+            string? unknownAlternativeId = null;
             foreach (var alternative in dependency.AnyOf)
             {
                 var alternativeMatch = FindInstalled(instance, alternative.ModId);
                 if (alternativeMatch is not null && alternative.BoundsContain(alternativeMatch.Version))
                     return new DependencyEvaluation(dependency, DependencyOutcome.Satisfied, installedModId: alternativeMatch.ModId);
+
+                if (FindForeign(instance, alternative.ModId) is { } foreign)
+                {
+                    if (alternative.MinVersion is null && alternative.MaxVersion is null)
+                        return new DependencyEvaluation(dependency, DependencyOutcome.Satisfied, installedModId: foreign.ModId);
+
+                    unknownAlternativeId = foreign.ModId;
+                }
             }
+
+            if (unknownAlternativeId is not null)
+                return new DependencyEvaluation(dependency, DependencyOutcome.Unknown, installedModId: unknownAlternativeId);
 
             return new DependencyEvaluation(dependency, MissingOutcome(dependency.Kind));
         }
 
         var match = FindInstalled(instance, dependency.ModId);
+
+        if (match is null && FindForeign(instance, dependency.ModId) is { } foreignMatch)
+        {
+            if (dependency.MinVersion is not null || dependency.MaxVersion is not null)
+                return new DependencyEvaluation(dependency, DependencyOutcome.Unknown, installedModId: foreignMatch.ModId);
+
+            return dependency.Kind == ModDependencyKind.Conflict
+                ? new DependencyEvaluation(dependency, DependencyOutcome.Conflict, installedModId: foreignMatch.ModId)
+                : new DependencyEvaluation(dependency, DependencyOutcome.Satisfied, installedModId: foreignMatch.ModId);
+        }
 
         if (match is null || !dependency.BoundsContain(match.Version))
         {
@@ -136,7 +181,7 @@ public sealed class ModDependencyResolver
             if (!removedSatisfies)
                 return false;
 
-            return !dependency.AnyOf.Any(a => !ModIds.Equals(a.ModId, removedId) && FindInstalled(instance, a.ModId) is { } m && a.BoundsContain(m.Version));
+            return !dependency.AnyOf.Any(a => !ModIds.Equals(a.ModId, removedId) && AlternativeIsSatisfied(instance, a));
         }
 
         return ModIds.Equals(dependency.ModId, removedId) && dependency.BoundsContain(removedVersion);
@@ -144,4 +189,29 @@ public sealed class ModDependencyResolver
 
     private static InstalledMod? FindInstalled(Instance instance, string modId)
         => instance.Mods.FirstOrDefault(m => ModIds.Equals(m.ModId, modId));
+
+    private static ForeignMod? FindForeign(Instance instance, string modId)
+        => instance.ForeignMods.FirstOrDefault(m => ModIds.Equals(m.ModId, modId));
+
+    private static string? FindLocalDependency(Instance instance, ForeignMod dependent, string modId)
+    {
+        var installed = FindInstalled(instance, modId);
+        if (installed is not null)
+            return installed.ModId;
+
+        return instance.ForeignMods
+            .Where(mod => !ReferenceEquals(mod, dependent))
+            .FirstOrDefault(mod => ModIds.Equals(mod.ModId, modId))
+            ?.ModId;
+    }
+
+    private static bool AlternativeIsSatisfied(Instance instance, ModDependencyAlternative alternative)
+    {
+        if (FindInstalled(instance, alternative.ModId) is { } installed)
+            return alternative.BoundsContain(installed.Version);
+
+        return alternative.MinVersion is null
+            && alternative.MaxVersion is null
+            && FindForeign(instance, alternative.ModId) is not null;
+    }
 }

--- a/src/Borea.Core/Instances/IInstanceRepository.cs
+++ b/src/Borea.Core/Instances/IInstanceRepository.cs
@@ -1,4 +1,4 @@
-﻿namespace Borea.Core.Instances;
+namespace Borea.Core.Instances;
 
 /// <summary>
 /// Owns the identity, naming, and lifecycle of instances.
@@ -31,4 +31,14 @@ public interface IInstanceRepository
     Task DeleteAsync(Guid instanceId);
 
     Task SaveAsync(Instance instance);
+
+    /// <summary>
+    /// Loads, changes, and saves one instance while other changes to that
+    /// instance wait. The change is not saved if <paramref name="update"/>
+    /// throws.
+    /// </summary>
+    Task<TResult> UpdateAsync<TResult>(
+        Guid instanceId,
+        Func<Instance, TResult> update,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Borea.Core/Instances/Instance.cs
+++ b/src/Borea.Core/Instances/Instance.cs
@@ -1,4 +1,4 @@
-﻿using Borea.Core.Mods;
+using Borea.Core.Mods;
 using System.Collections.ObjectModel;
 
 namespace Borea.Core.Instances;
@@ -10,6 +10,7 @@ namespace Borea.Core.Instances;
 public sealed class Instance
 {
     private readonly List<InstalledMod> _mods;
+    private readonly List<ForeignMod> _foreignMods;
 
     /// <summary>
     /// Immutable identifier assigned at creation. Used as the instance's folder name
@@ -28,16 +29,35 @@ public sealed class Instance
 
     public IReadOnlyList<InstalledMod> Mods => new ReadOnlyCollection<InstalledMod>(_mods);
 
+    public IReadOnlyList<ForeignMod> ForeignMods => new ReadOnlyCollection<ForeignMod>(_foreignMods);
+
     public bool IsFavorite { get; private set; }
 
-    public Instance(string name, InstanceSource source) : this(Guid.NewGuid(), name, source, DateTimeOffset.UtcNow, Array.Empty<InstalledMod>())
+    public Instance(string name, InstanceSource source) : this(Guid.NewGuid(), name, source, DateTimeOffset.UtcNow, Array.Empty<InstalledMod>(), Array.Empty<ForeignMod>())
     {
     }
 
     public static Instance FromExisting(Guid instanceId, string name, InstanceSource source, DateTimeOffset createdAt, IReadOnlyList<InstalledMod> mods, bool isFavorite)
-        => new(instanceId, name, source, createdAt, mods, isFavorite);
+        => new(instanceId, name, source, createdAt, mods, Array.Empty<ForeignMod>(), isFavorite);
 
-    private Instance(Guid instanceId, string name, InstanceSource source, DateTimeOffset createdAt, IReadOnlyList<InstalledMod> mods, bool isFavorite = false)
+    public static Instance FromExisting(
+        Guid instanceId,
+        string name,
+        InstanceSource source,
+        DateTimeOffset createdAt,
+        IReadOnlyList<InstalledMod> mods,
+        IReadOnlyList<ForeignMod> foreignMods,
+        bool isFavorite)
+        => new(instanceId, name, source, createdAt, mods, foreignMods, isFavorite);
+
+    private Instance(
+        Guid instanceId,
+        string name,
+        InstanceSource source,
+        DateTimeOffset createdAt,
+        IReadOnlyList<InstalledMod> mods,
+        IReadOnlyList<ForeignMod> foreignMods,
+        bool isFavorite = false)
     {
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException("Instance name cannot be null or whitespace.", nameof(name));
@@ -45,11 +65,15 @@ public sealed class Instance
         if (mods is null)
             throw new ArgumentNullException(nameof(mods));
 
+        if (foreignMods is null)
+            throw new ArgumentNullException(nameof(foreignMods));
+
         InstanceId = instanceId;
         Name = name;
         Source = source ?? throw new ArgumentNullException(nameof(source));
         CreatedAt = createdAt;
         _mods = mods.ToList();
+        _foreignMods = foreignMods.ToList();
         IsFavorite = isFavorite;
 
         var duplicateId = _mods
@@ -58,6 +82,17 @@ public sealed class Instance
 
         if (duplicateId is not null)
             throw new ArgumentException($"Duplicate mod '{duplicateId}' in initial mod list.", nameof(mods));
+
+        var duplicateForeignFolder = _foreignMods
+            .GroupBy(m => m.FolderName, StringComparer.Ordinal)
+            .FirstOrDefault(g => g.Count() > 1)?.Key;
+
+        if (duplicateForeignFolder is not null)
+            throw new ArgumentException($"Duplicate foreign mod '{duplicateForeignFolder}' in initial mod list.", nameof(foreignMods));
+
+        var trackedForeignFolder = _foreignMods.FirstOrDefault(f => _mods.Any(m => ModIds.Equals(m.ModId, f.ModId)));
+        if (trackedForeignFolder is not null)
+            throw new ArgumentException($"Mod '{trackedForeignFolder.ModId}' cannot be both installed and foreign.", nameof(foreignMods));
     }
 
     public void Rename(string newName)
@@ -76,6 +111,9 @@ public sealed class Instance
         if (_mods.Any(m => ModIds.Equals(m.ModId, mod.ModId)))
             throw new InvalidOperationException($"Mod '{mod.ModId}' is already installed in this instance.");
 
+        if (_foreignMods.Any(m => ModIds.Equals(m.ModId, mod.ModId)))
+            throw new InvalidOperationException($"Mod '{mod.ModId}' is recorded as foreign in this instance.");
+
         _mods.Add(mod);
     }
 
@@ -90,6 +128,38 @@ public sealed class Instance
 
         _mods.Remove(existing);
         return true;
+    }
+
+    public void ReplaceForeignMods(IReadOnlyList<ForeignMod> foreignMods)
+    {
+        ArgumentNullException.ThrowIfNull(foreignMods);
+
+        var duplicateFolder = foreignMods
+            .GroupBy(m => m.FolderName, StringComparer.Ordinal)
+            .FirstOrDefault(g => g.Count() > 1)?.Key;
+        if (duplicateFolder is not null)
+            throw new ArgumentException($"Duplicate foreign mod '{duplicateFolder}'.", nameof(foreignMods));
+
+        var trackedFolder = foreignMods.FirstOrDefault(f => _mods.Any(m => ModIds.Equals(m.ModId, f.ModId)));
+        if (trackedFolder is not null)
+            throw new ArgumentException($"Mod '{trackedFolder.ModId}' is already installed.", nameof(foreignMods));
+
+        _foreignMods.Clear();
+        _foreignMods.AddRange(foreignMods);
+    }
+
+    public void AdoptForeignMod(InstalledMod mod)
+    {
+        ArgumentNullException.ThrowIfNull(mod);
+
+        if (mod.Ownership != ModInstallOwnership.Foreign)
+            throw new ArgumentException("An adopted mod must keep foreign file ownership.", nameof(mod));
+
+        var foreign = _foreignMods.FirstOrDefault(m => ModIds.Equals(m.ModId, mod.ModId))
+            ?? throw new InvalidOperationException($"Mod '{mod.ModId}' is not recorded as foreign in this instance.");
+
+        _foreignMods.Remove(foreign);
+        _mods.Add(mod);
     }
 
     public void SetFavorite(bool isFavorite) => IsFavorite = isFavorite;

--- a/src/Borea.Core/Mods/ForeignMod.cs
+++ b/src/Borea.Core/Mods/ForeignMod.cs
@@ -1,0 +1,34 @@
+using System.Collections.ObjectModel;
+using Borea.Core.Game;
+
+namespace Borea.Core.Mods;
+
+public sealed class ForeignMod
+{
+    private readonly IReadOnlyList<LocalModDependency> _dependencies;
+
+    public string FolderName { get; }
+    public string ModId => FolderName;
+    public ModVersion? Version => null;
+    public GameCompatibility Compatibility => GameCompatibility.Unknown;
+    public IReadOnlyList<LocalModDependency> Dependencies => _dependencies;
+    public string? DependencyReadError { get; }
+
+    public ForeignMod(
+        string folderName,
+        IReadOnlyList<LocalModDependency>? dependencies = null,
+        string? dependencyReadError = null)
+    {
+        if (string.IsNullOrWhiteSpace(folderName))
+            throw new ArgumentException("Folder name cannot be null or whitespace.", nameof(folderName));
+
+        if (folderName is "." or ".."
+            || folderName.IndexOf(Path.DirectorySeparatorChar) >= 0
+            || folderName.IndexOf(Path.AltDirectorySeparatorChar) >= 0)
+            throw new ArgumentException("Folder name must not contain a path.", nameof(folderName));
+
+        FolderName = folderName;
+        _dependencies = new ReadOnlyCollection<LocalModDependency>((dependencies ?? Array.Empty<LocalModDependency>()).ToArray());
+        DependencyReadError = dependencyReadError;
+    }
+}

--- a/src/Borea.Core/Mods/IForeignModAdopter.cs
+++ b/src/Borea.Core/Mods/IForeignModAdopter.cs
@@ -1,0 +1,16 @@
+namespace Borea.Core.Mods;
+
+public interface IForeignModAdopter
+{
+    Task<IReadOnlyList<ForeignMod>> ScanAsync(Guid instanceId, CancellationToken cancellationToken = default);
+
+    Task<ForeignModAdoptionResult> AdoptArchiveAsync(
+        Guid instanceId,
+        string folderName,
+        string archivePath,
+        CancellationToken cancellationToken = default);
+}
+public sealed record ForeignModAdoptionResult(string Sha256, ForeignMod? ForeignMod, InstalledMod? InstalledMod)
+{
+    public bool Matched => InstalledMod is not null;
+}

--- a/src/Borea.Core/Mods/IModArchiveReleaseLookup.cs
+++ b/src/Borea.Core/Mods/IModArchiveReleaseLookup.cs
@@ -1,0 +1,6 @@
+namespace Borea.Core.Mods;
+
+public interface IModArchiveReleaseLookup
+{
+    Task<ModVersionMetadata?> FindBySha256Async(string modId, string sha256, CancellationToken cancellationToken = default);
+}

--- a/src/Borea.Core/Mods/IModUninstaller.cs
+++ b/src/Borea.Core/Mods/IModUninstaller.cs
@@ -1,13 +1,14 @@
-﻿namespace Borea.Core.Mods;
+namespace Borea.Core.Mods;
 
 /// <summary>
-/// Removes an installed mod's files from a specific instance.
+/// Removes Borea-owned mod files from a specific instance.
 /// </summary>
 public interface IModUninstaller
 {
     /// <summary>
-    /// Uninstalls a mod from the specified instance by removing its files. Does not check for dependencies.
-    /// No-op if the mod does not exist.
+    /// Removes files only when the installed record says Borea owns them.
+    /// A missing record or a foreign record leaves the folder unchanged. A
+    /// Borea record without a verifiable ownership marker causes an error.
     /// </summary>
     /// <param name="instanceId">The ID of the instance to remove the mod from</param>
     /// <param name="modId">The ID of the mod to uninstall</param>

--- a/src/Borea.Core/Mods/InstalledMod.cs
+++ b/src/Borea.Core/Mods/InstalledMod.cs
@@ -1,4 +1,4 @@
-﻿using Borea.Core.Dependencies;
+using Borea.Core.Dependencies;
 using System.Collections.ObjectModel;
 
 namespace Borea.Core.Mods;
@@ -26,7 +26,21 @@ public sealed class InstalledMod
     /// </summary>
     public string? Checksum { get; }
 
-    public InstalledMod(string modId, ModVersion version, InstallReason reason, DateTimeOffset installedAt, ModVersionMetadata metadata, string? checksum = null)
+    public ModInstallOwnership Ownership { get; }
+
+    public string? OwnershipToken { get; }
+
+    public bool CanDeleteFiles => Ownership == ModInstallOwnership.Borea && !string.IsNullOrWhiteSpace(OwnershipToken);
+
+    public InstalledMod(
+        string modId,
+        ModVersion version,
+        InstallReason reason,
+        DateTimeOffset installedAt,
+        ModVersionMetadata metadata,
+        string? checksum = null,
+        ModInstallOwnership ownership = ModInstallOwnership.Borea,
+        string? ownershipToken = null)
     {
         if (string.IsNullOrWhiteSpace(modId))
             throw new ArgumentException("Mod ID cannot be null or whitespace.", nameof(modId));
@@ -43,6 +57,11 @@ public sealed class InstalledMod
         InstalledAt = installedAt;
         Metadata = metadata;
         Checksum = checksum;
+        Ownership = ownership;
+        OwnershipToken = ownershipToken;
+
+        if (ownership == ModInstallOwnership.Foreign && !string.IsNullOrWhiteSpace(ownershipToken))
+            throw new ArgumentException("A foreign mod cannot have a Borea ownership token.", nameof(ownershipToken));
     }
 
     public void MarkAsManuallyInstalled()

--- a/src/Borea.Core/Mods/LocalModDependency.cs
+++ b/src/Borea.Core/Mods/LocalModDependency.cs
@@ -1,0 +1,16 @@
+namespace Borea.Core.Mods;
+
+public sealed record LocalModDependency
+{
+    public string ModId { get; }
+    public bool Optional { get; }
+
+    public LocalModDependency(string modId, bool optional)
+    {
+        if (string.IsNullOrWhiteSpace(modId))
+            throw new ArgumentException("Mod ID cannot be null or whitespace.", nameof(modId));
+
+        ModId = modId;
+        Optional = optional;
+    }
+}

--- a/src/Borea.Core/Mods/ModInstallOwnership.cs
+++ b/src/Borea.Core/Mods/ModInstallOwnership.cs
@@ -1,0 +1,7 @@
+namespace Borea.Core.Mods;
+
+public enum ModInstallOwnership
+{
+    Borea,
+    Foreign,
+}

--- a/src/Borea.Network/Index/ContentIndexModRepository.cs
+++ b/src/Borea.Network/Index/ContentIndexModRepository.cs
@@ -9,7 +9,7 @@ namespace Borea.Network.Index;
 /// Successful snapshots are revalidated at most once per index watcher interval,
 /// and overlapping callers share one refresh and parse operation.
 /// </summary>
-public sealed class ContentIndexModRepository : IContentIndexRepository, IModIdClaimSource
+public sealed class ContentIndexModRepository : IContentIndexRepository, IModIdClaimSource, IModArchiveReleaseLookup
 {
     public const string SourceName = "index";
 
@@ -93,6 +93,24 @@ public sealed class ContentIndexModRepository : IContentIndexRepository, IModIdC
     {
         var snapshot = await GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
         return snapshot.Diagnostics;
+    }
+
+    public async Task<ModVersionMetadata?> FindBySha256Async(
+        string modId,
+        string sha256,
+        CancellationToken cancellationToken = default)
+    {
+        var listing = await FindListingAsync(modId, cancellationToken).ConfigureAwait(false);
+        if (listing?.Authored?.Type != ContentType.Mod)
+            return null;
+
+        var matches = listing.Releases
+            .Where(release => release.Type == ContentType.Mod)
+            .Where(release => ModIds.Equals(release.ModId, listing.Id))
+            .Where(release => string.Equals(release.Download.Sha256, sha256, StringComparison.OrdinalIgnoreCase))
+            .Take(2)
+            .ToArray();
+        return matches.Length == 1 ? matches[0] : null;
     }
 
     public async Task<IReadOnlyList<string>> GetClaimedModIdsAsync(

--- a/src/Borea.Storage/Instances/FileInstanceRepository.cs
+++ b/src/Borea.Storage/Instances/FileInstanceRepository.cs
@@ -1,4 +1,4 @@
-﻿using Borea.Core.Instances;
+using Borea.Core.Instances;
 using Borea.Core.Paths;
 using Borea.Storage.Toml;
 
@@ -14,6 +14,7 @@ namespace Borea.Storage.Instances;
 public sealed class FileInstanceRepository : IInstanceRepository
 {
     private readonly IGamePathProvider _pathProvider;
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<Guid, SemaphoreSlim> _instanceLocks = new();
 
     public FileInstanceRepository(IGamePathProvider pathProvider)
     {
@@ -60,6 +61,9 @@ public sealed class FileInstanceRepository : IInstanceRepository
     /// Returns the instance with the given ID, or null if it does not exist.
     /// </summary>
     public async Task<Instance?> GetByIdAsync(Guid instanceId)
+        => await GetByIdCoreAsync(instanceId).ConfigureAwait(false);
+
+    private async Task<Instance?> GetByIdCoreAsync(Guid instanceId)
     {
         var path = _pathProvider.GetInstanceMetadataPath(instanceId);
         var dto = await TomlFileStore.ReadAsync<InstanceDto>(path).ConfigureAwait(false);
@@ -96,40 +100,91 @@ public sealed class FileInstanceRepository : IInstanceRepository
     /// </summary>
     public async Task RenameAsync(Guid instanceId, string newName)
     {
-        var instance = await GetByIdAsync(instanceId).ConfigureAwait(false)
-            ?? throw new InvalidOperationException($"No instance with ID '{instanceId}' exists.");
-
         if (!await IsNameAvailableAsync(newName, excludingInstanceId: instanceId).ConfigureAwait(false))
             throw new InvalidOperationException($"Instance name '{newName}' is already in use.");
 
-        instance.Rename(newName);
-        await SaveAsync(instance).ConfigureAwait(false);
+        await UpdateAsync(
+            instanceId,
+            instance =>
+            {
+                instance.Rename(newName);
+                return true;
+            }).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Deletes the instance with the given ID from disk. No-op if the instance does not exist.
     /// </summary>
-    public Task DeleteAsync(Guid instanceId)
+    public async Task DeleteAsync(Guid instanceId)
     {
-        var root = _pathProvider.GetInstanceRoot(instanceId);
-        if (Directory.Exists(root))
-            Directory.Delete(root, recursive: true);
-
-        return Task.CompletedTask;
+        var gate = GetInstanceLock(instanceId);
+        await gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            var root = _pathProvider.GetInstanceRoot(instanceId);
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+        finally
+        {
+            gate.Release();
+        }
     }
 
     /// <summary>
     /// Saves the given instance to disk, overwriting any existing metadata. Throws if the instance is null.
     /// </summary>
-    public Task SaveAsync(Instance instance)
+    public async Task SaveAsync(Instance instance)
     {
         if (instance is null)
             throw new ArgumentNullException(nameof(instance));
 
+        var gate = GetInstanceLock(instance.InstanceId);
+        await gate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await SaveCoreAsync(instance).ConfigureAwait(false);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    public async Task<TResult> UpdateAsync<TResult>(
+        Guid instanceId,
+        Func<Instance, TResult> update,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+
+        var gate = GetInstanceLock(instanceId);
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var instance = await GetByIdCoreAsync(instanceId).ConfigureAwait(false)
+                ?? throw new InvalidOperationException($"No instance with ID '{instanceId}' exists.");
+            cancellationToken.ThrowIfCancellationRequested();
+            var result = update(instance);
+            cancellationToken.ThrowIfCancellationRequested();
+            await SaveCoreAsync(instance).ConfigureAwait(false);
+            return result;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private Task SaveCoreAsync(Instance instance)
+    {
         var dto = InstanceMapper.ToDto(instance);
         var path = _pathProvider.GetInstanceMetadataPath(instance.InstanceId);
         return TomlFileStore.WriteAsync(path, dto);
     }
+
+    private SemaphoreSlim GetInstanceLock(Guid instanceId)
+        => _instanceLocks.GetOrAdd(instanceId, static _ => new SemaphoreSlim(1, 1));
 
     /// <summary>
     /// Returns the ID of the currently active instance, or null if no instance is active.

--- a/src/Borea.Storage/Instances/InstanceDto.cs
+++ b/src/Borea.Storage/Instances/InstanceDto.cs
@@ -1,4 +1,4 @@
-﻿using Borea.Storage.Mods;
+using Borea.Storage.Mods;
 
 namespace Borea.Storage.Instances;
 
@@ -12,7 +12,7 @@ public sealed class InstanceDto
     public DateTimeOffset CreatedAt { get; set; }
     public bool IsFavorite { get; set; }
 
-    /// <summary>"ModPack" or "Custom" — discriminator for InstanceSource.</summary>
+    /// <summary>"ModPack" or "Custom" discriminator for InstanceSource.</summary>
     public string SourceType { get; set; } = string.Empty;
 
     /// <summary>Only populated when SourceType is "ModPack".</summary>
@@ -22,4 +22,5 @@ public sealed class InstanceDto
     public string? SourceModPackVersion { get; set; }
 
     public List<InstalledModDto> Mods { get; set; } = new();
+    public List<ForeignModDto> ForeignMods { get; set; } = new();
 }

--- a/src/Borea.Storage/Instances/InstanceMapper.cs
+++ b/src/Borea.Storage/Instances/InstanceMapper.cs
@@ -1,4 +1,4 @@
-﻿using Borea.Core.Instances;
+using Borea.Core.Instances;
 using Borea.Core.Mods;
 using Borea.Storage.Mods;
 
@@ -25,6 +25,7 @@ public static class InstanceMapper
             SourceModPackId = modPackId,
             SourceModPackVersion = modPackVersion,
             Mods = instance.Mods.Select(InstalledModMapper.ToDto).ToList(),
+            ForeignMods = instance.ForeignMods.Select(ForeignModMapper.ToDto).ToList(),
         };
     }
 
@@ -44,7 +45,8 @@ public static class InstanceMapper
         };
 
         var mods = dto.Mods.Select(InstalledModMapper.FromDto).ToList();
+        var foreignMods = dto.ForeignMods.Select(ForeignModMapper.FromDto).ToList();
 
-        return Instance.FromExisting(instanceId, dto.Name, source, dto.CreatedAt, mods, dto.IsFavorite);
+        return Instance.FromExisting(instanceId, dto.Name, source, dto.CreatedAt, mods, foreignMods, dto.IsFavorite);
     }
 }

--- a/src/Borea.Storage/Mods/FileForeignModAdopter.cs
+++ b/src/Borea.Storage/Mods/FileForeignModAdopter.cs
@@ -1,0 +1,234 @@
+using System.Security.Cryptography;
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+using Borea.Core.Paths;
+using Tomlyn;
+using Tomlyn.Serialization;
+
+namespace Borea.Storage.Mods;
+
+public sealed class FileForeignModAdopter : IForeignModAdopter
+{
+    private readonly IGamePathProvider _pathProvider;
+    private readonly IInstanceRepository _instances;
+    private readonly IModArchiveReleaseLookup _releaseLookup;
+    private readonly TimeProvider _timeProvider;
+
+    public FileForeignModAdopter(
+        IGamePathProvider pathProvider,
+        IInstanceRepository instances,
+        IModArchiveReleaseLookup releaseLookup,
+        TimeProvider? timeProvider = null)
+    {
+        _pathProvider = pathProvider ?? throw new ArgumentNullException(nameof(pathProvider));
+        _instances = instances ?? throw new ArgumentNullException(nameof(instances));
+        _releaseLookup = releaseLookup ?? throw new ArgumentNullException(nameof(releaseLookup));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public async Task<IReadOnlyList<ForeignMod>> ScanAsync(
+        Guid instanceId,
+        CancellationToken cancellationToken = default)
+    {
+        _ = await GetInstanceAsync(instanceId).ConfigureAwait(false);
+        var modsFolder = _pathProvider.GetInstanceModsFolder(instanceId);
+        var foreignMods = new List<ForeignMod>();
+
+        if (Directory.Exists(modsFolder))
+        {
+            foreach (var directory in Directory.EnumerateDirectories(modsFolder)
+                .OrderBy(path => Path.GetFileName(path), ModIds.Comparer)
+                .ThenBy(path => Path.GetFileName(path), StringComparer.Ordinal))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var definitionPath = Path.Combine(directory, ModFolders.DefinitionFileName);
+                if (!File.Exists(definitionPath))
+                    continue;
+
+                var folderName = Path.GetFileName(directory);
+                foreignMods.Add(await ReadForeignModAsync(folderName, definitionPath, cancellationToken).ConfigureAwait(false));
+            }
+        }
+
+        return await _instances.UpdateAsync(
+            instanceId,
+            instance =>
+            {
+                var current = foreignMods
+                    .Where(foreign => !instance.Mods.Any(mod => ModIds.Equals(mod.ModId, foreign.ModId)))
+                    .ToList();
+                instance.ReplaceForeignMods(current);
+                return instance.ForeignMods;
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<ForeignModAdoptionResult> AdoptArchiveAsync(
+        Guid instanceId,
+        string folderName,
+        string archivePath,
+        CancellationToken cancellationToken = default)
+    {
+        _ = new ForeignMod(folderName);
+        if (string.IsNullOrWhiteSpace(archivePath))
+            throw new ArgumentException("Archive path cannot be null or whitespace.", nameof(archivePath));
+
+        _ = await GetInstanceAsync(instanceId).ConfigureAwait(false);
+        var modsFolder = _pathProvider.GetInstanceModsFolder(instanceId);
+        var matchingFolders = Directory.Exists(modsFolder)
+            ? Directory.EnumerateDirectories(modsFolder)
+                .Where(path => ModIds.Equals(Path.GetFileName(path), folderName))
+                .ToList()
+            : new List<string>();
+        if (matchingFolders.Count > 1)
+            throw new InvalidOperationException($"More than one foreign folder has the ID '{folderName}'. Use unique folder spelling before adoption.");
+
+        var folder = matchingFolders.SingleOrDefault();
+        if (folder is null || !File.Exists(Path.Combine(folder, ModFolders.DefinitionFileName)))
+            throw new InvalidOperationException($"The instance has no foreign mod folder '{folderName}'.");
+
+        var actualFolderName = Path.GetFileName(folder);
+        if (!Path.IsPathFullyQualified(archivePath))
+            throw new ArgumentException("Archive path must be absolute.", nameof(archivePath));
+
+        var fullArchivePath = Path.GetFullPath(archivePath);
+        if (!File.Exists(fullArchivePath))
+            throw new FileNotFoundException("The imported archive does not exist.", fullArchivePath);
+
+        var sha256 = await ComputeSha256Async(fullArchivePath, cancellationToken).ConfigureAwait(false);
+        var release = await _releaseLookup.FindBySha256Async(actualFolderName, sha256, cancellationToken).ConfigureAwait(false);
+        if (release is null
+            || release.Type != ContentType.Mod
+            || !ModIds.Equals(release.ModId, actualFolderName)
+            || !string.Equals(release.Download.Sha256, sha256, StringComparison.OrdinalIgnoreCase))
+        {
+            var foreign = await ReadForeignModAsync(
+                actualFolderName,
+                Path.Combine(folder, ModFolders.DefinitionFileName),
+                cancellationToken).ConfigureAwait(false);
+            await StoreForeignAsync(instanceId, folder, foreign, cancellationToken).ConfigureAwait(false);
+            return new ForeignModAdoptionResult(sha256, foreign, null);
+        }
+
+        var installed = new InstalledMod(
+            actualFolderName,
+            release.Version,
+            InstallReason.Manual,
+            _timeProvider.GetUtcNow(),
+            release,
+            sha256,
+            ModInstallOwnership.Foreign);
+
+        var scannedForeign = await ReadForeignModAsync(
+            actualFolderName,
+            Path.Combine(folder, ModFolders.DefinitionFileName),
+            cancellationToken).ConfigureAwait(false);
+        await _instances.UpdateAsync(
+            instanceId,
+            instance =>
+            {
+                RequireForeignFolder(folder, actualFolderName);
+
+                if (instance.Mods.Any(mod => ModIds.Equals(mod.ModId, actualFolderName)))
+                    throw new InvalidOperationException($"Mod '{actualFolderName}' is already installed in this instance.");
+
+                if (!instance.ForeignMods.Any(mod => ModIds.Equals(mod.ModId, actualFolderName)))
+                {
+                    var current = instance.ForeignMods.ToList();
+                    current.Add(scannedForeign);
+                    instance.ReplaceForeignMods(current);
+                }
+
+                instance.AdoptForeignMod(installed);
+                return true;
+            },
+            cancellationToken).ConfigureAwait(false);
+        return new ForeignModAdoptionResult(sha256, null, installed);
+    }
+
+    private async Task<Instance> GetInstanceAsync(Guid instanceId)
+        => await _instances.GetByIdAsync(instanceId).ConfigureAwait(false)
+            ?? throw new InvalidOperationException($"No instance with ID '{instanceId}' exists.");
+
+    private async Task StoreForeignAsync(
+        Guid instanceId,
+        string folder,
+        ForeignMod foreign,
+        CancellationToken cancellationToken)
+    {
+        await _instances.UpdateAsync(
+            instanceId,
+            instance =>
+            {
+                RequireForeignFolder(folder, foreign.ModId);
+
+                if (instance.Mods.Any(mod => ModIds.Equals(mod.ModId, foreign.ModId)))
+                    throw new InvalidOperationException($"Mod '{foreign.ModId}' is already installed in this instance.");
+
+                var foreignMods = instance.ForeignMods
+                    .Where(mod => !ModIds.Equals(mod.ModId, foreign.ModId))
+                    .Append(foreign)
+                    .OrderBy(mod => mod.FolderName, ModIds.Comparer)
+                    .ThenBy(mod => mod.FolderName, StringComparer.Ordinal)
+                    .ToList();
+                instance.ReplaceForeignMods(foreignMods);
+                return true;
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void RequireForeignFolder(string folder, string folderName)
+    {
+        if (!Directory.Exists(folder) || !File.Exists(Path.Combine(folder, ModFolders.DefinitionFileName)))
+            throw new InvalidOperationException($"The instance no longer has the foreign mod folder '{folderName}'.");
+    }
+
+    private static async Task<ForeignMod> ReadForeignModAsync(
+        string folderName,
+        string definitionPath,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var text = await File.ReadAllTextAsync(definitionPath, cancellationToken).ConfigureAwait(false);
+            var manifest = TomlSerializer.Deserialize<LocalModManifestDto>(text);
+            var dependencies = manifest?.StarMap?.ModDependencies?
+                .Where(dependency => !string.IsNullOrWhiteSpace(dependency.ModId))
+                .Select(dependency => new LocalModDependency(dependency.ModId, dependency.Optional))
+                .ToList() ?? new List<LocalModDependency>();
+            return new ForeignMod(folderName, dependencies);
+        }
+        catch (Exception exception) when (exception is TomlException or IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            return new ForeignMod(folderName, dependencyReadError: exception.Message);
+        }
+    }
+
+    private static async Task<string> ComputeSha256Async(string path, CancellationToken cancellationToken)
+    {
+        await using var stream = File.OpenRead(path);
+        return Convert.ToHexString(await SHA256.HashDataAsync(stream, cancellationToken).ConfigureAwait(false));
+    }
+
+    private sealed class LocalModManifestDto
+    {
+        [TomlPropertyName("StarMap")]
+        public LocalStarMapDto? StarMap { get; set; }
+    }
+
+    private sealed class LocalStarMapDto
+    {
+        [TomlPropertyName("ModDependencies")]
+        public List<LocalDependencyDto>? ModDependencies { get; set; }
+    }
+
+    private sealed class LocalDependencyDto
+    {
+        [TomlPropertyName("ModId")]
+        public string ModId { get; set; } = string.Empty;
+
+        [TomlPropertyName("Optional")]
+        public bool Optional { get; set; }
+    }
+}

--- a/src/Borea.Storage/Mods/FileModInstaller.cs
+++ b/src/Borea.Storage/Mods/FileModInstaller.cs
@@ -61,17 +61,44 @@ public sealed class FileModInstaller : IModInstaller
 
         var archivePath = Path.Combine(Path.GetTempPath(), $"borea-download-{Guid.NewGuid():N}.zip");
         var modFolder = Path.Combine(modsFolder, release.ModId);
+        var stagingFolder = Path.Combine(_pathProvider.GetInstanceRoot(instanceId), $".borea-staging-{Guid.NewGuid():N}");
         var recorded = false;
+        string? ownershipToken = null;
 
         try
         {
             var download = await _downloader.DownloadAsync(release, archivePath, progress, cancellationToken).ConfigureAwait(false);
 
-            Unpack(archivePath, release, modFolder);
+            Unpack(archivePath, release, stagingFolder);
 
-            var installed = new InstalledMod(release.ModId, release.Version, reason, _timeProvider.GetUtcNow(), release, download.Sha256);
-            instance.AddMod(installed);
-            await _instances.SaveAsync(instance).ConfigureAwait(false);
+            ownershipToken = Guid.NewGuid().ToString("N");
+            await File.WriteAllTextAsync(
+                Path.Combine(stagingFolder, ModFolders.OwnershipFileName),
+                ownershipToken,
+                cancellationToken).ConfigureAwait(false);
+
+            var installed = new InstalledMod(
+                release.ModId,
+                release.Version,
+                reason,
+                _timeProvider.GetUtcNow(),
+                release,
+                download.Sha256,
+                ModInstallOwnership.Borea,
+                ownershipToken);
+            await _instances.UpdateAsync(
+                instanceId,
+                current =>
+                {
+                    if (ModFolders.Find(modsFolder, release.ModId) is not null)
+                        throw new InvalidOperationException($"The instance received a foreign folder for '{release.ModId}' while the archive downloaded.");
+
+                    Directory.CreateDirectory(modsFolder);
+                    Directory.Move(stagingFolder, modFolder);
+                    current.AddMod(installed);
+                    return true;
+                },
+                cancellationToken).ConfigureAwait(false);
             recorded = true;
 
             var entry = await _modState.AddEntryAsync(instanceId, release.ModId, enable, cancellationToken).ConfigureAwait(false);
@@ -80,16 +107,23 @@ public sealed class FileModInstaller : IModInstaller
         }
         catch
         {
-            TryDeleteDirectory(modFolder);
+            TryDeleteDirectory(stagingFolder);
+            if (ownershipToken is not null)
+            {
+                var ownedFolder = ModFolders.FindOwned(modsFolder, release.ModId, ownershipToken);
+                if (ownedFolder is not null)
+                    TryDeleteDirectory(ownedFolder);
+            }
 
             if (recorded)
-                await TryForgetAsync(instance, release.ModId).ConfigureAwait(false);
+                await TryForgetAsync(instanceId, release.ModId).ConfigureAwait(false);
 
             throw;
         }
         finally
         {
             TryDeleteFile(archivePath);
+            TryDeleteDirectory(stagingFolder);
         }
     }
 
@@ -148,12 +182,13 @@ public sealed class FileModInstaller : IModInstaller
     /// failure here is swallowed so the error that caused the rollback is the
     /// one the caller sees.
     /// </summary>
-    private async Task TryForgetAsync(Instance instance, string modId)
+    private async Task TryForgetAsync(Guid instanceId, string modId)
     {
-        instance.RemoveMod(modId);
         try
         {
-            await _instances.SaveAsync(instance).ConfigureAwait(false);
+            await _instances.UpdateAsync(
+                instanceId,
+                instance => instance.RemoveMod(modId)).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/src/Borea.Storage/Mods/FileModUninstaller.cs
+++ b/src/Borea.Storage/Mods/FileModUninstaller.cs
@@ -1,4 +1,4 @@
-﻿using Borea.Core.Mods;
+using Borea.Core.Mods;
 using Borea.Core.Paths;
 
 namespace Borea.Storage.Mods;
@@ -9,21 +9,39 @@ namespace Borea.Storage.Mods;
 public sealed class FileModUninstaller : IModUninstaller
 {
     private readonly IGamePathProvider _pathProvider;
+    private readonly Borea.Core.Instances.IInstanceRepository _instances;
 
-    public FileModUninstaller(IGamePathProvider pathProvider)
+    public FileModUninstaller(IGamePathProvider pathProvider, Borea.Core.Instances.IInstanceRepository instances)
     {
         _pathProvider = pathProvider ?? throw new ArgumentNullException(nameof(pathProvider));
+        _instances = instances ?? throw new ArgumentNullException(nameof(instances));
     }
 
-    public Task UninstallAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default)
+    public async Task UninstallAsync(Guid instanceId, string modId, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(modId))
             throw new ArgumentException("Mod ID cannot be null or whitespace.", nameof(modId));
 
-        var modDirectory = ModFolders.Find(_pathProvider.GetInstanceModsFolder(instanceId), modId);
-        if (modDirectory is not null)
-            Directory.Delete(modDirectory, recursive: true);
+        cancellationToken.ThrowIfCancellationRequested();
+        var instance = await _instances.GetByIdAsync(instanceId).ConfigureAwait(false);
+        var installed = instance?.Mods.FirstOrDefault(mod => ModIds.Equals(mod.ModId, modId));
+        if (installed is null || installed.Ownership == ModInstallOwnership.Foreign)
+            return;
 
-        return Task.CompletedTask;
+        if (!installed.CanDeleteFiles)
+        {
+            throw new InvalidOperationException(
+                $"Borea cannot verify ownership of the installed folder for '{installed.ModId}'. Remove it manually or install it again before uninstalling it.");
+        }
+
+        var modDirectory = ModFolders.FindOwned(
+            _pathProvider.GetInstanceModsFolder(instanceId),
+            installed.ModId,
+            installed.OwnershipToken!);
+        if (modDirectory is not null)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Directory.Delete(modDirectory, recursive: true);
+        }
     }
 }

--- a/src/Borea.Storage/Mods/ForeignModDto.cs
+++ b/src/Borea.Storage/Mods/ForeignModDto.cs
@@ -1,0 +1,13 @@
+namespace Borea.Storage.Mods;
+
+public sealed class ForeignModDto
+{
+    public string FolderName { get; set; } = string.Empty;
+    public List<LocalModDependencyDto> Dependencies { get; set; } = new();
+    public string? DependencyReadError { get; set; }
+}
+public sealed class LocalModDependencyDto
+{
+    public string ModId { get; set; } = string.Empty;
+    public bool Optional { get; set; }
+}

--- a/src/Borea.Storage/Mods/ForeignModMapper.cs
+++ b/src/Borea.Storage/Mods/ForeignModMapper.cs
@@ -1,0 +1,22 @@
+using Borea.Core.Mods;
+
+namespace Borea.Storage.Mods;
+
+public static class ForeignModMapper
+{
+    public static ForeignModDto ToDto(ForeignMod mod) => new()
+    {
+        FolderName = mod.FolderName,
+        Dependencies = mod.Dependencies.Select(dependency => new LocalModDependencyDto
+        {
+            ModId = dependency.ModId,
+            Optional = dependency.Optional,
+        }).ToList(),
+        DependencyReadError = mod.DependencyReadError,
+    };
+
+    public static ForeignMod FromDto(ForeignModDto dto) => new(
+        dto.FolderName,
+        dto.Dependencies.Select(dependency => new LocalModDependency(dependency.ModId, dependency.Optional)).ToList(),
+        dto.DependencyReadError);
+}

--- a/src/Borea.Storage/Mods/InstalledModDto.cs
+++ b/src/Borea.Storage/Mods/InstalledModDto.cs
@@ -1,4 +1,4 @@
-﻿namespace Borea.Storage.Mods;
+namespace Borea.Storage.Mods;
 
 /// <summary>
 /// TOML-serializable representation of an InstalledMod.
@@ -13,6 +13,8 @@ public sealed class InstalledModDto
 
     public DateTimeOffset InstalledAt { get; set; }
     public string? Checksum { get; set; }
+    public string? Ownership { get; set; }
+    public string? OwnershipToken { get; set; }
 
     /// <summary>The release the mod was installed from.</summary>
     public ModVersionMetadataDto Metadata { get; set; } = new();

--- a/src/Borea.Storage/Mods/InstalledModMapper.cs
+++ b/src/Borea.Storage/Mods/InstalledModMapper.cs
@@ -1,4 +1,4 @@
-﻿using Borea.Core.Mods;
+using Borea.Core.Mods;
 
 namespace Borea.Storage.Mods;
 
@@ -11,6 +11,8 @@ public static class InstalledModMapper
         Reason = mod.Reason.ToString(),
         InstalledAt = mod.InstalledAt,
         Checksum = mod.Checksum,
+        Ownership = mod.Ownership.ToString(),
+        OwnershipToken = mod.OwnershipToken,
         Metadata = ModVersionMetadataMapper.ToDto(mod.Metadata),
     };
 
@@ -20,5 +22,9 @@ public static class InstalledModMapper
         Enum.Parse<InstallReason>(dto.Reason),
         dto.InstalledAt,
         ModVersionMetadataMapper.FromDto(dto.Metadata),
-        dto.Checksum);
+        dto.Checksum,
+        string.IsNullOrWhiteSpace(dto.Ownership)
+            ? ModInstallOwnership.Borea
+            : Enum.Parse<ModInstallOwnership>(dto.Ownership),
+        dto.OwnershipToken);
 }

--- a/src/Borea.Storage/Mods/ModFolders.cs
+++ b/src/Borea.Storage/Mods/ModFolders.cs
@@ -10,6 +10,7 @@ internal static class ModFolders
 {
     /// <summary>The file that makes a folder a mod to the game (ModLibrary.AddMods).</summary>
     public const string DefinitionFileName = "mod.toml";
+    public const string OwnershipFileName = ".borea-owner";
 
     /// <summary>
     /// The folder under <paramref name="modsFolder"/> that carries the id, or
@@ -22,5 +23,41 @@ internal static class ModFolders
 
         return Directory.EnumerateDirectories(modsFolder)
             .FirstOrDefault(d => ModIds.Equals(Path.GetFileName(d), modId));
+    }
+
+    public static string? FindOwned(string modsFolder, string modId, string ownershipToken)
+    {
+        if (!Directory.Exists(modsFolder))
+            return null;
+
+        string? ownedFolder = null;
+        foreach (var directory in Directory.EnumerateDirectories(modsFolder)
+            .Where(path => ModIds.Equals(Path.GetFileName(path), modId)))
+        {
+            try
+            {
+                var markerPath = Path.Combine(directory, OwnershipFileName);
+                if (!File.Exists(markerPath)
+                    || !string.Equals(File.ReadAllText(markerPath), ownershipToken, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (ownedFolder is not null)
+                    return null;
+
+                ownedFolder = directory;
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return null;
+            }
+        }
+
+        return ownedFolder;
     }
 }

--- a/tests/Borea.Composition.Tests/BoreaServicesTests.cs
+++ b/tests/Borea.Composition.Tests/BoreaServicesTests.cs
@@ -1,8 +1,10 @@
 using System.Net;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Borea.Core.Dependencies;
 using Borea.Core.Index;
+using Borea.Core.Instances;
 using Borea.Core.ModLoaders;
 using Borea.Storage.Launch;
 using Borea.Core.Mods;
@@ -12,6 +14,7 @@ using Borea.Network.Sources;
 using Borea.Storage.Game;
 using Borea.Storage.Index;
 using Borea.Storage.ModLoaders;
+using Borea.Storage.Mods;
 using Borea.Storage.Paths;
 using Borea.Storage.Settings;
 
@@ -21,6 +24,7 @@ public sealed class BoreaServicesTests : IDisposable
 {
     private const string GamePath = @"C:\Games\KSA";
     private const string StarMapPath = @"C:\Games\StarMap";
+    private const string FixtureArchiveSha256 = "AD14E4FE8111F4DAE8406D50459B7E5C42D58F1E01F549636946922CF72AE9E6";
 
     private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
 
@@ -203,6 +207,69 @@ public sealed class BoreaServicesTests : IDisposable
     }
 
     [Fact]
+    public async Task ForeignModAdopter_MatchingIdAndArchive_PreservesForeignFolderOwnership()
+    {
+        byte[] archiveBytes = [1, 2, 3, 4];
+        var snapshot = await SnapshotWithArchiveHashAsync(archiveBytes);
+        using var services = await BoreaServices.BuildAsync(
+            _tempRoot,
+            new ControlledHttpMessageHandler(snapshot),
+            new ConflictingStarMapRepository());
+        Assert.IsType<FileForeignModAdopter>(services.ForeignModAdopter);
+        var instance = await services.Instances.CreateAsync("Test", InstanceSource.Custom.Value);
+        var folder = WriteForeignMod(services, instance.InstanceId, "AdvancedFlightComputer");
+        var payload = Path.Combine(folder, "keep.txt");
+        await File.WriteAllTextAsync(payload, "Keep these bytes.");
+        var archive = await WriteArchiveAsync(archiveBytes);
+        await services.ForeignModAdopter.ScanAsync(instance.InstanceId);
+
+        var result = await services.ForeignModAdopter.AdoptArchiveAsync(
+            instance.InstanceId,
+            "advancedflightcomputer",
+            archive);
+        await services.Uninstaller.UninstallAsync(instance.InstanceId, "AdvancedFlightComputer");
+
+        Assert.True(result.Matched);
+        Assert.Equal(ModInstallOwnership.Foreign, result.InstalledMod!.Ownership);
+        Assert.False(result.InstalledMod.CanDeleteFiles);
+        Assert.True(Directory.Exists(folder));
+        Assert.Equal("Keep these bytes.", await File.ReadAllTextAsync(payload));
+        var saved = await services.Instances.GetByIdAsync(instance.InstanceId);
+        Assert.Empty(saved!.ForeignMods);
+        Assert.Equal(ModInstallOwnership.Foreign, Assert.Single(saved.Mods).Ownership);
+    }
+
+    [Theory]
+    [InlineData("OtherMod", true)]
+    [InlineData("AdvancedFlightComputer", false)]
+    public async Task ForeignModAdopter_WrongIdOrUnknownArchive_KeepsUnknownForeignMod(
+        string folderName,
+        bool publishArchiveHash)
+    {
+        byte[] archiveBytes = [5, 6, 7, 8];
+        var publishedBytes = publishArchiveHash ? archiveBytes : new byte[] { 9, 10, 11, 12 };
+        var snapshot = await SnapshotWithArchiveHashAsync(publishedBytes);
+        using var services = await BoreaServices.BuildAsync(
+            _tempRoot,
+            new ControlledHttpMessageHandler(snapshot),
+            new ConflictingStarMapRepository());
+        var instance = await services.Instances.CreateAsync("Test", InstanceSource.Custom.Value);
+        var folder = WriteForeignMod(services, instance.InstanceId, folderName);
+        var archive = await WriteArchiveAsync(archiveBytes);
+        await services.ForeignModAdopter.ScanAsync(instance.InstanceId);
+
+        var result = await services.ForeignModAdopter.AdoptArchiveAsync(instance.InstanceId, folderName, archive);
+
+        Assert.False(result.Matched);
+        Assert.Null(result.InstalledMod);
+        Assert.Equal(folderName, result.ForeignMod!.ModId);
+        Assert.True(Directory.Exists(folder));
+        var saved = await services.Instances.GetByIdAsync(instance.InstanceId);
+        Assert.Empty(saved!.Mods);
+        Assert.Equal(folderName, Assert.Single(saved.ForeignMods).ModId);
+    }
+
+    [Fact]
     public async Task GameDirectoryChanger_ControlledSnapshot_UpdatesStarMapAndSettings()
     {
         var oldGame = Path.Combine(_tempRoot, "OldGame");
@@ -295,6 +362,30 @@ public sealed class BoreaServicesTests : IDisposable
         dependencies: Array.Empty<ModDependency>());
 
     private string SettingsPath => new GamePathProvider(gameDirectory: null, boreaRoot: _tempRoot).GetBoreaSettingsPath();
+
+    private async Task<string> SnapshotWithArchiveHashAsync(byte[] archiveBytes)
+    {
+        var snapshot = await File.ReadAllTextAsync(SnapshotFixturePath);
+        var sha256 = Convert.ToHexString(SHA256.HashData(archiveBytes));
+        Assert.Contains(FixtureArchiveSha256, snapshot, StringComparison.Ordinal);
+        return snapshot.Replace(FixtureArchiveSha256, sha256, StringComparison.Ordinal);
+    }
+
+    private static string WriteForeignMod(BoreaServices services, Guid instanceId, string folderName)
+    {
+        var folder = Path.Combine(services.Paths.GetInstanceModsFolder(instanceId), folderName);
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "mod.toml"), "name = \"Local\"");
+        return folder;
+    }
+
+    private async Task<string> WriteArchiveAsync(byte[] bytes)
+    {
+        var path = Path.Combine(_tempRoot, Guid.NewGuid().ToString("N") + ".zip");
+        Directory.CreateDirectory(_tempRoot);
+        await File.WriteAllBytesAsync(path, bytes);
+        return path;
+    }
 
     private static string SnapshotFixturePath =>
         Path.Combine(AppContext.BaseDirectory, "Index", "Fixtures", "current-snapshot.json");

--- a/tests/Borea.Core.Tests/Dependencies/ModDependencyResolverTests.cs
+++ b/tests/Borea.Core.Tests/Dependencies/ModDependencyResolverTests.cs
@@ -251,4 +251,93 @@ public sealed class ModDependencyResolverTests
         Assert.Equal(instance.InstanceId, check.InstanceId);
         Assert.True(check.IsActive);
     }
+
+    [Fact]
+    public void Evaluate_UnversionedDependencyOnForeignMod_IsSatisfied()
+    {
+        var instance = InstanceWithForeign(new ForeignMod("LocalLibrary"));
+        var candidate = TestFixtures.SampleVersionMetadata(
+            "candidate",
+            dependencies: new[] { Required("locallibrary") });
+
+        var evaluation = Assert.Single(_resolver.Evaluate(instance, candidate));
+
+        Assert.Equal(DependencyOutcome.Satisfied, evaluation.Outcome);
+        Assert.Equal("LocalLibrary", evaluation.InstalledModId);
+    }
+
+    [Fact]
+    public void Evaluate_VersionBoundDependencyOnForeignMod_IsUnknown()
+    {
+        var instance = InstanceWithForeign(new ForeignMod("LocalLibrary"));
+        var candidate = TestFixtures.SampleVersionMetadata(
+            "candidate",
+            dependencies: new[] { Required("LocalLibrary", "1.0.0") });
+
+        var evaluation = Assert.Single(_resolver.Evaluate(instance, candidate));
+
+        Assert.Equal(DependencyOutcome.Unknown, evaluation.Outcome);
+    }
+
+    [Fact]
+    public void Evaluate_ForeignMod_UsesLocalRequiredAndOptionalDependencies()
+    {
+        var foreign = new ForeignMod("LocalMod", new[]
+        {
+            new LocalModDependency("RequiredMod", optional: false),
+            new LocalModDependency("OptionalMod", optional: true),
+        });
+        var instance = InstanceWithForeign(foreign);
+
+        var evaluations = _resolver.EvaluateForeign(instance, foreign);
+
+        Assert.Collection(
+            evaluations,
+            evaluation => Assert.Equal(DependencyOutcome.Install, evaluation.Outcome),
+            evaluation => Assert.Equal(DependencyOutcome.Offer, evaluation.Outcome));
+    }
+
+    [Fact]
+    public void Evaluate_ForeignMod_AcceptsRawStarMapDependencyId()
+    {
+        var foreign = new ForeignMod("LocalMod", new[]
+        {
+            new LocalModDependency("Local Library", optional: false),
+        });
+        var instance = InstanceWithForeign(foreign);
+
+        var evaluation = Assert.Single(_resolver.EvaluateForeign(instance, foreign));
+
+        Assert.Equal("Local Library", evaluation.Dependency.ModId);
+        Assert.Equal(DependencyOutcome.Install, evaluation.Outcome);
+    }
+
+    [Fact]
+    public void CheckUninstall_ForeignRequiredDependent_IsReported()
+    {
+        var installed = TestFixtures.SampleInstalledMod("RequiredMod");
+        var foreign = new ForeignMod("LocalMod", new[] { new LocalModDependency("RequiredMod", optional: false) });
+        var instance = Instance.FromExisting(
+            Guid.NewGuid(),
+            "Test",
+            InstanceSource.Custom.Value,
+            DateTimeOffset.UtcNow,
+            new[] { installed },
+            new[] { foreign },
+            isFavorite: false);
+
+        var check = _resolver.CheckUninstall(instance, installed.ModId, installed.Version, isActive: true);
+
+        Assert.False(check.CanUninstall);
+        Assert.Contains("LocalMod", check.DependentModIds);
+    }
+
+    private static Instance InstanceWithForeign(ForeignMod foreign) => Instance.FromExisting(
+        Guid.NewGuid(),
+        "Test",
+        InstanceSource.Custom.Value,
+        DateTimeOffset.UtcNow,
+        Array.Empty<InstalledMod>(),
+        new[] { foreign },
+        isFavorite: false);
 }

--- a/tests/Borea.Network.Tests/Index/ContentIndexModRepositoryTests.cs
+++ b/tests/Borea.Network.Tests/Index/ContentIndexModRepositoryTests.cs
@@ -193,6 +193,42 @@ public sealed class ContentIndexModRepositoryTests
     }
 
     [Fact]
+    public async Task FindBySha256Async_RequiresOneUsableModWithMatchingIdAndHash()
+    {
+        var digest = new string('A', 64);
+        var snapshot = Snapshot(
+            new ContentIndexListing(
+                "target-mod",
+                TestFixtures.SampleModMetadata("target-mod", "index"),
+                [Release("target-mod", "1.0.0")],
+                null),
+            new ContentIndexListing(
+                "other-mod",
+                TestFixtures.SampleModMetadata("other-mod", "index"),
+                [Release("other-mod", "1.0.0")],
+                null),
+            new ContentIndexListing(
+                "hidden-mod",
+                TestFixtures.SampleModMetadata("hidden-mod", "index"),
+                [Release("hidden-mod", "1.0.0")],
+                new IndexStatus(IndexStatusState.Delisted, "delisted")));
+        var repository = new ContentIndexModRepository(
+            new FakeFetcher(ContentIndexFetchResult.Downloaded),
+            new FakeReader(snapshot),
+            new TestPathProvider());
+
+        var match = await repository.FindBySha256Async("TARGET-MOD", digest);
+        var wrongId = await repository.FindBySha256Async("missing-mod", digest);
+        var unknownArchive = await repository.FindBySha256Async("target-mod", new string('B', 64));
+        var delisted = await repository.FindBySha256Async("hidden-mod", digest);
+
+        Assert.Equal("target-mod", match!.ModId);
+        Assert.Null(wrongId);
+        Assert.Null(unknownArchive);
+        Assert.Null(delisted);
+    }
+
+    [Fact]
     public async Task GetDiagnosticsAsync_ExposesUnknownModerationWarning()
     {
         var diagnostic = new ContentIndexDiagnostic(

--- a/tests/Borea.Storage.Tests/Mods/FakeModDownloader.cs
+++ b/tests/Borea.Storage.Tests/Mods/FakeModDownloader.cs
@@ -12,6 +12,8 @@ internal sealed class FakeModDownloader : IModDownloader
 
     public Exception? Failure { get; set; }
 
+    public Action? AfterDownload { get; set; }
+
     public List<string> ArchivePaths { get; } = new();
 
     public IProgress<DownloadProgress>? LastProgress { get; private set; }
@@ -32,6 +34,7 @@ internal sealed class FakeModDownloader : IModDownloader
             throw Failure;
 
         await File.WriteAllBytesAsync(archivePath, Bytes, cancellationToken);
+        AfterDownload?.Invoke();
         return new DownloadResult(release.Download.Url, Bytes.Length, Convert.ToHexString(SHA256.HashData(Bytes)));
     }
 }

--- a/tests/Borea.Storage.Tests/Mods/FileForeignModAdopterTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/FileForeignModAdopterTests.cs
@@ -1,0 +1,249 @@
+using System.Security.Cryptography;
+using Borea.Core.Game;
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+using Borea.Storage.Instances;
+using Borea.Storage.Mods;
+using Borea.Storage.Tests.Paths;
+
+namespace Borea.Storage.Tests.Mods;
+
+public sealed class FileForeignModAdopterTests : IAsyncLifetime
+{
+    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+    private readonly FakeArchiveReleaseLookup _lookup = new();
+    private TestGamePathProvider _paths = null!;
+    private FileInstanceRepository _instances = null!;
+    private FileForeignModAdopter _adopter = null!;
+    private Guid _instanceId;
+
+    public async Task InitializeAsync()
+    {
+        _paths = new TestGamePathProvider(_tempRoot);
+        _instances = new FileInstanceRepository(_paths);
+        _instanceId = (await _instances.CreateAsync("Test", InstanceSource.Custom.Value)).InstanceId;
+        _adopter = new FileForeignModAdopter(_paths, _instances, _lookup);
+    }
+
+    public Task DisposeAsync()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task ScanAsync_ListsOnlyUntrackedFoldersWithModToml()
+    {
+        WriteMod("UnknownMod", "name = \"Unknown\"");
+        Directory.CreateDirectory(Path.Combine(ModsFolder, "NotAMod"));
+
+        var foreign = Assert.Single(await _adopter.ScanAsync(_instanceId));
+
+        Assert.Equal("UnknownMod", foreign.FolderName);
+        Assert.Null(foreign.Version);
+        Assert.Equal(GameCompatibility.Unknown, foreign.Compatibility);
+        var saved = await _instances.GetByIdAsync(_instanceId);
+        Assert.Equal("UnknownMod", Assert.Single(saved!.ForeignMods).FolderName);
+    }
+
+    [Fact]
+    public async Task ScanAsync_ReadsStarMapDependenciesWithoutVersionBounds()
+    {
+        WriteMod("LocalMod", """
+            [StarMap]
+            EntryAssembly = "LocalMod"
+
+            [[StarMap.ModDependencies]]
+            ModId = "RequiredMod"
+
+            [[StarMap.ModDependencies]]
+            ModId = "OptionalMod"
+            Optional = true
+            """);
+
+        var foreign = Assert.Single(await _adopter.ScanAsync(_instanceId));
+
+        Assert.Collection(
+            foreign.Dependencies,
+            dependency =>
+            {
+                Assert.Equal("RequiredMod", dependency.ModId);
+                Assert.False(dependency.Optional);
+            },
+            dependency =>
+            {
+                Assert.Equal("OptionalMod", dependency.ModId);
+                Assert.True(dependency.Optional);
+            });
+    }
+
+    [Fact]
+    public async Task AdoptArchiveAsync_MatchingDigest_RecordsExactReleaseAsForeignOwned()
+    {
+        WriteMod("LocalMod", "name = \"Local\"");
+        await _adopter.ScanAsync(_instanceId);
+        var archive = WriteArchive(new byte[] { 1, 2, 3, 4 });
+        var digest = Convert.ToHexString(SHA256.HashData(await File.ReadAllBytesAsync(archive)));
+        _lookup.Release = Release("LocalMod", digest);
+
+        var result = await _adopter.AdoptArchiveAsync(_instanceId, "localmod", archive);
+
+        Assert.True(result.Matched);
+        Assert.Equal(digest, result.Sha256);
+        Assert.Equal(ModVersion.Parse("1.2.0"), result.InstalledMod!.Version);
+        Assert.Equal(ModInstallOwnership.Foreign, result.InstalledMod.Ownership);
+        Assert.False(result.InstalledMod.CanDeleteFiles);
+        Assert.Null(result.ForeignMod);
+        Assert.Equal("LocalMod", _lookup.LastModId);
+        Assert.Equal(digest, _lookup.LastSha256);
+
+        var saved = await _instances.GetByIdAsync(_instanceId);
+        Assert.Empty(saved!.ForeignMods);
+        var savedMod = Assert.Single(saved.Mods);
+        Assert.Equal("LocalMod", savedMod.ModId);
+        Assert.Equal(ModInstallOwnership.Foreign, savedMod.Ownership);
+    }
+
+    [Fact]
+    public async Task AdoptArchiveAsync_UnmatchedDigest_KeepsUnknownForeignMod()
+    {
+        WriteMod("LocalMod", "name = \"Local\"");
+        var archive = WriteArchive(new byte[] { 5, 6, 7 });
+
+        var result = await _adopter.AdoptArchiveAsync(_instanceId, "LocalMod", archive);
+
+        Assert.False(result.Matched);
+        Assert.NotNull(result.ForeignMod);
+        Assert.Null(result.ForeignMod.Version);
+        Assert.Null(result.InstalledMod);
+        var saved = await _instances.GetByIdAsync(_instanceId);
+        Assert.Empty(saved!.Mods);
+        Assert.Equal("LocalMod", Assert.Single(saved.ForeignMods).FolderName);
+    }
+
+    [Fact]
+    public async Task AdoptArchiveAsync_ConcurrentInstanceUpdate_PreservesBothMods()
+    {
+        WriteMod("LocalMod", "name = \"Local\"");
+        var archive = WriteArchive(new byte[] { 8, 9, 10 });
+        var digest = Convert.ToHexString(SHA256.HashData(await File.ReadAllBytesAsync(archive)));
+        _lookup.Release = Release("LocalMod", digest);
+        _lookup.BlockNextLookup();
+
+        var adoption = _adopter.AdoptArchiveAsync(_instanceId, "LocalMod", archive);
+        await _lookup.LookupStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var otherRelease = Release("OtherMod", new string('A', 64));
+        await _instances.UpdateAsync(
+            _instanceId,
+            instance =>
+            {
+                instance.AddMod(new InstalledMod(
+                    "OtherMod",
+                    otherRelease.Version,
+                    InstallReason.Manual,
+                    DateTimeOffset.UtcNow,
+                    otherRelease,
+                    ownership: ModInstallOwnership.Foreign));
+                return true;
+            });
+        _lookup.ContinueLookup();
+
+        await adoption;
+
+        var saved = await _instances.GetByIdAsync(_instanceId);
+        Assert.Collection(
+            saved!.Mods.OrderBy(mod => mod.ModId, ModIds.Comparer),
+            mod => Assert.Equal("LocalMod", mod.ModId),
+            mod => Assert.Equal("OtherMod", mod.ModId));
+    }
+
+    [Fact]
+    public async Task AdoptArchiveAsync_FolderRemovedDuringLookup_DoesNotRecordMod()
+    {
+        WriteMod("LocalMod", "name = \"Local\"");
+        var archive = WriteArchive(new byte[] { 11, 12, 13 });
+        var digest = Convert.ToHexString(SHA256.HashData(await File.ReadAllBytesAsync(archive)));
+        _lookup.Release = Release("LocalMod", digest);
+        _lookup.BlockNextLookup();
+
+        var adoption = _adopter.AdoptArchiveAsync(_instanceId, "LocalMod", archive);
+        await _lookup.LookupStarted.WaitAsync(TimeSpan.FromSeconds(5));
+        Directory.Delete(Path.Combine(ModsFolder, "LocalMod"), recursive: true);
+        _lookup.ContinueLookup();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => adoption);
+
+        Assert.Contains("no longer has", exception.Message);
+        var saved = await _instances.GetByIdAsync(_instanceId);
+        Assert.Empty(saved!.Mods);
+        Assert.Empty(saved.ForeignMods);
+    }
+
+    private string ModsFolder => _paths.GetInstanceModsFolder(_instanceId);
+
+    private void WriteMod(string folderName, string manifest)
+    {
+        var folder = Path.Combine(ModsFolder, folderName);
+        Directory.CreateDirectory(folder);
+        File.WriteAllText(Path.Combine(folder, "mod.toml"), manifest);
+    }
+
+    private string WriteArchive(byte[] bytes)
+    {
+        var path = Path.Combine(_tempRoot, Guid.NewGuid().ToString("N") + ".zip");
+        Directory.CreateDirectory(_tempRoot);
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    private static ModVersionMetadata Release(string modId, string sha256) => new(
+        specVersion: 1,
+        modId: modId,
+        version: ModVersion.Parse("1.2.0"),
+        releaseStatus: ReleaseStatus.Stable,
+        releaseDate: DateTimeOffset.Parse("2026-09-12T00:00:00Z"),
+        gameMin: "2026.9.7.5402",
+        gameMinRevision: 5402,
+        download: new DownloadInfo("https://example.invalid/mod.zip", sha256, null, "application/zip"),
+        installSizeBytes: null,
+        dependencies: Array.Empty<Borea.Core.Dependencies.ModDependency>());
+
+    private sealed class FakeArchiveReleaseLookup : IModArchiveReleaseLookup
+    {
+        private TaskCompletionSource? _continueLookup;
+
+        public ModVersionMetadata? Release { get; set; }
+        public string? LastModId { get; private set; }
+        public string? LastSha256 { get; private set; }
+        public Task LookupStarted { get; private set; } = Task.CompletedTask;
+
+        public void BlockNextLookup()
+        {
+            var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            LookupStarted = started.Task;
+            _continueLookup = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _lookupStarted = started;
+        }
+
+        public void ContinueLookup() => _continueLookup?.SetResult();
+
+        private TaskCompletionSource? _lookupStarted;
+
+        public async Task<ModVersionMetadata?> FindBySha256Async(
+            string modId,
+            string sha256,
+            CancellationToken cancellationToken = default)
+        {
+            LastModId = modId;
+            LastSha256 = sha256;
+            _lookupStarted?.SetResult();
+            if (_continueLookup is not null)
+                await _continueLookup.Task.WaitAsync(cancellationToken);
+
+            return Release;
+        }
+    }
+}

--- a/tests/Borea.Storage.Tests/Mods/FileModInstallerTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/FileModInstallerTests.cs
@@ -253,6 +253,9 @@ public sealed class FileModInstallerTests : IAsyncLifetime
         Assert.Equal(InstallReason.Dependency, installed.Reason);
         Assert.Equal(Now, installed.InstalledAt);
         Assert.Equal(Sha256Of(_downloader.Bytes), installed.Checksum);
+        Assert.Equal(ModInstallOwnership.Borea, installed.Ownership);
+        Assert.False(string.IsNullOrWhiteSpace(installed.OwnershipToken));
+        Assert.Equal(installed.OwnershipToken, File.ReadAllText(Path.Combine(ModFolder, ".borea-owner")));
         Assert.Equal(release.Download.Url, installed.Metadata.Download.Url);
         Assert.Equal(installed.ModId, result.Mod.ModId);
         Assert.Equal(Sha256Of(_downloader.Bytes), result.Download.Sha256);
@@ -344,6 +347,25 @@ public sealed class FileModInstallerTests : IAsyncLifetime
         await AssertNothingInstalledAsync();
     }
 
+    [Fact]
+    public async Task InstallAsync_RollbackAfterOwnedFolderIsReplaced_LeavesReplacementIntact()
+    {
+        var state = new FailingModStateRepository(() =>
+        {
+            Directory.Delete(ModFolder, recursive: true);
+            Directory.CreateDirectory(ModFolder);
+            File.WriteAllText(Path.Combine(ModFolder, "local-file.dat"), "content");
+        });
+        var installer = new FileModInstaller(_pathProvider, _downloader, _instances, state, new FixedTimeProvider(Now));
+        _downloader.Bytes = BuildZip(("mod.toml", "name"));
+
+        await Assert.ThrowsAsync<IOException>(() => installer.InstallAsync(_instanceId, Release(), InstallReason.Manual, enable: true));
+
+        Assert.True(File.Exists(Path.Combine(ModFolder, "local-file.dat")));
+        var instance = await _instances.GetByIdAsync(_instanceId);
+        Assert.Empty(instance!.Mods);
+    }
+
     #endregion
 
     #region Refusals
@@ -372,6 +394,23 @@ public sealed class FileModInstallerTests : IAsyncLifetime
 
         Assert.Empty(_downloader.ArchivePaths);
         Assert.True(Directory.Exists(foreign));
+    }
+
+    [Fact]
+    public async Task InstallAsync_ForeignFolderAppearsDuringDownload_LeavesItIntact()
+    {
+        _downloader.Bytes = BuildZip(("mod.toml", "name"));
+        _downloader.AfterDownload = () =>
+        {
+            Directory.CreateDirectory(ModFolder);
+            File.WriteAllText(Path.Combine(ModFolder, "local-file.dat"), "content");
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => InstallAsync());
+
+        Assert.True(File.Exists(Path.Combine(ModFolder, "local-file.dat")));
+        var instance = await _instances.GetByIdAsync(_instanceId);
+        Assert.Empty(instance!.Mods);
     }
 
     [Fact]
@@ -445,10 +484,13 @@ public sealed class FileModInstallerTests : IAsyncLifetime
     #endregion
 
     /// <summary>A manifest that cannot be written, to exercise the rollback.</summary>
-    private sealed class FailingModStateRepository : IModStateRepository
+    private sealed class FailingModStateRepository(Action? beforeFailure = null) : IModStateRepository
     {
-        public Task<ModEntryAddResult> AddEntryAsync(Guid instanceId, string modId, bool enabled, CancellationToken cancellationToken = default) =>
+        public Task<ModEntryAddResult> AddEntryAsync(Guid instanceId, string modId, bool enabled, CancellationToken cancellationToken = default)
+        {
+            beforeFailure?.Invoke();
             throw new IOException("The disk is full.");
+        }
 
         public Task<IReadOnlyList<ModManifestEntry>> GetEntriesAsync(Guid instanceId, CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();

--- a/tests/Borea.Storage.Tests/Mods/FileModUninstallerTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/FileModUninstallerTests.cs
@@ -1,28 +1,44 @@
-﻿using Borea.Storage.Mods;
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+using Borea.Storage.Instances;
+using Borea.Storage.Mods;
 using Borea.Storage.Tests.Paths;
 
 namespace Borea.Storage.Tests.Mods;
 
-public sealed class FileModUninstallerTests : IDisposable
+public sealed class FileModUninstallerTests : IAsyncLifetime
 {
     private readonly string _tempRoot;
     private readonly TestGamePathProvider _pathProvider;
+    private readonly FileInstanceRepository _instances;
     private readonly FileModUninstaller _uninstaller;
-    private readonly Guid _instanceId = Guid.NewGuid();
+    private Guid _instanceId;
 
     public FileModUninstallerTests()
     {
-        _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + _instanceId);
+        _tempRoot = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
         _pathProvider = new TestGamePathProvider(_tempRoot);
-        _uninstaller = new FileModUninstaller(_pathProvider);
+        _instances = new FileInstanceRepository(_pathProvider);
+        _uninstaller = new FileModUninstaller(_pathProvider, _instances);
     }
 
-    private string ModDirectory(string modId) =>
-        Path.Combine(_pathProvider.GetInstanceModsFolder(_instanceId), modId);
+    public async Task InitializeAsync()
+    {
+        _instanceId = (await _instances.CreateAsync("Test", InstanceSource.Custom.Value)).InstanceId;
+    }
+
+    public Task DisposeAsync()
+    {
+        if (Directory.Exists(_tempRoot))
+            Directory.Delete(_tempRoot, recursive: true);
+
+        return Task.CompletedTask;
+    }
 
     [Fact]
-    public async Task UninstallAsync_ExistingModFolder_DeletesIt()
+    public async Task UninstallAsync_BoreaOwnedFolder_DeletesIt()
     {
+        await AddInstalledModAsync(ModInstallOwnership.Borea);
         var modDir = ModDirectory("test-mod");
         Directory.CreateDirectory(modDir);
         File.WriteAllText(Path.Combine(modDir, "some-file.dat"), "content");
@@ -33,16 +49,63 @@ public sealed class FileModUninstallerTests : IDisposable
     }
 
     [Fact]
-    public async Task UninstallAsync_NonexistentModFolder_IsNoOpRatherThanThrowing()
+    public async Task UninstallAsync_UntrackedFolder_LeavesItIntact()
     {
+        var modDir = ModDirectory("never-installed");
+        Directory.CreateDirectory(modDir);
+        File.WriteAllText(Path.Combine(modDir, "local-file.dat"), "content");
+
         await _uninstaller.UninstallAsync(_instanceId, "never-installed");
 
-        Assert.False(Directory.Exists(ModDirectory("never-installed")));
+        Assert.True(File.Exists(Path.Combine(modDir, "local-file.dat")));
+    }
+
+    [Fact]
+    public async Task UninstallAsync_ForeignOwnedRecord_LeavesFolderIntact()
+    {
+        await AddInstalledModAsync(ModInstallOwnership.Foreign);
+        var modDir = ModDirectory("test-mod");
+        Directory.CreateDirectory(modDir);
+        File.WriteAllText(Path.Combine(modDir, "local-file.dat"), "content");
+
+        await _uninstaller.UninstallAsync(_instanceId, "test-mod");
+
+        Assert.True(File.Exists(Path.Combine(modDir, "local-file.dat")));
+    }
+
+    [Fact]
+    public async Task UninstallAsync_ReplacedOwnedFolder_LeavesItIntact()
+    {
+        await AddInstalledModAsync(ModInstallOwnership.Borea);
+        var modDir = ModDirectory("test-mod");
+        Directory.Delete(modDir, recursive: true);
+        Directory.CreateDirectory(modDir);
+        File.WriteAllText(Path.Combine(modDir, "local-file.dat"), "content");
+
+        await _uninstaller.UninstallAsync(_instanceId, "test-mod");
+
+        Assert.True(File.Exists(Path.Combine(modDir, "local-file.dat")));
+    }
+
+    [Fact]
+    public async Task UninstallAsync_LegacyBoreaRecordWithoutToken_ReportsActionableError()
+    {
+        await AddInstalledModAsync(ModInstallOwnership.Borea, createOwnershipMarker: false);
+        var modDir = ModDirectory("test-mod");
+        Directory.CreateDirectory(modDir);
+        File.WriteAllText(Path.Combine(modDir, "local-file.dat"), "content");
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _uninstaller.UninstallAsync(_instanceId, "test-mod"));
+
+        Assert.Contains("cannot verify ownership", exception.Message);
+        Assert.True(File.Exists(Path.Combine(modDir, "local-file.dat")));
     }
 
     [Fact]
     public async Task UninstallAsync_OnlyDeletesTargetMod_LeavesSiblingsIntact()
     {
+        await AddInstalledModAsync(ModInstallOwnership.Borea, "mod-to-remove");
         var targetDir = ModDirectory("mod-to-remove");
         var siblingDir = ModDirectory("mod-to-keep");
         Directory.CreateDirectory(targetDir);
@@ -52,6 +115,20 @@ public sealed class FileModUninstallerTests : IDisposable
 
         Assert.False(Directory.Exists(targetDir));
         Assert.True(Directory.Exists(siblingDir));
+    }
+
+    [Fact]
+    public async Task UninstallAsync_CanceledBeforeRead_LeavesOwnedFolderIntact()
+    {
+        await AddInstalledModAsync(ModInstallOwnership.Borea);
+        var modDir = ModDirectory("test-mod");
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => _uninstaller.UninstallAsync(_instanceId, "test-mod", cancellation.Token));
+
+        Assert.True(Directory.Exists(modDir));
     }
 
     [Theory]
@@ -64,14 +141,39 @@ public sealed class FileModUninstallerTests : IDisposable
     }
 
     [Fact]
-    public void Constructor_NullPathProvider_ThrowsArgumentNullException()
+    public void Constructor_NullDependency_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() => new FileModUninstaller(null!));
+        Assert.Throws<ArgumentNullException>(() => new FileModUninstaller(null!, _instances));
+        Assert.Throws<ArgumentNullException>(() => new FileModUninstaller(_pathProvider, null!));
     }
 
-    public void Dispose()
+    private string ModDirectory(string modId) => Path.Combine(_pathProvider.GetInstanceModsFolder(_instanceId), modId);
+
+    private async Task AddInstalledModAsync(
+        ModInstallOwnership ownership,
+        string modId = "test-mod",
+        bool createOwnershipMarker = true)
     {
-        if (Directory.Exists(_tempRoot))
-            Directory.Delete(_tempRoot, recursive: true);
+        var instance = await _instances.GetByIdAsync(_instanceId);
+        var release = MetadataFixtures.MinimalRelease(modId);
+        var ownershipToken = ownership == ModInstallOwnership.Borea && createOwnershipMarker
+            ? Guid.NewGuid().ToString("N")
+            : null;
+        instance!.AddMod(new InstalledMod(
+            modId,
+            release.Version,
+            InstallReason.Manual,
+            DateTimeOffset.UtcNow,
+            release,
+            ownership: ownership,
+            ownershipToken: ownershipToken));
+        await _instances.SaveAsync(instance);
+
+        if (ownershipToken is not null)
+        {
+            var modDirectory = ModDirectory(modId);
+            Directory.CreateDirectory(modDirectory);
+            File.WriteAllText(Path.Combine(modDirectory, ".borea-owner"), ownershipToken);
+        }
     }
 }


### PR DESCRIPTION
Closes #52

Borea records existing mod folders as foreign mods and includes their local dependencies in checks.
Archive adoption requires one trusted release matching both the mod ID and SHA-256 digest and never grants ownership of the existing files.
Managed installs use matching ownership markers, and instance updates are serialized to prevent lost records.

Stacked on #112.
