### PR TITLE
Read mod packs from the content index

### DIFF
--- a/src/Borea.Composition/BoreaServices.cs
+++ b/src/Borea.Composition/BoreaServices.cs
@@ -85,6 +85,8 @@ public sealed class BoreaServices : IDisposable
     /// </summary>
     public required IModRepository Mods { get; init; }
 
+    public required IModPackRepository ModPacks { get; init; }
+
     public required IModDownloader Downloader { get; init; }
 
     public required ILoaderInstaller LoaderInstaller { get; init; }
@@ -102,6 +104,8 @@ public sealed class BoreaServices : IDisposable
     public required IContentIndexFetcher IndexFetcher { get; init; }
 
     public required IContentIndexReader IndexReader { get; init; }
+
+    public required IContentIndexSnapshotProvider IndexSnapshots { get; init; }
 
     public required IContentIndexRepository ContentIndex { get; init; }
 
@@ -167,7 +171,9 @@ public sealed class BoreaServices : IDisposable
         var resolver = new SpaceDockResolver();
         var indexReader = new ContentIndexReader(paths, ContentIndexModRepository.SourceName);
         var indexFetcher = new ContentIndexFetcher(http, ContentIndexUri, indexReader);
-        var contentIndex = new ContentIndexModRepository(indexFetcher, indexReader, paths);
+        var indexSnapshots = new ContentIndexSnapshotProvider(indexFetcher, indexReader, paths);
+        var contentIndex = new ContentIndexModRepository(indexSnapshots);
+        var modPacks = new ContentIndexModPackRepository(indexSnapshots);
         var sources = new Dictionary<string, IModRepository>
         {
             [ContentIndexModRepository.SourceName] = contentIndex,
@@ -192,6 +198,7 @@ public sealed class BoreaServices : IDisposable
             Uninstaller = new FileModUninstaller(paths, instances),
             ForeignModAdopter = new FileForeignModAdopter(paths, instances, contentIndex),
             Mods = mods,
+            ModPacks = modPacks,
             Downloader = downloader,
             LoaderInstaller = new FileLoaderInstaller(paths, downloader, settingsRepository, loaderConfiguration),
             LoaderAdopter = new FileLoaderAdopter(settingsRepository, loaderConfiguration),
@@ -201,6 +208,7 @@ public sealed class BoreaServices : IDisposable
             InstalledVersion = new InstalledGameVersionProvider(paths),
             IndexFetcher = indexFetcher,
             IndexReader = indexReader,
+            IndexSnapshots = indexSnapshots,
             ContentIndex = contentIndex,
         };
     }

--- a/src/Borea.Core/Index/IContentIndexSnapshotProvider.cs
+++ b/src/Borea.Core/Index/IContentIndexSnapshotProvider.cs
@@ -1,0 +1,7 @@
+namespace Borea.Core.Index;
+
+/// <summary>Provides one shared, refreshed content index snapshot to index repositories.</summary>
+public interface IContentIndexSnapshotProvider
+{
+    Task<ContentIndexSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Borea.Core/ModPacks/IModPackRepository.cs
+++ b/src/Borea.Core/ModPacks/IModPackRepository.cs
@@ -1,20 +1,31 @@
-﻿using Borea.Core.Mods;
+using Borea.Core.Mods;
 
 namespace Borea.Core.ModPacks;
 
-/// <summary>
-/// Provides read access to mod packs available from Borea's pack source.
-/// Only reflects currently-available, non-removed packs and versions.
-/// </summary>
+/// <summary>Provides read access to mod packs from Borea's content index.</summary>
 public interface IModPackRepository
 {
-    Task<IReadOnlyList<ModPackMetadata>> GetAvailableModPacksAsync(CancellationToken cancellationToken = default);
+    /// <summary>Lists packs with a usable, non-retracted latest version, ordered by id.</summary>
+    Task<IReadOnlyList<ModPackResult>> GetAvailableModPacksAsync(CancellationToken cancellationToken = default);
 
-    Task<ModPackMetadata?> GetLatestAsync(string modPackId, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Gets a pack identity and its latest usable metadata.
+    /// A known delisted or unsupported pack returns an identity-only result.
+    /// </summary>
+    Task<ModPackResult?> GetAsync(string modPackId, CancellationToken cancellationToken = default);
 
-    Task<ModPackMetadata?> GetVersionAsync(string modPackId, ModVersion version, CancellationToken cancellationToken = default);
+    /// <summary>Gets the newest usable version, excluding retracted and unsupported versions.</summary>
+    Task<ModPackResult?> GetLatestAsync(string modPackId, CancellationToken cancellationToken = default);
 
-    Task<IReadOnlyList<ModVersion>> GetAvailableVersionsAsync(string modPackId, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Gets one exact version, including a retracted version and its warning.
+    /// An unsupported version returns an identity-only result with its diagnostic.
+    /// </summary>
+    Task<ModPackResult?> GetVersionAsync(string modPackId, ModVersion version, CancellationToken cancellationToken = default);
 
-    Task<IReadOnlyList<ModPackMetadata>> SearchAsync(string query, CancellationToken cancellationToken = default);
+    /// <summary>Lists usable versions newest-first, excluding retracted and unsupported versions.</summary>
+    Task<IReadOnlyList<ModPackResult>> GetAvailableVersionsAsync(string modPackId, CancellationToken cancellationToken = default);
+
+    /// <summary>Searches packs with usable latest metadata and orders matches by id.</summary>
+    Task<IReadOnlyList<ModPackResult>> SearchAsync(string query, CancellationToken cancellationToken = default);
 }

--- a/src/Borea.Core/ModPacks/ModPackResult.cs
+++ b/src/Borea.Core/ModPacks/ModPackResult.cs
@@ -1,0 +1,41 @@
+using System.Collections.ObjectModel;
+using Borea.Core.Index;
+using Borea.Core.Mods;
+
+namespace Borea.Core.ModPacks;
+
+/// <summary>One pack query result, including index state that can make its metadata unusable.</summary>
+public sealed class ModPackResult
+{
+    public string Id { get; }
+    public string? Version { get; }
+    public ModPackMetadata? Metadata { get; }
+    public IndexStatus? PackStatus { get; }
+    public IndexStatus? VersionStatus { get; }
+    public IReadOnlyList<ContentIndexDiagnostic> Diagnostics { get; }
+
+    public ModPackResult(
+        string id,
+        string? version,
+        ModPackMetadata? metadata,
+        IndexStatus? packStatus,
+        IndexStatus? versionStatus,
+        IReadOnlyList<ContentIndexDiagnostic> diagnostics)
+    {
+        ModIds.Validate(id, nameof(id));
+        ArgumentNullException.ThrowIfNull(diagnostics);
+
+        if (metadata is not null && !ModIds.Equals(id, metadata.ModPackId))
+            throw new ArgumentException("The metadata id must match the result id.", nameof(metadata));
+
+        if (metadata is not null && !string.Equals(version, metadata.Version.ToString(), StringComparison.Ordinal))
+            throw new ArgumentException("The metadata version must match the result version.", nameof(metadata));
+
+        Id = id;
+        Version = version;
+        Metadata = metadata;
+        PackStatus = packStatus;
+        VersionStatus = versionStatus;
+        Diagnostics = new ReadOnlyCollection<ContentIndexDiagnostic>(diagnostics.ToArray());
+    }
+}

--- a/src/Borea.Network/Index/ContentIndexModPackRepository.cs
+++ b/src/Borea.Network/Index/ContentIndexModPackRepository.cs
@@ -1,0 +1,171 @@
+using Borea.Core.Index;
+using Borea.Core.ModPacks;
+using Borea.Core.Mods;
+
+namespace Borea.Network.Index;
+
+/// <summary>Serves mod packs from the snapshot shared with the mod repository.</summary>
+public sealed class ContentIndexModPackRepository : IModPackRepository
+{
+    private readonly IContentIndexSnapshotProvider _snapshots;
+
+    public ContentIndexModPackRepository(IContentIndexSnapshotProvider snapshots)
+    {
+        _snapshots = snapshots ?? throw new ArgumentNullException(nameof(snapshots));
+    }
+
+    public async Task<IReadOnlyList<ModPackResult>> GetAvailableModPacksAsync(CancellationToken cancellationToken = default)
+    {
+        var snapshot = await _snapshots.GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        return snapshot.Packs
+            .Where(pack => pack.IndexStatus?.State != IndexStatusState.Delisted)
+            .Select(pack => LatestResult(snapshot, pack))
+            .Where(result => result.Metadata is not null)
+            .OrderBy(result => result.Id, ModIds.Comparer)
+            .ToArray();
+    }
+
+    public async Task<ModPackResult?> GetAsync(string modPackId, CancellationToken cancellationToken = default)
+    {
+        var snapshot = await _snapshots.GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        var pack = snapshot.Packs.FirstOrDefault(candidate => ModIds.Equals(candidate.Id, modPackId));
+        if (pack is not null)
+        {
+            if (pack.IndexStatus?.State == IndexStatusState.Delisted)
+                return Result(snapshot, pack.Id, null, null, pack.IndexStatus, null);
+
+            return LatestResult(snapshot, pack);
+        }
+
+        return PackDiagnosticIdentity(snapshot, modPackId);
+    }
+
+    public async Task<ModPackResult?> GetLatestAsync(string modPackId, CancellationToken cancellationToken = default)
+    {
+        var snapshot = await _snapshots.GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        var pack = AvailablePack(snapshot, modPackId);
+        if (pack is null)
+            return null;
+
+        var latest = pack.Versions
+            .Where(IsAvailable)
+            .OrderByDescending(version => version.Metadata.Version)
+            .FirstOrDefault();
+        return latest is null ? null : Result(snapshot, pack, latest);
+    }
+
+    public async Task<ModPackResult?> GetVersionAsync(string modPackId, ModVersion version, CancellationToken cancellationToken = default)
+    {
+        var snapshot = await _snapshots.GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        var pack = snapshot.Packs.FirstOrDefault(candidate => ModIds.Equals(candidate.Id, modPackId));
+        if (pack is null)
+            return VersionDiagnosticIdentity(snapshot, modPackId, version);
+
+        if (pack.IndexStatus?.State == IndexStatusState.Delisted)
+            return Result(snapshot, pack.Id, version.ToString(), null, pack.IndexStatus, null);
+
+        var match = pack.Versions.FirstOrDefault(candidate => candidate.Metadata.Version.Equals(version));
+        return match is null
+            ? VersionDiagnosticIdentity(snapshot, pack.Id, version)
+            : Result(snapshot, pack, match);
+    }
+
+    public async Task<IReadOnlyList<ModPackResult>> GetAvailableVersionsAsync(string modPackId, CancellationToken cancellationToken = default)
+    {
+        var snapshot = await _snapshots.GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        var pack = AvailablePack(snapshot, modPackId);
+        return pack?.Versions
+            .Where(IsAvailable)
+            .OrderByDescending(version => version.Metadata.Version)
+            .Select(version => Result(snapshot, pack, version))
+            .ToArray()
+            ?? Array.Empty<ModPackResult>();
+    }
+
+    public async Task<IReadOnlyList<ModPackResult>> SearchAsync(string query, CancellationToken cancellationToken = default)
+    {
+        var packs = await GetAvailableModPacksAsync(cancellationToken).ConfigureAwait(false);
+        return packs.Where(result => Matches(result.Metadata!, query)).ToArray();
+    }
+
+    private static ContentIndexPack? AvailablePack(ContentIndexSnapshot snapshot, string id) =>
+        snapshot.Packs.FirstOrDefault(pack =>
+            ModIds.Equals(pack.Id, id)
+            && pack.IndexStatus?.State != IndexStatusState.Delisted);
+
+    private static bool IsAvailable(ContentIndexPackVersion version) =>
+        version.IndexStatus?.State != IndexStatusState.Retracted;
+
+    private static ModPackResult LatestResult(ContentIndexSnapshot snapshot, ContentIndexPack pack)
+    {
+        var latest = pack.Versions
+            .Where(IsAvailable)
+            .OrderByDescending(version => version.Metadata.Version)
+            .FirstOrDefault();
+        return latest is null
+            ? Result(snapshot, pack.Id, null, null, pack.IndexStatus, null)
+            : Result(snapshot, pack, latest);
+    }
+
+    private static ModPackResult Result(ContentIndexSnapshot snapshot, ContentIndexPack pack, ContentIndexPackVersion version) =>
+        Result(snapshot, pack.Id, version.Metadata.Version.ToString(), version.Metadata, pack.IndexStatus, version.IndexStatus);
+
+    private static ModPackResult Result(
+        ContentIndexSnapshot snapshot,
+        string id,
+        string? version,
+        ModPackMetadata? metadata,
+        IndexStatus? packStatus,
+        IndexStatus? versionStatus) =>
+        new(id, version, metadata, packStatus, versionStatus, Diagnostics(snapshot, id, version));
+
+    private static ModPackResult? PackDiagnosticIdentity(ContentIndexSnapshot snapshot, string id)
+    {
+        var identity = snapshot.Diagnostics.FirstOrDefault(diagnostic =>
+            diagnostic.Scope == ContentIndexDiagnosticScope.Pack
+            && ModIds.Equals(diagnostic.Id, id)
+            && ModIds.IsValid(diagnostic.Id));
+        return identity is null
+            ? null
+            : new ModPackResult(identity.Id!, null, null, null, null, Diagnostics(snapshot, identity.Id!, null));
+    }
+
+    private static ModPackResult? VersionDiagnosticIdentity(ContentIndexSnapshot snapshot, string id, ModVersion version)
+    {
+        var versionText = version.ToString();
+        var identity = snapshot.Diagnostics.FirstOrDefault(diagnostic =>
+            diagnostic.Scope == ContentIndexDiagnosticScope.PackVersion
+            && ModIds.Equals(diagnostic.Id, id)
+            && ModIds.IsValid(diagnostic.Id)
+            && diagnostic.Version is not null
+            && VersionEquals(diagnostic.Version, versionText));
+        return identity is null
+            ? null
+            : new ModPackResult(identity.Id!, identity.Version, null, null, null, Diagnostics(snapshot, identity.Id!, identity.Version));
+    }
+
+    private static IReadOnlyList<ContentIndexDiagnostic> Diagnostics(ContentIndexSnapshot snapshot, string id, string? version) =>
+        snapshot.Diagnostics
+            .Where(diagnostic => ModIds.Equals(diagnostic.Id, id))
+            .Where(diagnostic => diagnostic.Scope is ContentIndexDiagnosticScope.Pack
+                or ContentIndexDiagnosticScope.PackVersion
+                or ContentIndexDiagnosticScope.IndexStatus)
+            .Where(diagnostic => diagnostic.Version is null || version is null || VersionEquals(diagnostic.Version, version))
+            .ToArray();
+
+    private static bool VersionEquals(string left, string right) =>
+        ModVersion.TryParse(left, out var leftVersion)
+        && ModVersion.TryParse(right, out var rightVersion)
+        && leftVersion.Equals(rightVersion);
+
+    private static bool Matches(ModPackMetadata pack, string query) =>
+        Contains(pack.ModPackId, query)
+        || Contains(pack.Name, query)
+        || Contains(pack.Abstract, query)
+        || Contains(pack.Description, query)
+        || pack.Authors.Any(author => Contains(author, query))
+        || pack.Tags.Any(tag => Contains(tag, query));
+
+    private static bool Contains(string? value, string query) =>
+        value?.Contains(query, StringComparison.OrdinalIgnoreCase) == true;
+}

--- a/src/Borea.Network/Index/ContentIndexModRepository.cs
+++ b/src/Borea.Network/Index/ContentIndexModRepository.cs
@@ -6,35 +6,26 @@ namespace Borea.Network.Index;
 
 /// <summary>
 /// Serves the community index through <see cref="IModRepository"/>.
-/// Successful snapshots are revalidated at most once per index watcher interval,
-/// and overlapping callers share one refresh and parse operation.
+/// The repository uses the snapshot provider shared with other index content.
 /// </summary>
 public sealed class ContentIndexModRepository : IContentIndexRepository, IModIdClaimSource, IModArchiveReleaseLookup
 {
     public const string SourceName = "index";
 
-    private static readonly TimeSpan RevalidationInterval = TimeSpan.FromMinutes(10);
-
-    private readonly IContentIndexFetcher _fetcher;
-    private readonly IContentIndexReader _reader;
-    private readonly IGamePathProvider _paths;
-    private readonly TimeProvider _timeProvider;
-    private readonly object _gate = new();
-
-    private ContentIndexSnapshot? _snapshot;
-    private DateTimeOffset _lastAttemptAt;
-    private Task<ContentIndexSnapshot>? _inFlight;
+    private readonly IContentIndexSnapshotProvider _snapshots;
 
     public ContentIndexModRepository(
         IContentIndexFetcher fetcher,
         IContentIndexReader reader,
         IGamePathProvider paths,
         TimeProvider? timeProvider = null)
+        : this(new ContentIndexSnapshotProvider(fetcher, reader, paths, timeProvider))
     {
-        _fetcher = fetcher ?? throw new ArgumentNullException(nameof(fetcher));
-        _reader = reader ?? throw new ArgumentNullException(nameof(reader));
-        _paths = paths ?? throw new ArgumentNullException(nameof(paths));
-        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public ContentIndexModRepository(IContentIndexSnapshotProvider snapshots)
+    {
+        _snapshots = snapshots ?? throw new ArgumentNullException(nameof(snapshots));
     }
 
     public async Task<IReadOnlyList<ModMetadata>> GetAvailableModsAsync(CancellationToken cancellationToken = default)
@@ -137,60 +128,7 @@ public sealed class ContentIndexModRepository : IContentIndexRepository, IModIdC
     }
 
     private Task<ContentIndexSnapshot> GetSnapshotAsync(CancellationToken cancellationToken)
-    {
-        lock (_gate)
-        {
-            if (_snapshot is not null
-                && _timeProvider.GetUtcNow() - _lastAttemptAt < RevalidationInterval)
-            {
-                return Task.FromResult(_snapshot);
-            }
-
-            if (_inFlight is null || _inFlight.IsCompleted)
-                _inFlight = RefreshAsync();
-
-            return _inFlight.WaitAsync(cancellationToken);
-        }
-    }
-
-    private async Task<ContentIndexSnapshot> RefreshAsync()
-    {
-        ContentIndexSnapshot? current;
-        lock (_gate)
-            current = _snapshot;
-
-        try
-        {
-            var fetchResult = await _fetcher.FetchAsync(_paths.GetIndexPath()).ConfigureAwait(false);
-            if (fetchResult == ContentIndexFetchResult.NotModified && current is not null)
-                return RecordAttempt(current);
-        }
-        catch (Exception ex) when (ex is HttpRequestException or IOException or TaskCanceledException)
-        {
-            if (current is not null)
-                return RecordAttempt(current);
-        }
-
-        try
-        {
-            var loaded = await _reader.ReadAsync().ConfigureAwait(false);
-            return RecordAttempt(loaded);
-        }
-        catch (Exception ex) when (current is not null && ex is (InvalidOperationException or IOException))
-        {
-            return RecordAttempt(current);
-        }
-    }
-
-    private ContentIndexSnapshot RecordAttempt(ContentIndexSnapshot snapshot)
-    {
-        lock (_gate)
-        {
-            _snapshot = snapshot;
-            _lastAttemptAt = _timeProvider.GetUtcNow();
-            return snapshot;
-        }
-    }
+        => _snapshots.GetSnapshotAsync(cancellationToken);
 
     private static IEnumerable<ContentIndexListing> AvailableListings(ContentIndexSnapshot snapshot) =>
         snapshot.Listings.Where(listing =>

--- a/src/Borea.Network/Index/ContentIndexSnapshotProvider.cs
+++ b/src/Borea.Network/Index/ContentIndexSnapshotProvider.cs
@@ -1,0 +1,78 @@
+using Borea.Core.Index;
+using Borea.Core.Paths;
+
+namespace Borea.Network.Index;
+
+/// <summary>Refreshes and caches the one snapshot shared by all index repositories.</summary>
+public sealed class ContentIndexSnapshotProvider : IContentIndexSnapshotProvider
+{
+    private static readonly TimeSpan RevalidationInterval = TimeSpan.FromMinutes(10);
+    private readonly IContentIndexFetcher _fetcher;
+    private readonly IContentIndexReader _reader;
+    private readonly IGamePathProvider _paths;
+    private readonly TimeProvider _timeProvider;
+    private readonly object _gate = new();
+    private ContentIndexSnapshot? _snapshot;
+    private DateTimeOffset _lastAttemptAt;
+    private Task<ContentIndexSnapshot>? _inFlight;
+
+    public ContentIndexSnapshotProvider(IContentIndexFetcher fetcher, IContentIndexReader reader, IGamePathProvider paths, TimeProvider? timeProvider = null)
+    {
+        _fetcher = fetcher ?? throw new ArgumentNullException(nameof(fetcher));
+        _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        _paths = paths ?? throw new ArgumentNullException(nameof(paths));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public Task<ContentIndexSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_gate)
+        {
+            if (_snapshot is not null && _timeProvider.GetUtcNow() - _lastAttemptAt < RevalidationInterval)
+                return Task.FromResult(_snapshot);
+
+            if (_inFlight is null || _inFlight.IsCompleted)
+                _inFlight = RefreshAsync();
+
+            return _inFlight.WaitAsync(cancellationToken);
+        }
+    }
+
+    private async Task<ContentIndexSnapshot> RefreshAsync()
+    {
+        ContentIndexSnapshot? current;
+        lock (_gate)
+            current = _snapshot;
+
+        try
+        {
+            var fetchResult = await _fetcher.FetchAsync(_paths.GetIndexPath()).ConfigureAwait(false);
+            if (fetchResult == ContentIndexFetchResult.NotModified && current is not null)
+                return RecordAttempt(current);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or IOException or TaskCanceledException)
+        {
+            if (current is not null)
+                return RecordAttempt(current);
+        }
+
+        try
+        {
+            return RecordAttempt(await _reader.ReadAsync().ConfigureAwait(false));
+        }
+        catch (Exception ex) when (current is not null && ex is (InvalidOperationException or IOException))
+        {
+            return RecordAttempt(current);
+        }
+    }
+
+    private ContentIndexSnapshot RecordAttempt(ContentIndexSnapshot snapshot)
+    {
+        lock (_gate)
+        {
+            _snapshot = snapshot;
+            _lastAttemptAt = _timeProvider.GetUtcNow();
+            return snapshot;
+        }
+    }
+}

--- a/tests/Borea.Composition.Tests/BoreaServicesTests.cs
+++ b/tests/Borea.Composition.Tests/BoreaServicesTests.cs
@@ -148,8 +148,10 @@ public sealed class BoreaServicesTests : IDisposable
         using var services = await BoreaServices.BuildAsync(_tempRoot);
 
         Assert.IsType<ContentIndexReader>(services.IndexReader);
+        Assert.IsType<ContentIndexSnapshotProvider>(services.IndexSnapshots);
         Assert.IsType<ContentIndexModRepository>(services.ContentIndex);
         Assert.IsAssignableFrom<IContentIndexRepository>(services.ContentIndex);
+        Assert.IsType<ContentIndexModPackRepository>(services.ModPacks);
     }
 
     [Fact]
@@ -184,11 +186,15 @@ public sealed class BoreaServicesTests : IDisposable
         using var services = await BoreaServices.BuildAsync(_tempRoot, handler, new ConflictingStarMapRepository());
 
         var available = await services.Mods.GetAvailableModsAsync();
+        var packs = await services.ModPacks.GetAvailableModPacksAsync();
+        var retainedSnapshot = await services.IndexSnapshots.GetSnapshotAsync();
         var starMap = Assert.Single(available, mod => mod.ModId == "StarMap");
         var versions = await services.Mods.GetAvailableVersionsAsync("StarMap");
         var latest = await services.Mods.GetLatestReleaseAsync("StarMap");
 
         Assert.Equal(ContentIndexModRepository.SourceName, starMap.Source);
+        Assert.Empty(packs);
+        Assert.Equal(4, retainedSnapshot.Listings.Count);
         Assert.Equal(ContentType.ModLoader, starMap.Type);
         Assert.Equal(InstallAnchor.Standalone, starMap.Install!.Target);
         Assert.Equal("StarMap.exe", starMap.Provides!.Launch);

--- a/tests/Borea.Network.Tests/Index/ContentIndexModPackRepositoryTests.cs
+++ b/tests/Borea.Network.Tests/Index/ContentIndexModPackRepositoryTests.cs
@@ -1,0 +1,239 @@
+using Borea.Core.Index;
+using Borea.Core.ModPacks;
+using Borea.Core.Mods;
+using Borea.Core.Paths;
+using Borea.Network.Index;
+
+namespace Borea.Network.Tests.Index;
+
+public sealed class ContentIndexModPackRepositoryTests
+{
+    [Fact]
+    public async Task Queries_AreCaseInsensitiveStableAndSkipRetractedLatestVersion()
+    {
+        var older = Version("zeta-pack", "1.0.0", name: "Navigation Tools");
+        var latest = Version("zeta-pack", "2.0.0", name: "Navigation Tools");
+        var retracted = Version(
+            "zeta-pack",
+            "3.0.0",
+            name: "Navigation Tools",
+            status: new IndexStatus(IndexStatusState.Retracted, "retracted", reason: "Broken release."));
+        var snapshot = Snapshot(
+            new ContentIndexPack("zeta-pack", [older, latest, retracted], null),
+            new ContentIndexPack("alpha-pack", [Version("alpha-pack", "1.0.0", name: "Science")], null));
+        var repository = new ContentIndexModPackRepository(new FixedSnapshotProvider(snapshot));
+
+        var available = await repository.GetAvailableModPacksAsync();
+        var selected = await repository.GetLatestAsync("ZETA-PACK");
+        var versions = await repository.GetAvailableVersionsAsync("zeta-pack");
+        var search = await repository.SearchAsync("navigation");
+        var noMatch = await repository.SearchAsync("propulsion");
+
+        Assert.Equal(["alpha-pack", "zeta-pack"], available.Select(result => result.Id));
+        Assert.Equal("2.0.0", selected!.Version);
+        Assert.Equal(["2.0.0", "1.0.0"], versions.Select(result => result.Version));
+        Assert.Equal("zeta-pack", Assert.Single(search).Id);
+        Assert.Empty(noMatch);
+    }
+
+    [Fact]
+    public async Task ExactAndIdentityQueries_RetainWarningsAndUnknownIdentities()
+    {
+        var retractedStatus = new IndexStatus(IndexStatusState.Retracted, "retracted", reason: "Broken release.");
+        var disputedStatus = new IndexStatus(IndexStatusState.Disputed, "disputed", reason: "Ownership is disputed.");
+        var unknownStatus = new IndexStatus(IndexStatusState.Unknown, "future-state");
+        var delistedStatus = new IndexStatus(IndexStatusState.Delisted, "delisted", reason: "Removed.");
+        var diagnostics = new[]
+        {
+            Diagnostic("Unknown-Pack", null, ContentIndexDiagnosticScope.Pack),
+            Diagnostic("mixed-pack", "2.0.0", ContentIndexDiagnosticScope.PackVersion),
+            Diagnostic("listing-only", null, ContentIndexDiagnosticScope.Listing),
+            new ContentIndexDiagnostic(
+                ContentIndexDiagnosticKind.UnsupportedValue,
+                ContentIndexDiagnosticScope.IndexStatus,
+                "Unknown pack status.",
+                "status-pack"),
+        };
+        var snapshot = new ContentIndexSnapshot(
+            1,
+            [],
+            [
+                new ContentIndexPack("retracted-pack", [Version("retracted-pack", "1.0.0", status: retractedStatus)], null),
+                new ContentIndexPack("disputed-pack", [Version("disputed-pack", "1.0.0")], disputedStatus),
+                new ContentIndexPack("delisted-pack", [], delistedStatus),
+                new ContentIndexPack("status-pack", [Version("status-pack", "1.0.0")], unknownStatus),
+                new ContentIndexPack("mixed-pack", [Version("mixed-pack", "1.0.0")], null),
+            ],
+            null,
+            diagnostics);
+        var repository = new ContentIndexModPackRepository(new FixedSnapshotProvider(snapshot));
+
+        var retracted = await repository.GetVersionAsync("retracted-pack", ModVersion.Parse("1.0.0"));
+        var disputed = await repository.GetLatestAsync("disputed-pack");
+        var delisted = await repository.GetAsync("DELISTED-PACK");
+        var unknownPack = await repository.GetAsync("unknown-pack");
+        var unknownVersion = await repository.GetVersionAsync("mixed-pack", ModVersion.Parse("2.0.0"));
+        var missingVersion = await repository.GetVersionAsync("status-pack", ModVersion.Parse("9.9.9"));
+        var supportedSibling = await repository.GetVersionAsync("mixed-pack", ModVersion.Parse("1.0.0"));
+        var unknownState = await repository.GetLatestAsync("status-pack");
+        var listingOnly = await repository.GetAsync("listing-only");
+        var missing = await repository.GetAsync("missing-pack");
+
+        Assert.Equal(IndexStatusState.Retracted, retracted!.VersionStatus!.State);
+        Assert.NotNull(retracted.Metadata);
+        Assert.Equal(IndexStatusState.Disputed, disputed!.PackStatus!.State);
+        Assert.Null(delisted!.Metadata);
+        Assert.Equal(IndexStatusState.Delisted, delisted.PackStatus!.State);
+        Assert.Null(unknownPack!.Metadata);
+        Assert.Equal("Unknown-Pack", unknownPack.Id);
+        Assert.Equal(ContentIndexDiagnosticKind.UnsupportedVersion, Assert.Single(unknownPack.Diagnostics).Kind);
+        Assert.Null(unknownVersion!.Metadata);
+        Assert.Equal("2.0.0", unknownVersion.Version);
+        Assert.Null(missingVersion);
+        Assert.NotNull(supportedSibling!.Metadata);
+        Assert.Equal(IndexStatusState.Unknown, unknownState!.PackStatus!.State);
+        Assert.Single(unknownState.Diagnostics);
+        Assert.Null(listingOnly);
+        Assert.Null(missing);
+    }
+
+    [Fact]
+    public async Task ModAndPackRepositories_ShareRefreshCacheAndLastUsableSnapshot()
+    {
+        var time = new TestTimeProvider();
+        var snapshot = Snapshot(new ContentIndexPack("test-pack", [Version("test-pack", "1.0.0")], null));
+        var fetcher = new SequenceFetcher(
+            _ => Task.FromResult(ContentIndexFetchResult.Downloaded),
+            _ => Task.FromException<ContentIndexFetchResult>(new HttpRequestException("offline")));
+        var reader = new CountingReader(snapshot);
+        var provider = new ContentIndexSnapshotProvider(fetcher, reader, new TestPathProvider(), time);
+        var mods = new ContentIndexModRepository(provider);
+        var packs = new ContentIndexModPackRepository(provider);
+
+        Assert.Single(await packs.GetAvailableModPacksAsync());
+        Assert.Empty(await mods.GetAvailableModsAsync());
+        time.UtcNow += TimeSpan.FromMinutes(11);
+        Assert.Single(await packs.GetAvailableModPacksAsync());
+
+        Assert.Equal(2, fetcher.CallCount);
+        Assert.Equal(1, reader.CallCount);
+    }
+
+    [Fact]
+    public async Task OfflineFirstQuery_ReadsTheCachedSnapshot()
+    {
+        var snapshot = Snapshot(new ContentIndexPack("test-pack", [Version("test-pack", "1.0.0")], null));
+        var fetcher = new SequenceFetcher(
+            _ => Task.FromException<ContentIndexFetchResult>(new HttpRequestException("offline")));
+        var reader = new CountingReader(snapshot);
+        var provider = new ContentIndexSnapshotProvider(fetcher, reader, new TestPathProvider());
+
+        Assert.Single(await new ContentIndexModPackRepository(provider).GetAvailableModPacksAsync());
+        Assert.Equal(1, reader.CallCount);
+    }
+
+    [Fact]
+    public async Task ModAndPackRepositories_ShareOneConcurrentRefresh()
+    {
+        var completion = new TaskCompletionSource<ContentIndexFetchResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var fetcher = new SequenceFetcher(_ => completion.Task);
+        var reader = new CountingReader(Snapshot(new ContentIndexPack("test-pack", [Version("test-pack", "1.0.0")], null)));
+        var provider = new ContentIndexSnapshotProvider(fetcher, reader, new TestPathProvider());
+
+        var packQuery = new ContentIndexModPackRepository(provider).GetAvailableModPacksAsync();
+        var modQuery = new ContentIndexModRepository(provider).GetAvailableModsAsync();
+        Assert.Equal(1, fetcher.CallCount);
+
+        completion.SetResult(ContentIndexFetchResult.Downloaded);
+        await Task.WhenAll(packQuery, modQuery);
+
+        Assert.Single(await packQuery);
+        Assert.Empty(await modQuery);
+        Assert.Equal(1, reader.CallCount);
+    }
+
+    private static ContentIndexDiagnostic Diagnostic(string id, string? version, ContentIndexDiagnosticScope scope) => new(
+        ContentIndexDiagnosticKind.UnsupportedVersion,
+        scope,
+        "The document version is not supported.",
+        id,
+        version,
+        2);
+
+    private static ContentIndexSnapshot Snapshot(params ContentIndexPack[] packs) => new(1, [], packs, null, []);
+
+    private static ContentIndexPackVersion Version(
+        string id,
+        string version,
+        string name = "Test Pack",
+        IndexStatus? status = null) => new(
+            new ModPackMetadata(
+                1,
+                id,
+                "index",
+                name,
+                ["Test Author"],
+                "A test pack.",
+                "CC0-1.0",
+                new Dictionary<string, string> { ["forums"] = "https://forums.example/threads/test.1/" },
+                "2026.9.7.5402",
+                ModVersion.Parse(version),
+                new DateTimeOffset(2026, 9, 1, 12, 0, 0, TimeSpan.Zero),
+                [new ModPackEntry("test-mod", ModVersion.Parse("1.0.0"))]),
+            status);
+
+    private sealed class FixedSnapshotProvider(ContentIndexSnapshot snapshot) : IContentIndexSnapshotProvider
+    {
+        public Task<ContentIndexSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(snapshot);
+    }
+
+    private sealed class SequenceFetcher(params Func<CancellationToken, Task<ContentIndexFetchResult>>[] results) : IContentIndexFetcher
+    {
+        private readonly Queue<Func<CancellationToken, Task<ContentIndexFetchResult>>> _results = new(results);
+        public int CallCount { get; private set; }
+
+        public Task<ContentIndexFetchResult> FetchAsync(string destinationPath, CancellationToken ct = default)
+        {
+            CallCount++;
+            return _results.Dequeue()(ct);
+        }
+    }
+
+    private sealed class CountingReader(ContentIndexSnapshot snapshot) : IContentIndexReader
+    {
+        public int CallCount { get; private set; }
+
+        public Task<ContentIndexSnapshot> ReadAsync(CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(snapshot);
+        }
+    }
+
+    private sealed class TestTimeProvider : TimeProvider
+    {
+        public DateTimeOffset UtcNow { get; set; } = new(2026, 9, 12, 12, 0, 0, TimeSpan.Zero);
+        public override DateTimeOffset GetUtcNow() => UtcNow;
+    }
+
+    private sealed class TestPathProvider : IGamePathProvider
+    {
+        public string GetIndexPath() => "index.json";
+        public string GetInstancesRoot() => throw new NotSupportedException();
+        public string GetLoadersRoot() => throw new NotSupportedException();
+        public string GetActiveInstancePointerPath() => throw new NotSupportedException();
+        public string GetModFavoritesPath() => throw new NotSupportedException();
+        public string GetModPackFavoritesPath() => throw new NotSupportedException();
+        public string GetBoreaSettingsPath() => throw new NotSupportedException();
+        public string GetInstanceRoot(Guid instanceId) => throw new NotSupportedException();
+        public string GetInstanceModsFolder(Guid instanceId) => throw new NotSupportedException();
+        public string GetInstanceSavesFolder(Guid instanceId) => throw new NotSupportedException();
+        public string GetInstanceVehiclesFolder(Guid instanceId) => throw new NotSupportedException();
+        public string GetInstanceSettingsPath(Guid instanceId) => throw new NotSupportedException();
+        public string GetInstanceManifestPath(Guid instanceId) => throw new NotSupportedException();
+        public string GetInstanceMetadataPath(Guid instanceId) => throw new NotSupportedException();
+        public string? GetGameDirectoryPath() => throw new NotSupportedException();
+        public string? GetLoaderDirectoryPath(string loaderId) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
Review order: this repository change comes before https://github.com/KSAModding/Borea/pull/117, which uses its shared snapshot provider.

Closes #115.

Borea could parse pack metadata, but callers had no repository through which to find packs or select a version.
This adds those queries and returns the pack's moderation status and diagnostics with the result.
It shares the mod repository's snapshot and cache, so mod and pack queries do not download the index separately.

For example, if pack version 2.0.0 is retracted and 1.0.0 is available, normal latest selection returns 1.0.0.
An explicit request for 2.0.0 still returns that version with its retracted status, allowing a caller to show the warning.
Delisted or unsupported content retains its identity without becoming usable pack metadata.

This supplies pack discovery and version selection.
Installing the selected pack's members remains #7.
