### PR TITLE
Add search and show commands

### DIFF
--- a/src/Borea.Cli/BoreaCli.cs
+++ b/src/Borea.Cli/BoreaCli.cs
@@ -23,6 +23,7 @@ internal static class BoreaCli
         root.Subcommands.Add(GameCommand.Build(services));
         root.Subcommands.Add(IndexCommand.Build(services));
         root.Subcommands.Add(SearchCommand.Build(services));
+        root.Subcommands.Add(ShowCommand.Build(services));
         root.Subcommands.Add(InstanceCommand.Build(services));
         root.Subcommands.Add(ModStateCommands.BuildEnable(services));
         root.Subcommands.Add(ModStateCommands.BuildDisable(services));

--- a/src/Borea.Cli/BoreaCli.cs
+++ b/src/Borea.Cli/BoreaCli.cs
@@ -22,6 +22,7 @@ internal static class BoreaCli
         root.Subcommands.Add(SettingsCommand.Build(services));
         root.Subcommands.Add(GameCommand.Build(services));
         root.Subcommands.Add(IndexCommand.Build(services));
+        root.Subcommands.Add(SearchCommand.Build(services));
         root.Subcommands.Add(InstanceCommand.Build(services));
         root.Subcommands.Add(ModStateCommands.BuildEnable(services));
         root.Subcommands.Add(ModStateCommands.BuildDisable(services));

--- a/src/Borea.Cli/CliServices.cs
+++ b/src/Borea.Cli/CliServices.cs
@@ -39,6 +39,8 @@ internal sealed class CliServices : IDisposable
 
     public required IContentIndexReader IndexReader { get; init; }
 
+    public required IContentIndexSnapshotProvider IndexSnapshots { get; init; }
+
     public required IGamePathProvider Paths { get; init; }
 
     public required IModRepository Mods { get; init; }
@@ -70,6 +72,7 @@ internal sealed class CliServices : IDisposable
         IInstalledGameVersionProvider? installedVersion = null,
         IContentIndexFetcher? indexFetcher = null,
         IContentIndexReader? indexReader = null,
+        IContentIndexSnapshotProvider? indexSnapshots = null,
         IModRepository? mods = null,
         ILoaderInstaller? loaderInstaller = null,
         ILoaderAdopter? loaderAdopter = null,
@@ -90,6 +93,7 @@ internal sealed class CliServices : IDisposable
             InstalledVersion = installedVersion ?? services.InstalledVersion,
             IndexFetcher = indexFetcher ?? services.IndexFetcher,
             IndexReader = indexReader ?? services.IndexReader,
+            IndexSnapshots = indexSnapshots ?? services.IndexSnapshots,
             Paths = services.Paths,
             Mods = mods ?? services.Mods,
             LoaderInstaller = loaderInstaller ?? services.LoaderInstaller,

--- a/src/Borea.Cli/Commands/SearchCommand.cs
+++ b/src/Borea.Cli/Commands/SearchCommand.cs
@@ -1,0 +1,118 @@
+using System.CommandLine;
+using Borea.Cli.Output;
+using Borea.Core.Game;
+using Borea.Core.Index;
+using Borea.Core.Mods;
+
+namespace Borea.Cli.Commands;
+
+internal static class SearchCommand
+{
+    public static Command Build(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var text = ArgumentRules.Text("text", "Text to find in a listing id, name, abstract, description, or tag.");
+        var json = ArgumentRules.Json();
+        var search = new Command("search", "Search the cached content index.");
+        search.Arguments.Add(text);
+        search.Options.Add(json);
+
+        search.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, _, ct) =>
+        {
+            var query = parseResult.GetRequiredValue(text);
+            var installed = cli.InstalledVersion.GetInstalledVersion()?.Version;
+            var listings = await cli.Mods.SearchAsync(query, ct).ConfigureAwait(false);
+            var results = new List<SearchResultView>(listings.Count);
+
+            foreach (var listing in listings)
+            {
+                var latest = await cli.Mods.GetLatestReleaseAsync(listing.ModId, ct).ConfigureAwait(false);
+                results.Add(SearchResultView.From(listing, latest, installed));
+            }
+
+            var snapshot = await cli.IndexSnapshots.GetSnapshotAsync(ct).ConfigureAwait(false);
+            var resultIds = new HashSet<string>(results.Select(result => result.Id), ModIds.Comparer);
+            var unknownListings = snapshot.Diagnostics
+                .Where(diagnostic => diagnostic.Kind == ContentIndexDiagnosticKind.UnsupportedVersion)
+                .Where(diagnostic => diagnostic.Scope == ContentIndexDiagnosticScope.Listing)
+                .Where(diagnostic => diagnostic.Id?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
+                .Where(diagnostic => !resultIds.Contains(diagnostic.Id!))
+                .OrderBy(diagnostic => diagnostic.Id, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            foreach (var diagnostic in unknownListings)
+            {
+                results.Add(new SearchResultView(
+                    diagnostic.Id!,
+                    null,
+                    "unknown",
+                    null,
+                    null,
+                    "unknown",
+                    "unknown"));
+                resultIds.Add(diagnostic.Id!);
+            }
+
+            results.Sort((left, right) => StringComparer.OrdinalIgnoreCase.Compare(left.Id, right.Id));
+            var diagnostics = snapshot.Diagnostics
+                .Where(diagnostic => diagnostic.Id is not null && resultIds.Contains(diagnostic.Id))
+                .Where(diagnostic => diagnostic.Scope is ContentIndexDiagnosticScope.Listing
+                    or ContentIndexDiagnosticScope.Release
+                    or ContentIndexDiagnosticScope.IndexStatus)
+                .Select(ContentOutput.Diagnostic)
+                .ToArray();
+            var view = new SearchView(query, installed?.ToString(), results, diagnostics);
+
+            if (parseResult.GetValue(json))
+                JsonOutput.Write(output, view);
+            else
+                WriteHuman(output, view);
+
+            return ExitCodes.Done;
+        }));
+
+        return search;
+    }
+
+    private static void WriteHuman(TextWriter output, SearchView view)
+    {
+        if (view.Results.Count == 0)
+        {
+            output.WriteLine($"No listings match '{view.Query}'.");
+            return;
+        }
+
+        foreach (var result in view.Results)
+        {
+            var name = result.Name ?? "unknown listing";
+            var version = result.LatestVersion ?? "no release";
+            output.WriteLine($"{result.Id}  {name}  {version}  {result.Compatibility}");
+        }
+
+        ContentOutput.WriteDiagnostics(output, view.Diagnostics);
+    }
+
+    private sealed record SearchView(
+        string Query,
+        string? InstalledGameVersion,
+        IReadOnlyList<SearchResultView> Results,
+        IReadOnlyList<DiagnosticView> Diagnostics);
+
+    private sealed record SearchResultView(
+        string Id,
+        string? Name,
+        string State,
+        string? Type,
+        string? Source,
+        string? LatestVersion,
+        string Compatibility)
+    {
+        public static SearchResultView From(ModMetadata listing, ModVersionMetadata? latest, GameVersion? installed) => new(
+            listing.ModId,
+            listing.Name,
+            "known",
+            ContentOutput.Name(listing.Type),
+            listing.Source,
+            latest?.Version.ToString(),
+            ContentOutput.Name(latest is null ? GameCompatibility.Unknown : Borea.Core.Game.Compatibility.Evaluate(latest, installed)));
+    }
+}

--- a/src/Borea.Cli/Commands/ShowCommand.cs
+++ b/src/Borea.Cli/Commands/ShowCommand.cs
@@ -1,0 +1,371 @@
+using System.CommandLine;
+using Borea.Cli.Output;
+using Borea.Core.Dependencies;
+using Borea.Core.Game;
+using Borea.Core.Index;
+using Borea.Core.Mods;
+
+namespace Borea.Cli.Commands;
+
+internal static class ShowCommand
+{
+    public static Command Build(Func<CancellationToken, Task<CliServices>> services)
+    {
+        var id = ArgumentRules.ContentId("id", "The listing id.");
+        var version = VersionOption();
+        var json = ArgumentRules.Json();
+        var show = new Command("show", "Show one listing or one of its releases.");
+        show.Arguments.Add(id);
+        show.Options.Add(version);
+        show.Options.Add(json);
+
+        show.SetAction((parseResult, cancellationToken) => CommandRunner.RunAsync(parseResult, services, cancellationToken, async (cli, output, _, ct) =>
+        {
+            var listingId = parseResult.GetRequiredValue(id);
+            var requestedText = parseResult.GetValue(version);
+            var requestedVersion = requestedText is null ? (ModVersion?)null : ModVersion.Parse(requestedText);
+            var requestedCanonical = requestedVersion?.ToString();
+            var available = await cli.Mods.GetAvailableModsAsync(ct).ConfigureAwait(false);
+            var repositoryListing = available.FirstOrDefault(listing => ModIds.Equals(listing.ModId, listingId));
+            var repositoryRelease = requestedVersion is null
+                ? null
+                : await cli.Mods.GetReleaseAsync(listingId, requestedVersion.Value, ct).ConfigureAwait(false);
+            var snapshot = await cli.IndexSnapshots.GetSnapshotAsync(ct).ConfigureAwait(false);
+            var indexListing = snapshot.Listings.FirstOrDefault(listing => ModIds.Equals(listing.Id, listingId));
+            var metadata = repositoryListing ?? indexListing?.Authored;
+            var diagnostics = MatchingDiagnostics(snapshot, listingId, requestedCanonical);
+            var hasUnknownListing = diagnostics.Any(diagnostic =>
+                diagnostic.Kind == "unsupported-version" && diagnostic.Scope == "listing");
+
+            if (metadata is null && indexListing is null && !hasUnknownListing)
+                throw new InvalidOperationException($"Listing '{listingId}' was not found.");
+
+            IReadOnlyList<ModVersionMetadata> releases;
+            if (requestedVersion is { } exact)
+            {
+                var release = repositoryRelease
+                    ?? indexListing?.Releases.FirstOrDefault(candidate => candidate.Version.Equals(exact));
+                var hasUnknownRelease = diagnostics.Any(diagnostic =>
+                    diagnostic.Kind == "unsupported-version"
+                    && diagnostic.Scope == "release"
+                    && string.Equals(diagnostic.Version, requestedCanonical, StringComparison.OrdinalIgnoreCase));
+
+                if (release is null && metadata is not null && !hasUnknownRelease)
+                    throw new InvalidOperationException($"Release '{listingId}' {exact} was not found.");
+
+                releases = release is null ? Array.Empty<ModVersionMetadata>() : new[] { release };
+            }
+            else if (indexListing is not null)
+            {
+                releases = indexListing.Releases.OrderByDescending(release => release.Version).ToArray();
+            }
+            else
+            {
+                releases = await GetRepositoryReleasesAsync(cli.Mods, listingId, ct).ConfigureAwait(false);
+            }
+
+            var installed = cli.InstalledVersion.GetInstalledVersion()?.Version;
+            var releaseViews = releases
+                .Select(release => ReleaseView.From(release, installed, requestedVersion is not null))
+                .Concat(diagnostics
+                    .Where(diagnostic => diagnostic.Kind == "unsupported-version")
+                    .Where(diagnostic => diagnostic.Scope == "release")
+                    .Where(diagnostic => diagnostic.Version is not null)
+                    .Where(diagnostic => releases.All(release =>
+                        !string.Equals(release.Version.ToString(), diagnostic.Version, StringComparison.OrdinalIgnoreCase)))
+                    .Select(ReleaseView.Unknown))
+                .ToList();
+            releaseViews.Sort(CompareReleasesNewestFirst);
+            var state = metadata is not null
+                ? "known"
+                : indexListing?.IndexStatus?.State == IndexStatusState.Delisted
+                    ? "delisted"
+                    : "unknown";
+            var view = new ShowView(
+                listingId,
+                state,
+                installed?.ToString(),
+                requestedVersion?.ToString(),
+                metadata is null ? null : ListingView.From(metadata),
+                ContentOutput.IndexStatus(indexListing?.IndexStatus),
+                releaseViews,
+                diagnostics);
+
+            if (parseResult.GetValue(json))
+                JsonOutput.Write(output, view);
+            else
+                WriteHuman(output, view);
+
+            return ExitCodes.Done;
+        }));
+
+        return show;
+    }
+
+    private static Option<string?> VersionOption()
+    {
+        var version = new Option<string?>("--version") { Description = "Show only this release." };
+        version.Validators.Add(result =>
+        {
+            var value = result.GetValueOrDefault<string?>();
+            if (string.IsNullOrWhiteSpace(value) || !ModVersion.TryParse(value, out _))
+                result.AddError($"'{value}' is not a valid semantic version.");
+        });
+        return version;
+    }
+
+    private static async Task<IReadOnlyList<ModVersionMetadata>> GetRepositoryReleasesAsync(
+        IModRepository repository,
+        string id,
+        CancellationToken cancellationToken)
+    {
+        var versions = await repository.GetAvailableVersionsAsync(id, cancellationToken).ConfigureAwait(false);
+        var releases = new List<ModVersionMetadata>(versions.Count);
+        foreach (var version in versions.OrderByDescending(value => value))
+        {
+            var release = await repository.GetReleaseAsync(id, version, cancellationToken).ConfigureAwait(false);
+            if (release is not null)
+                releases.Add(release);
+        }
+        return releases;
+    }
+
+    private static IReadOnlyList<DiagnosticView> MatchingDiagnostics(
+        ContentIndexSnapshot snapshot,
+        string id,
+        string? version)
+    {
+        return snapshot.Diagnostics
+            .Where(diagnostic => ModIds.Equals(diagnostic.Id, id))
+            .Where(diagnostic => version is null
+                || diagnostic.Scope is ContentIndexDiagnosticScope.Listing or ContentIndexDiagnosticScope.IndexStatus
+                || string.Equals(diagnostic.Version, version, StringComparison.OrdinalIgnoreCase))
+            .Select(ContentOutput.Diagnostic)
+            .ToArray();
+    }
+
+    private static void WriteHuman(TextWriter output, ShowView view)
+    {
+        output.WriteLine(view.Listing is null
+            ? $"{view.Id} ({view.State})"
+            : $"{view.Listing.Name} ({view.Id})");
+
+        if (view.Listing is { } listing)
+        {
+            output.WriteLine($"Type: {listing.Type}");
+            output.WriteLine($"Source: {listing.Source}");
+            output.WriteLine($"Authors: {string.Join(", ", listing.Authors)}");
+            output.WriteLine($"License: {listing.License}");
+            output.WriteLine($"Status: {listing.Status}");
+            if (listing.SupersededBy is not null)
+                output.WriteLine($"Superseded by: {listing.SupersededBy}");
+            output.WriteLine(listing.Abstract);
+            if (!string.IsNullOrWhiteSpace(listing.Description))
+                output.WriteLine(listing.Description);
+            if (listing.Tags.Count > 0)
+                output.WriteLine($"Tags: {string.Join(", ", listing.Tags)}");
+            output.WriteLine("Links:");
+            foreach (var link in listing.Links)
+                output.WriteLine($"  {link.Key}: {link.Value}");
+        }
+
+        if (view.IndexStatus is { } status)
+        {
+            var since = status.Since is null ? string.Empty : $" since {status.Since:O}";
+            output.WriteLine($"Index status: {status.State}{since}");
+            if (status.Reason is not null)
+                output.WriteLine($"Index reason: {status.Reason}");
+        }
+
+        if (view.Releases.Count == 0)
+        {
+            output.WriteLine(view.RequestedVersion is null
+                ? "Releases: none"
+                : $"Release {view.RequestedVersion}: unknown");
+        }
+        else
+        {
+            output.WriteLine(view.RequestedVersion is null ? "Releases:" : "Release:");
+            foreach (var release in view.Releases)
+            {
+                if (release.State == "unknown")
+                {
+                    var specVersion = release.SpecVersion is null ? string.Empty : $" (spec version {release.SpecVersion})";
+                    output.WriteLine($"  {release.Version}  unknown{specVersion}: {release.Reason}");
+                    continue;
+                }
+
+                var yanked = release.Yanked
+                    ? release.YankedReason is null ? "  yanked" : $"  yanked: {release.YankedReason}"
+                    : string.Empty;
+                output.WriteLine($"  {release.Version}  {release.Compatibility}  {release.ReleaseStatus}{yanked}");
+                output.WriteLine($"    Game: {release.GameMin} to {release.GameMax ?? "open"}");
+                if (release.Dependencies is not null)
+                {
+                    output.WriteLine(release.Dependencies.Count == 0 ? "    Dependencies: none" : "    Dependencies:");
+                    foreach (var dependency in release.Dependencies)
+                        output.WriteLine($"      {Describe(dependency)}");
+                }
+            }
+        }
+
+        ContentOutput.WriteDiagnostics(output, view.Diagnostics);
+    }
+
+    private static string Describe(DependencyView dependency)
+    {
+        var target = dependency.Id ?? $"any of [{string.Join(", ", dependency.AnyOf!.Select(Describe))}]";
+        var bounds = Bounds(dependency.MinVersion, dependency.MaxVersion);
+        var source = dependency.Source is null ? string.Empty : $" ({dependency.Source})";
+        return $"{dependency.Kind}  {target}{bounds}{source}";
+    }
+
+    private static string Describe(DependencyAlternativeView alternative) =>
+        $"{alternative.Id}{Bounds(alternative.MinVersion, alternative.MaxVersion)}";
+
+    private static string Bounds(string? min, string? max) => (min, max) switch
+    {
+        (null, null) => string.Empty,
+        (not null, null) => $" >= {min}",
+        (null, not null) => $" <= {max}",
+        _ => $" >= {min} <= {max}",
+    };
+
+    private static int CompareReleasesNewestFirst(ReleaseView left, ReleaseView right)
+    {
+        var leftParsed = ModVersion.TryParse(left.Version, out var leftVersion);
+        var rightParsed = ModVersion.TryParse(right.Version, out var rightVersion);
+        if (leftParsed && rightParsed)
+        {
+            var precedence = rightVersion.CompareTo(leftVersion);
+            if (precedence != 0)
+                return precedence;
+        }
+        else if (leftParsed != rightParsed)
+        {
+            return leftParsed ? -1 : 1;
+        }
+
+        return StringComparer.Ordinal.Compare(left.Version, right.Version);
+    }
+
+    private sealed record ShowView(
+        string Id,
+        string State,
+        string? InstalledGameVersion,
+        string? RequestedVersion,
+        ListingView? Listing,
+        IndexStatusView? IndexStatus,
+        IReadOnlyList<ReleaseView> Releases,
+        IReadOnlyList<DiagnosticView> Diagnostics);
+
+    private sealed record ListingView(
+        int SpecVersion,
+        string Id,
+        string Type,
+        string Source,
+        string Name,
+        IReadOnlyList<string> Authors,
+        string Abstract,
+        string? Description,
+        string License,
+        IReadOnlyList<string> Tags,
+        string Status,
+        string? SupersededBy,
+        IReadOnlyDictionary<string, string> Links)
+    {
+        public static ListingView From(ModMetadata listing) => new(
+            listing.SpecVersion,
+            listing.ModId,
+            ContentOutput.Name(listing.Type),
+            listing.Source,
+            listing.Name,
+            listing.Authors,
+            listing.Abstract,
+            listing.Description,
+            listing.License,
+            listing.Tags,
+            ContentOutput.Name(listing.Status),
+            listing.SupersededBy,
+            new SortedDictionary<string, string>(
+                listing.Links.ToDictionary(link => link.Key, link => link.Value),
+                StringComparer.OrdinalIgnoreCase));
+    }
+
+    private sealed record ReleaseView(
+        string State,
+        int? SpecVersion,
+        string Version,
+        string? ReleaseStatus,
+        DateTimeOffset? ReleaseDate,
+        string Compatibility,
+        string? GameMin,
+        int? GameMinRevision,
+        string? GameMax,
+        int? GameMaxRevision,
+        bool Yanked,
+        string? YankedReason,
+        string? Source,
+        IReadOnlyList<DependencyView>? Dependencies,
+        string? Reason)
+    {
+        public static ReleaseView From(ModVersionMetadata release, GameVersion? installed, bool includeDependencies) => new(
+            "known",
+            release.SpecVersion,
+            release.Version.ToString(),
+            ContentOutput.Name(release.ReleaseStatus),
+            release.ReleaseDate,
+            ContentOutput.Name(Borea.Core.Game.Compatibility.Evaluate(release, installed)),
+            release.GameMin,
+            release.GameMinRevision,
+            release.GameMax,
+            release.GameMaxRevision,
+            release.Yanked,
+            release.YankedReason,
+            release.Source,
+            includeDependencies ? release.Dependencies.Select(DependencyView.From).ToArray() : null,
+            null);
+
+        public static ReleaseView Unknown(DiagnosticView diagnostic) => new(
+            "unknown",
+            diagnostic.SpecVersion,
+            diagnostic.Version!,
+            null,
+            null,
+            "unknown",
+            null,
+            null,
+            null,
+            null,
+            false,
+            null,
+            null,
+            null,
+            diagnostic.Reason);
+    }
+
+    private sealed record DependencyView(
+        string Kind,
+        string? Id,
+        string? MinVersion,
+        string? MaxVersion,
+        IReadOnlyList<DependencyAlternativeView>? AnyOf,
+        string? Source)
+    {
+        public static DependencyView From(ModDependency dependency) => new(
+            ContentOutput.Name(dependency.Kind),
+            dependency.ModId,
+            dependency.MinVersion?.ToString(),
+            dependency.MaxVersion?.ToString(),
+            dependency.AnyOf?.Select(DependencyAlternativeView.From).ToArray(),
+            ContentOutput.Name(dependency.Source));
+    }
+
+    private sealed record DependencyAlternativeView(string Id, string? MinVersion, string? MaxVersion)
+    {
+        public static DependencyAlternativeView From(ModDependencyAlternative alternative) => new(
+            alternative.ModId,
+            alternative.MinVersion?.ToString(),
+            alternative.MaxVersion?.ToString());
+    }
+}

--- a/src/Borea.Cli/Output/ContentOutput.cs
+++ b/src/Borea.Cli/Output/ContentOutput.cs
@@ -1,0 +1,116 @@
+using Borea.Core.Dependencies;
+using Borea.Core.Game;
+using Borea.Core.Index;
+using Borea.Core.Mods;
+
+namespace Borea.Cli.Output;
+
+internal static class ContentOutput
+{
+    public static string Name(GameCompatibility compatibility) => compatibility switch
+    {
+        GameCompatibility.Compatible => "compatible",
+        GameCompatibility.Untested => "untested",
+        GameCompatibility.Incompatible => "incompatible",
+        GameCompatibility.Unknown => "unknown",
+        _ => throw new ArgumentOutOfRangeException(nameof(compatibility), compatibility, null),
+    };
+
+    public static string Name(ContentType type) => type switch
+    {
+        ContentType.Mod => "mod",
+        ContentType.ModLoader => "mod-loader",
+        ContentType.ModPack => "modpack",
+        ContentType.Unknown => "unknown",
+        _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
+    };
+
+    public static string Name(ModStatus status) => status switch
+    {
+        ModStatus.Active => "active",
+        ModStatus.Deprecated => "deprecated",
+        ModStatus.Unknown => "unknown",
+        _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),
+    };
+
+    public static string Name(ReleaseStatus status) => status switch
+    {
+        ReleaseStatus.Stable => "stable",
+        ReleaseStatus.Testing => "testing",
+        ReleaseStatus.Dev => "dev",
+        ReleaseStatus.Unknown => "unknown",
+        _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),
+    };
+
+    public static string Name(ModDependencyKind kind) => kind switch
+    {
+        ModDependencyKind.Required => "required",
+        ModDependencyKind.Optional => "optional",
+        ModDependencyKind.Recommends => "recommends",
+        ModDependencyKind.Suggests => "suggests",
+        ModDependencyKind.Conflict => "conflict",
+        ModDependencyKind.Unknown => "unknown",
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
+    };
+
+    public static string? Name(MetadataSource? source) => source switch
+    {
+        null => null,
+        MetadataSource.Authored => "authored",
+        MetadataSource.Derived => "derived",
+        MetadataSource.Unknown => "unknown",
+        _ => throw new ArgumentOutOfRangeException(nameof(source), source, null),
+    };
+
+    public static DiagnosticView Diagnostic(ContentIndexDiagnostic diagnostic) => new(
+        diagnostic.Kind switch
+        {
+            ContentIndexDiagnosticKind.Malformed => "malformed",
+            ContentIndexDiagnosticKind.UnsupportedVersion => "unsupported-version",
+            ContentIndexDiagnosticKind.UnsupportedValue => "unsupported-value",
+            _ => throw new ArgumentOutOfRangeException(nameof(diagnostic), diagnostic.Kind, null),
+        },
+        diagnostic.Scope switch
+        {
+            ContentIndexDiagnosticScope.Listing => "listing",
+            ContentIndexDiagnosticScope.Release => "release",
+            ContentIndexDiagnosticScope.Pack => "pack",
+            ContentIndexDiagnosticScope.PackVersion => "pack-version",
+            ContentIndexDiagnosticScope.IndexStatus => "index-status",
+            ContentIndexDiagnosticScope.GameVersions => "game-versions",
+            _ => throw new ArgumentOutOfRangeException(nameof(diagnostic), diagnostic.Scope, null),
+        },
+        diagnostic.Reason,
+        diagnostic.Id,
+        diagnostic.Version,
+        diagnostic.SpecVersion);
+
+    public static IndexStatusView? IndexStatus(IndexStatus? status) => status is null
+        ? null
+        : new IndexStatusView(status.RawState, status.Since, status.Reason);
+
+    public static void WriteDiagnostics(TextWriter output, IReadOnlyList<DiagnosticView> diagnostics)
+    {
+        if (diagnostics.Count == 0)
+            return;
+
+        output.WriteLine("Diagnostics:");
+        foreach (var diagnostic in diagnostics)
+        {
+            var identity = diagnostic.Id is null ? string.Empty : $" {diagnostic.Id}";
+            var version = diagnostic.Version is null ? string.Empty : $" {diagnostic.Version}";
+            var specVersion = diagnostic.SpecVersion is null ? string.Empty : $" (spec version {diagnostic.SpecVersion})";
+            output.WriteLine($"  {diagnostic.Kind} {diagnostic.Scope}{identity}{version}{specVersion}: {diagnostic.Reason}");
+        }
+    }
+}
+
+internal sealed record DiagnosticView(
+    string Kind,
+    string Scope,
+    string Reason,
+    string? Id,
+    string? Version,
+    int? SpecVersion);
+
+internal sealed record IndexStatusView(string State, DateTimeOffset? Since, string? Reason);

--- a/src/Borea.Composition/BoreaServices.cs
+++ b/src/Borea.Composition/BoreaServices.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Headers;
+using Borea.Core.Dependencies;
 using Borea.Core.Game;
 using Borea.Core.Index;
 using Borea.Core.Instances;
@@ -7,11 +8,13 @@ using Borea.Core.ModLoaders;
 using Borea.Core.ModPacks;
 using Borea.Core.Mods;
 using Borea.Core.Paths;
+using Borea.Core.Planning;
 using Borea.Core.Settings;
 using Borea.Core.State;
 using Borea.Network.Downloads;
 using Borea.Network.Index;
 using Borea.Network.MasterServer;
+using Borea.Network.Planning;
 using Borea.Network.Sources;
 using Borea.Network.SpaceDock;
 using Borea.Storage.Game;
@@ -88,6 +91,8 @@ public sealed class BoreaServices : IDisposable
     public required IModPackRepository ModPacks { get; init; }
 
     public required IModDownloader Downloader { get; init; }
+
+    public required IInstallPlanner InstallPlanner { get; init; }
 
     public required ILoaderInstaller LoaderInstaller { get; init; }
 
@@ -200,6 +205,7 @@ public sealed class BoreaServices : IDisposable
             Mods = mods,
             ModPacks = modPacks,
             Downloader = downloader,
+            InstallPlanner = new RepositoryInstallPlanner(new ModDependencyResolver()),
             LoaderInstaller = new FileLoaderInstaller(paths, downloader, settingsRepository, loaderConfiguration),
             LoaderAdopter = new FileLoaderAdopter(settingsRepository, loaderConfiguration),
             LoaderUninstaller = new FileLoaderUninstaller(settingsRepository),

--- a/src/Borea.Composition/BoreaServices.cs
+++ b/src/Borea.Composition/BoreaServices.cs
@@ -81,6 +81,8 @@ public sealed class BoreaServices : IDisposable
 
     public required IModUninstaller Uninstaller { get; init; }
 
+    public required IModReplacer Replacer { get; init; }
+
     public required IForeignModAdopter ForeignModAdopter { get; init; }
 
     /// <summary>
@@ -190,6 +192,8 @@ public sealed class BoreaServices : IDisposable
         var loaderConfiguration = new LoaderConfigurator();
         var instances = new FileInstanceRepository(paths);
 
+        var modState = new FileModStateRepository(paths);
+
         return new BoreaServices(http)
         {
             Settings = settings,
@@ -197,10 +201,11 @@ public sealed class BoreaServices : IDisposable
             SettingsRepository = settingsRepository,
             GameDirectoryChanger = new GameDirectoryChanger(settingsRepository, mods, loaderConfiguration),
             Instances = instances,
-            ModState = new FileModStateRepository(paths),
+            ModState = modState,
             ModFavorites = new FileModFavoritesRepository(paths),
             ModPackFavorites = new FileModPackFavoritesRepository(paths),
             Uninstaller = new FileModUninstaller(paths, instances),
+            Replacer = new FileModReplacer(paths, downloader, instances, modState),
             ForeignModAdopter = new FileForeignModAdopter(paths, instances, contentIndex),
             Mods = mods,
             ModPacks = modPacks,

--- a/src/Borea.Core/Instances/Instance.cs
+++ b/src/Borea.Core/Instances/Instance.cs
@@ -130,6 +130,17 @@ public sealed class Instance
         return true;
     }
 
+    public void ReplaceMod(InstalledMod replacement)
+    {
+        ArgumentNullException.ThrowIfNull(replacement);
+
+        var index = _mods.FindIndex(mod => ModIds.Equals(mod.ModId, replacement.ModId));
+        if (index < 0)
+            throw new InvalidOperationException($"Mod '{replacement.ModId}' is not installed in this instance.");
+
+        _mods[index] = replacement;
+    }
+
     public void ReplaceForeignMods(IReadOnlyList<ForeignMod> foreignMods)
     {
         ArgumentNullException.ThrowIfNull(foreignMods);

--- a/src/Borea.Core/Mods/IModInstaller.cs
+++ b/src/Borea.Core/Mods/IModInstaller.cs
@@ -1,4 +1,5 @@
 using Borea.Core.State;
+using Borea.Core.Planning;
 
 namespace Borea.Core.Mods;
 
@@ -42,6 +43,15 @@ public interface IModInstaller
         bool enable,
         IProgress<DownloadProgress>? progress = null,
         CancellationToken cancellationToken = default);
+
+    Task<GuardedInstallResult> InstallGuardedAsync(
+        Guid instanceId,
+        ModVersionMetadata release,
+        InstallReason reason,
+        bool enable,
+        InstallPlanningState expectedState,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -51,3 +61,5 @@ public interface IModInstaller
 /// <param name="Download">Where the archive came from and what it hashed to.</param>
 /// <param name="ManifestEntry">Whether the manifest entry was written or was already there.</param>
 public sealed record InstallResult(InstalledMod Mod, DownloadResult Download, ModEntryAddResult ManifestEntry);
+
+public sealed record GuardedInstallResult(InstallResult Result, InstallPlanningState State);

--- a/src/Borea.Core/Mods/IModReplacer.cs
+++ b/src/Borea.Core/Mods/IModReplacer.cs
@@ -1,0 +1,39 @@
+namespace Borea.Core.Mods;
+
+public interface IModReplacer
+{
+    Task<ModReplacementResult> ReplaceAsync(
+        Guid instanceId,
+        InstalledMod expectedCurrent,
+        ModVersionMetadata replacement,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record ModReplacementResult(
+    InstalledMod Previous,
+    InstalledMod Replacement,
+    DownloadResult Download,
+    string? RetainedRecoveryDirectory);
+
+public sealed class ModReplacementRecoveryException : Exception
+{
+    public Exception OperationError { get; }
+
+    public Exception RecoveryError { get; }
+
+    public string RecoveryDirectory { get; }
+
+    public ModReplacementRecoveryException(
+        Exception operationError,
+        Exception recoveryError,
+        string recoveryDirectory)
+        : base("The mod replacement failed, and Borea could not restore the previous installation.", operationError)
+    {
+        OperationError = operationError ?? throw new ArgumentNullException(nameof(operationError));
+        RecoveryError = recoveryError ?? throw new ArgumentNullException(nameof(recoveryError));
+        RecoveryDirectory = string.IsNullOrWhiteSpace(recoveryDirectory)
+            ? throw new ArgumentException("Recovery directory cannot be null or whitespace.", nameof(recoveryDirectory))
+            : recoveryDirectory;
+    }
+}

--- a/src/Borea.Core/Mods/IModReplacer.cs
+++ b/src/Borea.Core/Mods/IModReplacer.cs
@@ -1,3 +1,5 @@
+using Borea.Core.Planning;
+
 namespace Borea.Core.Mods;
 
 public interface IModReplacer
@@ -8,6 +10,14 @@ public interface IModReplacer
         ModVersionMetadata replacement,
         IProgress<DownloadProgress>? progress = null,
         CancellationToken cancellationToken = default);
+
+    Task<GuardedModReplacementResult> ReplaceGuardedAsync(
+        Guid instanceId,
+        InstalledMod expectedCurrent,
+        ModVersionMetadata replacement,
+        InstallPlanningState expectedState,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default);
 }
 
 public sealed record ModReplacementResult(
@@ -15,6 +25,8 @@ public sealed record ModReplacementResult(
     InstalledMod Replacement,
     DownloadResult Download,
     string? RetainedRecoveryDirectory);
+
+public sealed record GuardedModReplacementResult(ModReplacementResult Result, InstallPlanningState State);
 
 public sealed class ModReplacementRecoveryException : Exception
 {

--- a/src/Borea.Core/Planning/IInstallPlanner.cs
+++ b/src/Borea.Core/Planning/IInstallPlanner.cs
@@ -1,0 +1,10 @@
+using Borea.Core.Mods;
+
+namespace Borea.Core.Planning;
+
+public interface IInstallPlanner
+{
+    Task<InstallPlan> PlanAsync(InstallPlanningRequest request, CancellationToken cancellationToken = default);
+}
+
+public sealed record RequestedMod(ModVersionMetadata Release, InstallReason Reason, bool Exact = true);

--- a/src/Borea.Core/Planning/InstallPlan.cs
+++ b/src/Borea.Core/Planning/InstallPlan.cs
@@ -1,0 +1,34 @@
+using Borea.Core.Game;
+using Borea.Core.Mods;
+
+namespace Borea.Core.Planning;
+
+public sealed record PlannedInstall(ModVersionMetadata Release, InstallReason Reason, GameCompatibility Compatibility, OsSupport? PlatformSupport);
+public sealed record PlannedSelection(ModVersionMetadata Release, InstallReason Reason, bool IsAlreadyInstalled);
+public sealed record PlanningMessage(string ModId, string Code, string Message);
+public sealed record PlanningChoice(string Key, string OwnerModId, string Kind, IReadOnlyList<string> Options, string? Selected);
+
+public sealed class InstallPlan
+{
+    public Guid InstanceId { get; }
+    public InstallPlanningState InstanceState { get; }
+    public IReadOnlyList<PlannedSelection> Selections { get; }
+    public IReadOnlyList<PlannedInstall> Operations { get; }
+    public IReadOnlyList<PlanningMessage> Warnings { get; }
+    public IReadOnlyList<PlanningMessage> UnresolvedChoices { get; }
+    public IReadOnlyList<PlanningMessage> Conflicts { get; }
+    public IReadOnlyList<PlanningChoice> Choices { get; }
+    public bool IsReady => UnresolvedChoices.Count == 0 && Conflicts.Count == 0;
+
+    public InstallPlan(Guid instanceId, InstallPlanningState instanceState, IReadOnlyList<PlannedSelection> selections, IReadOnlyList<PlannedInstall> operations, IReadOnlyList<PlanningMessage> warnings, IReadOnlyList<PlanningMessage> unresolvedChoices, IReadOnlyList<PlanningMessage> conflicts, IReadOnlyList<PlanningChoice> choices)
+    {
+        InstanceId = instanceId;
+        InstanceState = instanceState;
+        Selections = selections;
+        Operations = operations;
+        Warnings = warnings;
+        UnresolvedChoices = unresolvedChoices;
+        Conflicts = conflicts;
+        Choices = choices;
+    }
+}

--- a/src/Borea.Core/Planning/InstallPlanningRequest.cs
+++ b/src/Borea.Core/Planning/InstallPlanningRequest.cs
@@ -1,0 +1,14 @@
+using Borea.Core.Game;
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+
+namespace Borea.Core.Planning;
+
+public sealed record InstallPlanningRequest(
+    Instance Instance,
+    IReadOnlyList<RequestedMod> Requested,
+    IModRepository Repository,
+    GameVersion? GameVersion = null,
+    OsPlatform? TargetPlatform = null,
+    IReadOnlySet<string>? Recommended = null,
+    IReadOnlyDictionary<string, string>? Alternatives = null);

--- a/src/Borea.Core/Planning/InstallPlanningState.cs
+++ b/src/Borea.Core/Planning/InstallPlanningState.cs
@@ -1,0 +1,98 @@
+using System.Security.Cryptography;
+using System.Text;
+using Borea.Core.Dependencies;
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+
+namespace Borea.Core.Planning;
+
+public sealed record InstallPlanningState(string Value)
+{
+    public static InstallPlanningState Capture(Instance instance)
+    {
+        ArgumentNullException.ThrowIfNull(instance);
+        var value = new StringBuilder();
+        Add(value, instance.InstanceId.ToString("D"));
+        Add(value, Source(instance.Source));
+        Add(value, instance.Mods.Count.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        foreach (var mod in instance.Mods.OrderBy(item => item.ModId, ModIds.Comparer))
+        {
+            Add(value, "managed");
+            Add(value, mod.ModId);
+            Add(value, mod.Version.ToString());
+            Add(value, mod.Reason.ToString());
+            Add(value, mod.Ownership.ToString());
+            Add(value, mod.OwnershipToken);
+            Add(value, mod.Checksum);
+            Add(value, mod.Metadata.ModId);
+            Add(value, mod.Metadata.Version.ToString());
+            Add(value, mod.Metadata.GameMinRevision.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            Add(value, mod.Metadata.GameMaxRevision?.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            Add(value, mod.Metadata.Os?.Count.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            foreach (var platform in mod.Metadata.Os ?? []) Add(value, platform);
+            Add(value, mod.Metadata.Yanked ? "yanked" : "available");
+            Add(value, mod.Metadata.YankedReason);
+            AddDependencies(value, mod.Metadata.Dependencies);
+        }
+        Add(value, instance.ForeignMods.Count.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        foreach (var mod in instance.ForeignMods.OrderBy(item => item.ModId, ModIds.Comparer))
+        {
+            Add(value, "foreign");
+            Add(value, mod.ModId);
+            Add(value, mod.DependencyReadError);
+            Add(value, mod.Dependencies.Count.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            foreach (var dependency in mod.Dependencies.OrderBy(item => item.ModId, StringComparer.Ordinal).ThenBy(item => item.Optional))
+            {
+                Add(value, dependency.ModId);
+                Add(value, dependency.Optional ? "optional" : "required");
+            }
+        }
+        return new InstallPlanningState(Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value.ToString()))));
+    }
+
+    public bool Matches(Instance instance) => this == Capture(instance);
+
+    private static void AddDependencies(StringBuilder value, IReadOnlyList<ModDependency> dependencies)
+    {
+        Add(value, dependencies.Count.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        foreach (var dependency in dependencies)
+        {
+            Add(value, dependency.Kind.ToString());
+            Add(value, dependency.Source?.ToString());
+            if (dependency.IsAnyOf)
+            {
+                Add(value, "any-of");
+                Add(value, dependency.AnyOf.Count.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                foreach (var alternative in dependency.AnyOf)
+                {
+                    Add(value, alternative.ModId);
+                    Add(value, alternative.MinVersion?.ToString());
+                    Add(value, alternative.MaxVersion?.ToString());
+                }
+            }
+            else
+            {
+                Add(value, dependency.ModId);
+                Add(value, dependency.MinVersion?.ToString());
+                Add(value, dependency.MaxVersion?.ToString());
+            }
+        }
+    }
+
+    private static string Source(InstanceSource source) => source switch
+    {
+        InstanceSource.Custom => "custom",
+        InstanceSource.FromModPack pack => $"pack:{pack.ModPackId}:{pack.Version}",
+        _ => throw new ArgumentOutOfRangeException(nameof(source)),
+    };
+
+    private static void Add(StringBuilder value, string? field)
+    {
+        if (field is null)
+        {
+            value.Append("-1:");
+            return;
+        }
+        value.Append(field.Length).Append(':').Append(field);
+    }
+}

--- a/src/Borea.Network/Planning/RepositoryInstallPlanner.cs
+++ b/src/Borea.Network/Planning/RepositoryInstallPlanner.cs
@@ -1,0 +1,307 @@
+using Borea.Core.Dependencies;
+using Borea.Core.Game;
+using Borea.Core.Mods;
+using Borea.Core.Planning;
+
+namespace Borea.Network.Planning;
+
+public sealed class RepositoryInstallPlanner : IInstallPlanner
+{
+    private const int SearchLimit = 100_000;
+    private readonly ModDependencyResolver _resolver;
+
+    public RepositoryInstallPlanner(ModDependencyResolver resolver) => _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+
+    public async Task<InstallPlan> PlanAsync(InstallPlanningRequest request, CancellationToken cancellationToken = default)
+    {
+        Validate(request);
+        var roots = BuildRoots(request, out var initialConflicts);
+        var domains = await BuildDomainsAsync(request, roots, cancellationToken).ConfigureAwait(false);
+        var ids = domains.Keys.OrderBy(value => value, ModIds.Comparer).ToList();
+        SearchResult? best = null;
+        var states = 0;
+        var truncated = false;
+        var assigned = new Dictionary<string, RequestedMod?>(ModIds.Comparer);
+
+        void Search(int index)
+        {
+            if (++states > SearchLimit) { truncated = true; return; }
+            if (index == ids.Count)
+            {
+                var result = Evaluate(request, roots, assigned, initialConflicts);
+                if (best is null || result.Score.CompareTo(best.Score) < 0) best = result;
+                return;
+            }
+            var id = ids[index];
+            foreach (var candidate in domains[id])
+            {
+                assigned[id] = candidate;
+                Search(index + 1);
+            }
+            assigned.Remove(id);
+        }
+
+        Search(0);
+        if (truncated)
+        {
+            var conflict = Message("planning", "search-limit", $"Planning exceeded the deterministic limit of {SearchLimit} candidate states.");
+            return new InstallPlan(request.Instance.InstanceId, InstallPlanningState.Capture(request.Instance), [], [], [], [], [conflict], []);
+        }
+        if (best is null)
+        {
+            var conflict = Message("planning", "search-limit", $"Planning exceeded the deterministic limit of {SearchLimit} candidate states.");
+            return new InstallPlan(request.Instance.InstanceId, InstallPlanningState.Capture(request.Instance), [], [], [], [], [conflict], []);
+        }
+        return ToPlan(request, best);
+    }
+
+    private static Dictionary<string, RequestedMod> BuildRoots(InstallPlanningRequest request, out List<PlanningMessage> conflicts)
+    {
+        var roots = new Dictionary<string, RequestedMod>(ModIds.Comparer);
+        conflicts = [];
+        foreach (var item in request.Requested.OrderBy(value => value.Release.ModId, ModIds.Comparer))
+        {
+            if (request.Instance.ForeignMods.Any(value => ModIds.Equals(value.ModId, item.Release.ModId)))
+                conflicts.Add(Message(item.Release.ModId, "foreign-owned", "A managed install cannot replace foreign content."));
+            if (roots.TryGetValue(item.Release.ModId, out var previous) && previous.Exact && item.Exact && previous.Release.Version != item.Release.Version)
+                conflicts.Add(Message(item.Release.ModId, "exact-pin-conflict", $"Exact versions {previous.Release.Version} and {item.Release.Version} were both requested."));
+            else if (!roots.TryGetValue(item.Release.ModId, out previous) || item.Exact || !previous.Exact)
+                roots[item.Release.ModId] = item;
+        }
+        return roots;
+    }
+
+    private static async Task<Dictionary<string, IReadOnlyList<RequestedMod?>>> BuildDomainsAsync(InstallPlanningRequest request, Dictionary<string, RequestedMod> roots, CancellationToken cancellationToken)
+    {
+        var releases = new Dictionary<string, List<ModVersionMetadata>>(ModIds.Comparer);
+        var pending = new Queue<string>(roots.Keys.OrderBy(value => value, ModIds.Comparer));
+        var seen = new HashSet<string>(ModIds.Comparer);
+        while (pending.Count > 0)
+        {
+            var id = pending.Dequeue();
+            if (!seen.Add(id)) continue;
+            var values = new List<ModVersionMetadata>();
+            if (roots.TryGetValue(id, out var root) && root.Exact)
+                values.Add(root.Release);
+            else if (!request.Instance.ForeignMods.Any(value => ModIds.Equals(value.ModId, id)))
+            {
+                if (request.Instance.Mods.FirstOrDefault(value => ModIds.Equals(value.ModId, id)) is { } installed && !roots.ContainsKey(id)) values.Add(installed.Metadata);
+                foreach (var version in (await request.Repository.GetAvailableVersionsAsync(id, cancellationToken).ConfigureAwait(false)).OrderByDescending(value => value))
+                {
+                    var release = await request.Repository.GetReleaseAsync(id, version, cancellationToken).ConfigureAwait(false);
+                    if (release is { Yanked: false }) values.Add(release);
+                }
+            }
+            if (roots.TryGetValue(id, out root) && values.All(value => value.Version != root.Release.Version)) values.Add(root.Release);
+            releases[id] = values.DistinctBy(value => value.Version).OrderByDescending(value => value.Version).ToList();
+            foreach (var dependencyId in releases[id].SelectMany(DependencyIds).Distinct(ModIds.Comparer).OrderBy(value => value, ModIds.Comparer)) pending.Enqueue(dependencyId);
+        }
+
+        return releases.ToDictionary(
+            pair => pair.Key,
+            pair => (IReadOnlyList<RequestedMod?>)pair.Value.Select(value => new RequestedMod(value, roots.TryGetValue(pair.Key, out var root) ? root.Reason : InstallReason.Dependency, roots.TryGetValue(pair.Key, out root) && root.Exact)).Cast<RequestedMod?>().Concat(roots.TryGetValue(pair.Key, out var requested) && requested.Exact ? [] : [null]).ToList(),
+            ModIds.Comparer);
+    }
+
+    private static IEnumerable<string> DependencyIds(ModVersionMetadata release) => release.Dependencies.SelectMany(value => value.IsAnyOf ? value.AnyOf.Select(item => item.ModId) : value.ModId is null ? [] : [value.ModId]);
+
+    private SearchResult Evaluate(InstallPlanningRequest request, Dictionary<string, RequestedMod> roots, Dictionary<string, RequestedMod?> assigned, IReadOnlyList<PlanningMessage> initialConflicts)
+    {
+        var selected = assigned.Where(value => value.Value is not null).ToDictionary(value => value.Key, value => value.Value!, ModIds.Comparer);
+        ExpandInstalledClosure(request, roots, selected);
+        var warnings = new List<PlanningMessage>();
+        var unresolved = new List<PlanningMessage>();
+        var conflicts = new List<PlanningMessage>(initialConflicts);
+        var choices = new List<PlanningChoice>();
+        var proposed = BuildProposedInstance(request, selected);
+
+        foreach (var root in roots.Values)
+        {
+            if (!selected.TryGetValue(root.Release.ModId, out var chosen)) conflicts.Add(Message(root.Release.ModId, "missing-request", "No release was selected for the request."));
+            else if (root.Exact && chosen.Release.Version != root.Release.Version) conflicts.Add(Message(root.Release.ModId, "exact-pin", $"Exact version {root.Release.Version} was not selected."));
+        }
+
+        foreach (var item in selected.Values.OrderBy(value => value.Release.ModId, ModIds.Comparer))
+        {
+            EvaluateRelease(request, item.Release, selected, warnings, unresolved, conflicts, choices);
+            foreach (var evaluation in _resolver.Evaluate(proposed, item.Release).Where(value => value.Outcome == DependencyOutcome.Conflict)) conflicts.Add(Message(item.Release.ModId, "proposed-conflict", evaluation.Dependency.ToString()));
+        }
+        EvaluateRetainedInstalled(request, selected, unresolved, conflicts);
+        return new SearchResult(selected, Sort(warnings), Sort(unresolved), Sort(conflicts), choices.OrderBy(value => value.Key, StringComparer.Ordinal).ToList());
+    }
+
+    private static void EvaluateRelease(InstallPlanningRequest request, ModVersionMetadata release, Dictionary<string, RequestedMod> selected, List<PlanningMessage> warnings, List<PlanningMessage> unresolved, List<PlanningMessage> conflicts, List<PlanningChoice> choices)
+    {
+        if (release.Yanked) warnings.Add(Message(release.ModId, "yanked", release.YankedReason ?? "The selected release is yanked."));
+        var compatibility = Compatibility.Evaluate(release, request.GameVersion);
+        if (compatibility == GameCompatibility.Incompatible) conflicts.Add(Message(release.ModId, "incompatible", "The release is incompatible with the target game."));
+        else if (compatibility != GameCompatibility.Compatible) warnings.Add(Message(release.ModId, "compatibility", $"Game compatibility is {compatibility}."));
+        if (request.TargetPlatform is { } target)
+        {
+            var support = Compatibility.EvaluateOs(release.Os, target);
+            if (!support.IsSupported) warnings.Add(Message(release.ModId, "platform", $"The release does not list {target} as a supported platform."));
+            foreach (var value in support.Unrecognized) warnings.Add(Message(release.ModId, "platform-unknown", $"The release contains the unknown platform '{value}'."));
+        }
+
+        for (var index = 0; index < release.Dependencies.Count; index++)
+        {
+            var dependency = release.Dependencies[index];
+            var key = ChoiceKey(release.ModId, index, "recommendation");
+            if (dependency.Kind == ModDependencyKind.Unknown) { unresolved.Add(Message(release.ModId, "unknown-dependency", dependency.ToString())); continue; }
+            if (dependency.Kind == ModDependencyKind.Recommends)
+            {
+                var chosen = request.Recommended?.Contains(key) ?? false;
+                choices.Add(new PlanningChoice(key, release.ModId, "recommendation", ["include", "exclude"], chosen ? "include" : "exclude"));
+                if (!chosen) continue;
+            }
+            if (dependency.Kind is ModDependencyKind.Optional or ModDependencyKind.Suggests) continue;
+            if (dependency.IsAnyOf) EvaluateAlternative(request, release.ModId, ChoiceKey(release.ModId, index, "alternative"), dependency, selected, unresolved, conflicts, choices);
+            else EvaluateSingle(request, release.ModId, dependency, selected, unresolved, conflicts);
+        }
+    }
+
+    private static void EvaluateSingle(InstallPlanningRequest request, string owner, ModDependency dependency, Dictionary<string, RequestedMod> selected, List<PlanningMessage> unresolved, List<PlanningMessage> conflicts)
+    {
+        var version = FindManagedVersion(request, selected, dependency.ModId!);
+        var foreign = request.Instance.ForeignMods.Any(value => ModIds.Equals(value.ModId, dependency.ModId));
+        if (dependency.Kind == ModDependencyKind.Conflict)
+        {
+            if (version is { } found && dependency.BoundsContain(found)) conflicts.Add(Message(owner, "dependency-conflict", dependency.ToString()));
+            else if (foreign && (dependency.MinVersion is not null || dependency.MaxVersion is not null)) unresolved.Add(Message(owner, "foreign-conflict-unknown", dependency.ToString()));
+            else if (foreign) conflicts.Add(Message(owner, "foreign-conflict", dependency.ToString()));
+            return;
+        }
+        if (version is { } installed && dependency.BoundsContain(installed)) return;
+        if (foreign && dependency.MinVersion is null && dependency.MaxVersion is null) return;
+        if (foreign) unresolved.Add(Message(owner, "foreign-version-unknown", dependency.ToString()));
+        else conflicts.Add(Message(owner, "unsatisfied-dependency", dependency.ToString()));
+    }
+
+    private static void EvaluateAlternative(InstallPlanningRequest request, string owner, string key, ModDependency dependency, Dictionary<string, RequestedMod> selected, List<PlanningMessage> unresolved, List<PlanningMessage> conflicts, List<PlanningChoice> choices)
+    {
+        var satisfied = dependency.AnyOf!.FirstOrDefault(value => ExistingAlternativeSatisfied(request, selected, value) && ForcedAlternative(request, selected, value.ModId));
+        string? requested = null;
+        request.Alternatives?.TryGetValue(key, out requested);
+        choices.Add(new PlanningChoice(key, owner, "alternative", dependency.AnyOf!.Select(value => value.ModId).ToList(), requested ?? satisfied?.ModId));
+        if (satisfied is not null && requested is null) return;
+        if (requested is null) { unresolved.Add(Message(owner, "alternative-choice", $"Select one alternative for {dependency}.")); return; }
+        var chosen = dependency.AnyOf!.FirstOrDefault(value => ModIds.Equals(value.ModId, requested));
+        if (chosen is null) { conflicts.Add(Message(owner, "invalid-alternative", $"'{requested}' is not an available alternative.")); return; }
+        if (AlternativeSatisfied(request, selected, chosen)) return;
+        if (request.Instance.ForeignMods.Any(value => ModIds.Equals(value.ModId, chosen.ModId))) unresolved.Add(Message(owner, "foreign-alternative-unknown", chosen.ModId));
+        else conflicts.Add(Message(owner, "unsatisfied-alternative", chosen.ModId));
+    }
+
+    private static void EvaluateRetainedInstalled(InstallPlanningRequest request, Dictionary<string, RequestedMod> selected, List<PlanningMessage> unresolved, List<PlanningMessage> conflicts)
+    {
+        foreach (var installed in request.Instance.Mods.Where(value => !selected.ContainsKey(value.ModId)))
+            foreach (var dependency in installed.Metadata.Dependencies)
+            {
+                if (dependency.Kind == ModDependencyKind.Required && dependency.IsAnyOf && !dependency.AnyOf.Any(value => AlternativeSatisfied(request, selected, value)))
+                {
+                    if (dependency.AnyOf.Any(value => request.Instance.ForeignMods.Any(foreign => ModIds.Equals(foreign.ModId, value.ModId)) && (value.MinVersion is not null || value.MaxVersion is not null))) unresolved.Add(Message(installed.ModId, "foreign-alternative-unknown", dependency.ToString()));
+                    else conflicts.Add(Message(installed.ModId, "retained-alternative", dependency.ToString()));
+                }
+                else if (!dependency.IsAnyOf && selected.TryGetValue(dependency.ModId!, out var planned))
+                {
+                    if (dependency.Kind == ModDependencyKind.Required && !dependency.BoundsContain(planned.Release.Version)) conflicts.Add(Message(installed.ModId, "retained-dependent", dependency.ToString()));
+                    if (dependency.Kind == ModDependencyKind.Conflict && dependency.BoundsContain(planned.Release.Version)) conflicts.Add(Message(installed.ModId, "retained-conflict", dependency.ToString()));
+                }
+                else if (!dependency.IsAnyOf && dependency.Kind == ModDependencyKind.Required)
+                {
+                    var local = request.Instance.Mods.FirstOrDefault(value => ModIds.Equals(value.ModId, dependency.ModId));
+                    if (local is not null && dependency.BoundsContain(local.Version)) continue;
+                    var foreign = request.Instance.ForeignMods.Any(value => ModIds.Equals(value.ModId, dependency.ModId));
+                    if (foreign && (dependency.MinVersion is not null || dependency.MaxVersion is not null)) unresolved.Add(Message(installed.ModId, "foreign-version-unknown", dependency.ToString()));
+                    else if (!foreign) conflicts.Add(Message(installed.ModId, "retained-unsatisfied", dependency.ToString()));
+                }
+            }
+    }
+
+    private static ModVersion? FindManagedVersion(InstallPlanningRequest request, Dictionary<string, RequestedMod> selected, string id) => selected.TryGetValue(id, out var item) ? item.Release.Version : request.Instance.Mods.FirstOrDefault(value => ModIds.Equals(value.ModId, id))?.Version;
+    private static bool AlternativeSatisfied(InstallPlanningRequest request, Dictionary<string, RequestedMod> selected, ModDependencyAlternative alternative) => FindManagedVersion(request, selected, alternative.ModId) is { } version ? alternative.BoundsContain(version) : request.Instance.ForeignMods.Any(value => ModIds.Equals(value.ModId, alternative.ModId)) && alternative.MinVersion is null && alternative.MaxVersion is null;
+    private static bool ExistingAlternativeSatisfied(InstallPlanningRequest request, Dictionary<string, RequestedMod> selected, ModDependencyAlternative alternative) => FindManagedVersion(request, selected, alternative.ModId) is { } version ? alternative.BoundsContain(version) : request.Instance.ForeignMods.Any(value => ModIds.Equals(value.ModId, alternative.ModId)) && alternative.MinVersion is null && alternative.MaxVersion is null;
+
+    private static bool ForcedAlternative(InstallPlanningRequest request, Dictionary<string, RequestedMod> selected, string alternativeId)
+    {
+        if (request.Instance.Mods.FirstOrDefault(value => ModIds.Equals(value.ModId, alternativeId)) is { } installed && (!selected.TryGetValue(alternativeId, out var planned) || planned.Release.Version == installed.Version)) return true;
+        var forced = new HashSet<string>(request.Requested.Select(value => value.Release.ModId), ModIds.Comparer);
+        var pending = new Queue<string>(forced);
+        while (pending.Count > 0)
+        {
+            var id = pending.Dequeue();
+            if (!selected.TryGetValue(id, out var item)) continue;
+            foreach (var dependency in item.Release.Dependencies.Where(value => !value.IsAnyOf && value.Kind == ModDependencyKind.Required))
+                if (forced.Add(dependency.ModId!)) pending.Enqueue(dependency.ModId!);
+        }
+        return forced.Contains(alternativeId);
+    }
+
+    private static void ExpandInstalledClosure(InstallPlanningRequest request, Dictionary<string, RequestedMod> roots, Dictionary<string, RequestedMod> selected)
+    {
+        var pending = new Queue<RequestedMod>(selected.Values);
+        while (pending.Count > 0)
+        {
+            var item = pending.Dequeue();
+            foreach (var dependency in item.Release.Dependencies.Where(value => value.Kind == ModDependencyKind.Required && !value.IsAnyOf))
+            {
+                if (selected.ContainsKey(dependency.ModId!)) continue;
+                var installed = request.Instance.Mods.FirstOrDefault(value => ModIds.Equals(value.ModId, dependency.ModId));
+                if (installed is null || !dependency.BoundsContain(installed.Version)) continue;
+                var reason = roots.TryGetValue(installed.ModId, out var root) ? root.Reason : InstallReason.Dependency;
+                var added = new RequestedMod(installed.Metadata, reason, Exact: false);
+                selected[installed.ModId] = added;
+                pending.Enqueue(added);
+            }
+        }
+    }
+
+    private static Borea.Core.Instances.Instance BuildProposedInstance(InstallPlanningRequest request, Dictionary<string, RequestedMod> selected)
+    {
+        var retained = request.Instance.Mods.Where(value => !selected.ContainsKey(value.ModId));
+        var planned = selected.Values.Select(value => new InstalledMod(value.Release.ModId, value.Release.Version, value.Reason, DateTimeOffset.UnixEpoch, value.Release));
+        var foreign = request.Instance.ForeignMods.Where(value => !selected.ContainsKey(value.ModId)).ToList();
+        return Borea.Core.Instances.Instance.FromExisting(request.Instance.InstanceId, request.Instance.Name, request.Instance.Source, request.Instance.CreatedAt, retained.Concat(planned).ToList(), foreign, request.Instance.IsFavorite);
+    }
+
+    private static InstallPlan ToPlan(InstallPlanningRequest request, SearchResult result)
+    {
+        var ordered = OrderOperations(request, result.Selected);
+        var selections = result.Selected.Values.OrderBy(value => value.Release.ModId, ModIds.Comparer).Select(value => new PlannedSelection(value.Release, value.Reason, IsInstalled(request, value.Release))).ToList();
+        var operations = ordered.Where(value => !IsInstalled(request, value.Release)).Select(value => new PlannedInstall(value.Release, value.Reason, Compatibility.Evaluate(value.Release, request.GameVersion), request.TargetPlatform is { } target ? Compatibility.EvaluateOs(value.Release.Os, target) : null)).ToList();
+        return new InstallPlan(request.Instance.InstanceId, InstallPlanningState.Capture(request.Instance), selections, operations, result.Warnings, result.Unresolved, result.Conflicts, result.Choices);
+    }
+
+    private static IReadOnlyList<RequestedMod> OrderOperations(InstallPlanningRequest request, Dictionary<string, RequestedMod> selected)
+    {
+        var result = new List<RequestedMod>(); var visited = new HashSet<string>(ModIds.Comparer);
+        void Visit(RequestedMod item)
+        {
+            if (!visited.Add(item.Release.ModId)) return;
+            for (var index = 0; index < item.Release.Dependencies.Count; index++)
+            {
+                var dependency = item.Release.Dependencies[index]; string? id = dependency.ModId;
+                if (dependency.IsAnyOf) { var key = ChoiceKey(item.Release.ModId, index, "alternative"); id = request.Alternatives is not null && request.Alternatives.TryGetValue(key, out var chosen) ? chosen : dependency.AnyOf.FirstOrDefault(value => AlternativeSatisfied(request, selected, value))?.ModId; }
+                if (id is not null && selected.TryGetValue(id, out var child)) Visit(child);
+            }
+            result.Add(item);
+        }
+        foreach (var item in selected.Values.OrderBy(value => value.Release.ModId, ModIds.Comparer)) Visit(item);
+        return result;
+    }
+
+    private static void Validate(InstallPlanningRequest request) { ArgumentNullException.ThrowIfNull(request); ArgumentNullException.ThrowIfNull(request.Instance); ArgumentNullException.ThrowIfNull(request.Requested); ArgumentNullException.ThrowIfNull(request.Repository); }
+    private static bool IsInstalled(InstallPlanningRequest request, ModVersionMetadata release) => request.Instance.Mods.Any(value => ModIds.Equals(value.ModId, release.ModId) && value.Version == release.Version);
+    private static string ChoiceKey(string owner, int index, string kind) => $"{owner}:dependency:{index}:{kind}";
+    private static PlanningMessage Message(string id, string code, string message) => new(id, code, message);
+    private static IReadOnlyList<PlanningMessage> Sort(List<PlanningMessage> values) => values.Distinct().OrderBy(value => value.ModId, ModIds.Comparer).ThenBy(value => value.Code, StringComparer.Ordinal).ThenBy(value => value.Message, StringComparer.Ordinal).ToList();
+
+    private sealed record SearchResult(Dictionary<string, RequestedMod> Selected, IReadOnlyList<PlanningMessage> Warnings, IReadOnlyList<PlanningMessage> Unresolved, IReadOnlyList<PlanningMessage> Conflicts, IReadOnlyList<PlanningChoice> Choices)
+    {
+        public SearchScore Score => new(Conflicts.Count, Conflicts.Count(value => value.Code is "unsatisfied-dependency" or "missing-request" or "retained-unsatisfied"), Unresolved.Count, Warnings.Count, Selected.Count);
+    }
+    private readonly record struct SearchScore(int Conflicts, int Missing, int Unresolved, int Warnings, int Selected) : IComparable<SearchScore>
+    {
+        public int CompareTo(SearchScore other) { var value = Conflicts.CompareTo(other.Conflicts); if (value != 0) return value; value = Missing.CompareTo(other.Missing); if (value != 0) return value; value = Unresolved.CompareTo(other.Unresolved); if (value != 0) return value; value = Warnings.CompareTo(other.Warnings); if (value != 0) return value; return Selected.CompareTo(other.Selected); }
+    }
+}

--- a/src/Borea.Storage/Borea.Storage.csproj
+++ b/src/Borea.Storage/Borea.Storage.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Borea.Core\Borea.Core.csproj" />
+    <InternalsVisibleTo Include="Borea.Storage.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Borea.Storage/Mods/FileModInstaller.cs
+++ b/src/Borea.Storage/Mods/FileModInstaller.cs
@@ -133,7 +133,7 @@ public sealed class FileModInstaller : IModInstaller
     /// the folder where the game does not look, since ModLibrary.AddMods scans
     /// the top level of the mods folder and nothing below it.
     /// </summary>
-    private static void RequireInstallable(ModVersionMetadata release)
+    internal static void RequireInstallable(ModVersionMetadata release)
     {
         if (release.Type != ContentType.Mod)
             throw new NotSupportedException($"'{release.ModId}' is a {release.Type}, and only a mod installs into the mods folder.");
@@ -158,7 +158,7 @@ public sealed class FileModInstaller : IModInstaller
     /// (ModLibrary.AddMods). The stated root decides where the content starts;
     /// a release that states none gets the root RFC 0035 rule 9 derives.
     /// </summary>
-    private static void Unpack(string archivePath, ModVersionMetadata release, string modFolder)
+    internal static void Unpack(string archivePath, ModVersionMetadata release, string modFolder)
     {
         var root = release.Install?.Root ?? ModArchive.DeriveRoot(archivePath);
         var files = ModArchive.Extract(archivePath, root, modFolder);

--- a/src/Borea.Storage/Mods/FileModInstaller.cs
+++ b/src/Borea.Storage/Mods/FileModInstaller.cs
@@ -1,6 +1,7 @@
 using Borea.Core.Instances;
 using Borea.Core.Mods;
 using Borea.Core.Paths;
+using Borea.Core.Planning;
 using Borea.Core.State;
 
 namespace Borea.Storage.Mods;
@@ -39,6 +40,29 @@ public sealed class FileModInstaller : IModInstaller
         bool enable,
         IProgress<DownloadProgress>? progress = null,
         CancellationToken cancellationToken = default)
+        => (await InstallCoreAsync(instanceId, release, reason, enable, expectedState: null, progress, cancellationToken).ConfigureAwait(false)).Result;
+
+    public async Task<GuardedInstallResult> InstallGuardedAsync(
+        Guid instanceId,
+        ModVersionMetadata release,
+        InstallReason reason,
+        bool enable,
+        InstallPlanningState expectedState,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(expectedState);
+        return await InstallCoreAsync(instanceId, release, reason, enable, expectedState, progress, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<GuardedInstallResult> InstallCoreAsync(
+        Guid instanceId,
+        ModVersionMetadata release,
+        InstallReason reason,
+        bool enable,
+        InstallPlanningState? expectedState,
+        IProgress<DownloadProgress>? progress,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(release);
         RequireInstallable(release);
@@ -64,6 +88,7 @@ public sealed class FileModInstaller : IModInstaller
         var stagingFolder = Path.Combine(_pathProvider.GetInstanceRoot(instanceId), $".borea-staging-{Guid.NewGuid():N}");
         var recorded = false;
         string? ownershipToken = null;
+        InstallPlanningState? resultingState = null;
 
         try
         {
@@ -90,12 +115,16 @@ public sealed class FileModInstaller : IModInstaller
                 instanceId,
                 current =>
                 {
+                    if (expectedState is not null && !expectedState.Matches(current))
+                        throw new InvalidOperationException("The instance changed after the installation was planned.");
+
                     if (ModFolders.Find(modsFolder, release.ModId) is not null)
                         throw new InvalidOperationException($"The instance received a foreign folder for '{release.ModId}' while the archive downloaded.");
 
                     Directory.CreateDirectory(modsFolder);
                     Directory.Move(stagingFolder, modFolder);
                     current.AddMod(installed);
+                    resultingState = InstallPlanningState.Capture(current);
                     return true;
                 },
                 cancellationToken).ConfigureAwait(false);
@@ -103,7 +132,8 @@ public sealed class FileModInstaller : IModInstaller
 
             var entry = await _modState.AddEntryAsync(instanceId, release.ModId, enable, cancellationToken).ConfigureAwait(false);
 
-            return new InstallResult(installed, download, entry);
+            var result = new InstallResult(installed, download, entry);
+            return new GuardedInstallResult(result, resultingState!);
         }
         catch
         {

--- a/src/Borea.Storage/Mods/FileModReplacer.cs
+++ b/src/Borea.Storage/Mods/FileModReplacer.cs
@@ -1,6 +1,7 @@
 using Borea.Core.Instances;
 using Borea.Core.Mods;
 using Borea.Core.Paths;
+using Borea.Core.Planning;
 using Borea.Core.State;
 
 namespace Borea.Storage.Mods;
@@ -46,6 +47,27 @@ public sealed class FileModReplacer : IModReplacer
         ModVersionMetadata replacement,
         IProgress<DownloadProgress>? progress = null,
         CancellationToken cancellationToken = default)
+        => (await ReplaceCoreAsync(instanceId, expectedCurrent, replacement, expectedState: null, progress, cancellationToken).ConfigureAwait(false)).Result;
+
+    public async Task<GuardedModReplacementResult> ReplaceGuardedAsync(
+        Guid instanceId,
+        InstalledMod expectedCurrent,
+        ModVersionMetadata replacement,
+        InstallPlanningState expectedState,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(expectedState);
+        return await ReplaceCoreAsync(instanceId, expectedCurrent, replacement, expectedState, progress, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<GuardedModReplacementResult> ReplaceCoreAsync(
+        Guid instanceId,
+        InstalledMod expectedCurrent,
+        ModVersionMetadata replacement,
+        InstallPlanningState? expectedState,
+        IProgress<DownloadProgress>? progress,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(expectedCurrent);
         ArgumentNullException.ThrowIfNull(replacement);
@@ -75,6 +97,7 @@ public sealed class FileModReplacer : IModReplacer
         string? installedFolder = null;
         var backupCreated = false;
         var replacementMoved = false;
+        InstallPlanningState? resultingState = null;
 
         try
         {
@@ -97,6 +120,9 @@ public sealed class FileModReplacer : IModReplacer
                 instanceId,
                 current =>
                 {
+                    if (expectedState is not null && !expectedState.Matches(current))
+                        throw new InvalidOperationException("The instance changed after the replacement was planned.");
+
                     RequireExpected(current, expectedCurrent);
                     installedFolder = ModFolders.FindOwned(modsFolder, expectedCurrent.ModId, expectedCurrent.OwnershipToken!)
                         ?? throw new InvalidOperationException($"Borea cannot find its owned folder for '{expectedCurrent.ModId}'.");
@@ -105,6 +131,7 @@ public sealed class FileModReplacer : IModReplacer
                     Directory.Move(stagingFolder, installedFolder);
                     replacementMoved = true;
                     current.ReplaceMod(installed);
+                    resultingState = InstallPlanningState.Capture(current);
                     return true;
                 },
                 cancellationToken).ConfigureAwait(false);
@@ -116,7 +143,8 @@ public sealed class FileModReplacer : IModReplacer
 
             var retainedRecoveryDirectory = _deleteRecoveryDirectory(backupFolder) ? null : backupFolder;
             backupCreated = retainedRecoveryDirectory is not null;
-            return new ModReplacementResult(expectedCurrent, installed, download, retainedRecoveryDirectory);
+            var result = new ModReplacementResult(expectedCurrent, installed, download, retainedRecoveryDirectory);
+            return new GuardedModReplacementResult(result, resultingState!);
         }
         catch (Exception operationError)
         {

--- a/src/Borea.Storage/Mods/FileModReplacer.cs
+++ b/src/Borea.Storage/Mods/FileModReplacer.cs
@@ -1,0 +1,220 @@
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+using Borea.Core.Paths;
+using Borea.Core.State;
+
+namespace Borea.Storage.Mods;
+
+public sealed class FileModReplacer : IModReplacer
+{
+    private readonly IGamePathProvider _paths;
+    private readonly IModDownloader _downloader;
+    private readonly IInstanceRepository _instances;
+    private readonly IModStateRepository _modState;
+    private readonly TimeProvider _timeProvider;
+    private readonly Func<string, bool> _deleteRecoveryDirectory;
+
+    public FileModReplacer(
+        IGamePathProvider paths,
+        IModDownloader downloader,
+        IInstanceRepository instances,
+        IModStateRepository modState,
+        TimeProvider? timeProvider = null)
+        : this(paths, downloader, instances, modState, timeProvider, TryDeleteDirectory)
+    {
+    }
+
+    internal FileModReplacer(
+        IGamePathProvider paths,
+        IModDownloader downloader,
+        IInstanceRepository instances,
+        IModStateRepository modState,
+        TimeProvider? timeProvider,
+        Func<string, bool> deleteRecoveryDirectory)
+    {
+        _paths = paths ?? throw new ArgumentNullException(nameof(paths));
+        _downloader = downloader ?? throw new ArgumentNullException(nameof(downloader));
+        _instances = instances ?? throw new ArgumentNullException(nameof(instances));
+        _modState = modState ?? throw new ArgumentNullException(nameof(modState));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _deleteRecoveryDirectory = deleteRecoveryDirectory ?? throw new ArgumentNullException(nameof(deleteRecoveryDirectory));
+    }
+
+    public async Task<ModReplacementResult> ReplaceAsync(
+        Guid instanceId,
+        InstalledMod expectedCurrent,
+        ModVersionMetadata replacement,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(expectedCurrent);
+        ArgumentNullException.ThrowIfNull(replacement);
+        FileModInstaller.RequireInstallable(replacement);
+
+        if (!ModIds.Equals(expectedCurrent.ModId, replacement.ModId))
+            throw new ArgumentException("The replacement must have the same mod ID as the installed mod.", nameof(replacement));
+
+        RequireOwned(expectedCurrent);
+        var before = await _instances.GetByIdAsync(instanceId).ConfigureAwait(false)
+            ?? throw new InvalidOperationException($"No instance with ID '{instanceId}' exists.");
+        RequireExpected(before, expectedCurrent);
+
+        var entries = await _modState.GetEntriesAsync(instanceId, cancellationToken).ConfigureAwait(false);
+        var matchingEntries = entries.Where(entry => ModIds.Equals(entry.ModId, expectedCurrent.ModId)).ToArray();
+        if (matchingEntries.Length == 0)
+            throw new InvalidOperationException($"The manifest has no entry for installed mod '{expectedCurrent.ModId}'.");
+        var wasActive = matchingEntries.Any(entry => entry.Enabled);
+
+        var archivePath = Path.Combine(Path.GetTempPath(), $"borea-download-{Guid.NewGuid():N}.zip");
+        var instanceRoot = _paths.GetInstanceRoot(instanceId);
+        var stagingFolder = Path.Combine(instanceRoot, $".borea-staging-{Guid.NewGuid():N}");
+        var backupFolder = Path.Combine(instanceRoot, $".borea-recovery-{Guid.NewGuid():N}");
+        var modsFolder = _paths.GetInstanceModsFolder(instanceId);
+        DownloadResult download;
+        InstalledMod? installed = null;
+        string? installedFolder = null;
+        var backupCreated = false;
+        var replacementMoved = false;
+
+        try
+        {
+            download = await _downloader.DownloadAsync(replacement, archivePath, progress, cancellationToken).ConfigureAwait(false);
+            FileModInstaller.Unpack(archivePath, replacement, stagingFolder);
+            var ownershipToken = Guid.NewGuid().ToString("N");
+            await File.WriteAllTextAsync(Path.Combine(stagingFolder, ModFolders.OwnershipFileName), ownershipToken, cancellationToken).ConfigureAwait(false);
+
+            installed = new InstalledMod(
+                replacement.ModId,
+                replacement.Version,
+                expectedCurrent.Reason,
+                _timeProvider.GetUtcNow(),
+                replacement,
+                download.Sha256,
+                ModInstallOwnership.Borea,
+                ownershipToken);
+
+            await _instances.UpdateAsync(
+                instanceId,
+                current =>
+                {
+                    RequireExpected(current, expectedCurrent);
+                    installedFolder = ModFolders.FindOwned(modsFolder, expectedCurrent.ModId, expectedCurrent.OwnershipToken!)
+                        ?? throw new InvalidOperationException($"Borea cannot find its owned folder for '{expectedCurrent.ModId}'.");
+                    Directory.Move(installedFolder, backupFolder);
+                    backupCreated = true;
+                    Directory.Move(stagingFolder, installedFolder);
+                    replacementMoved = true;
+                    current.ReplaceMod(installed);
+                    return true;
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            await _modState.AddEntryAsync(instanceId, replacement.ModId, wasActive, cancellationToken).ConfigureAwait(false);
+            var active = await _modState.IsActiveAsync(instanceId, replacement.ModId, cancellationToken).ConfigureAwait(false);
+            if (active != wasActive)
+                throw new InvalidOperationException($"The manifest state changed while '{replacement.ModId}' was replaced.");
+
+            var retainedRecoveryDirectory = _deleteRecoveryDirectory(backupFolder) ? null : backupFolder;
+            backupCreated = retainedRecoveryDirectory is not null;
+            return new ModReplacementResult(expectedCurrent, installed, download, retainedRecoveryDirectory);
+        }
+        catch (Exception operationError)
+        {
+            if (backupCreated)
+            {
+                try
+                {
+                    await RestoreAsync(instanceId, expectedCurrent, installed!, installedFolder!, backupFolder, replacementMoved).ConfigureAwait(false);
+                    backupCreated = false;
+                    replacementMoved = false;
+                }
+                catch (Exception recoveryError)
+                {
+                    var recoveryDirectory = Directory.Exists(backupFolder) ? backupFolder : installedFolder!;
+                    throw new ModReplacementRecoveryException(operationError, recoveryError, recoveryDirectory);
+                }
+            }
+
+            throw;
+        }
+        finally
+        {
+            TryDeleteFile(archivePath);
+            TryDeleteDirectory(stagingFolder);
+        }
+    }
+
+    private async Task RestoreAsync(Guid instanceId, InstalledMod previous, InstalledMod replacement, string installedFolder, string backupFolder, bool replacementMoved)
+    {
+        await _instances.UpdateAsync(
+            instanceId,
+            current =>
+            {
+                var currentMod = current.Mods.FirstOrDefault(mod => ModIds.Equals(mod.ModId, previous.ModId))
+                    ?? throw new InvalidOperationException($"The installed record for '{previous.ModId}' is missing.");
+                if (!Matches(currentMod, previous) && !Matches(currentMod, replacement))
+                    throw new InvalidOperationException($"Mod '{previous.ModId}' changed while Borea tried to restore it.");
+
+                if (replacementMoved && Directory.Exists(installedFolder))
+                {
+                    var ownedReplacement = ModFolders.FindOwned(Path.GetDirectoryName(installedFolder)!, replacement.ModId, replacement.OwnershipToken!);
+                    if (!string.Equals(ownedReplacement, installedFolder, StringComparison.Ordinal))
+                        throw new InvalidOperationException($"The installed folder for '{previous.ModId}' changed while Borea tried to restore it.");
+                    Directory.Delete(installedFolder, recursive: true);
+                }
+                if (!Directory.Exists(backupFolder))
+                    throw new InvalidOperationException($"The recovery folder for '{previous.ModId}' is missing.");
+                Directory.Move(backupFolder, installedFolder);
+
+                if (!Matches(currentMod, previous))
+                    current.ReplaceMod(previous);
+                return true;
+            }).ConfigureAwait(false);
+    }
+
+    private static void RequireExpected(Instance instance, InstalledMod expected)
+    {
+        var current = instance.Mods.FirstOrDefault(mod => ModIds.Equals(mod.ModId, expected.ModId))
+            ?? throw new InvalidOperationException($"Mod '{expected.ModId}' is no longer installed.");
+        RequireOwned(current);
+        if (!Matches(current, expected))
+            throw new InvalidOperationException($"Mod '{expected.ModId}' changed after the replacement was requested.");
+    }
+
+    private static bool Matches(InstalledMod current, InstalledMod expected) =>
+        current.Version == expected.Version &&
+        current.Reason == expected.Reason &&
+        current.InstalledAt == expected.InstalledAt &&
+        string.Equals(current.Checksum, expected.Checksum, StringComparison.OrdinalIgnoreCase) &&
+        current.Ownership == expected.Ownership &&
+        string.Equals(current.OwnershipToken, expected.OwnershipToken, StringComparison.Ordinal);
+
+    private static void RequireOwned(InstalledMod installed)
+    {
+        if (!installed.CanDeleteFiles)
+            throw new InvalidOperationException($"Borea cannot replace '{installed.ModId}' because it does not own the installed folder.");
+    }
+
+    private static bool TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+            return true;
+        }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+}

--- a/tests/Borea.Cli.Tests/BoreaCliTests.cs
+++ b/tests/Borea.Cli.Tests/BoreaCliTests.cs
@@ -14,6 +14,7 @@ public sealed class BoreaCliTests : IDisposable
         Assert.Contains("game", run.Output);
         Assert.Contains("index", run.Output);
         Assert.Contains("search", run.Output);
+        Assert.Contains("show", run.Output);
         Assert.Contains("instance", run.Output);
         Assert.Contains("enable", run.Output);
         Assert.Contains("disable", run.Output);

--- a/tests/Borea.Cli.Tests/BoreaCliTests.cs
+++ b/tests/Borea.Cli.Tests/BoreaCliTests.cs
@@ -13,6 +13,7 @@ public sealed class BoreaCliTests : IDisposable
         Assert.Contains("settings", run.Output);
         Assert.Contains("game", run.Output);
         Assert.Contains("index", run.Output);
+        Assert.Contains("search", run.Output);
         Assert.Contains("instance", run.Output);
         Assert.Contains("enable", run.Output);
         Assert.Contains("disable", run.Output);

--- a/tests/Borea.Cli.Tests/CliHost.cs
+++ b/tests/Borea.Cli.Tests/CliHost.cs
@@ -1,6 +1,8 @@
 using System.Text.Json;
 using Borea.Composition;
+using Borea.Core.Index;
 using Borea.Core.ModLoaders;
+using Borea.Core.Mods;
 using Borea.Storage.Launch;
 using Borea.Storage.Paths;
 
@@ -24,7 +26,11 @@ internal sealed class CliHost : IDisposable
 
     public FakeContentIndexReader IndexReader { get; } = new();
 
+    public IContentIndexSnapshotProvider? IndexSnapshots { get; set; }
+
     public FakeModRepository Mods { get; } = new();
+
+    public IModRepository? ModRepository { get; set; }
 
     public FakeProcessStarter ProcessStarter { get; } = new();
 
@@ -62,7 +68,8 @@ internal sealed class CliHost : IDisposable
             installedVersion: InstalledVersion,
             indexFetcher: IndexFetcher,
             indexReader: IndexReader,
-            mods: Mods,
+            indexSnapshots: IndexSnapshots ?? new ReaderSnapshotProvider(IndexReader),
+            mods: ModRepository ?? Mods,
             loaderInstaller: LoaderInstaller,
             loaderAdopter: LoaderAdopter,
             loaderUninstaller: LoaderUninstaller,
@@ -73,6 +80,12 @@ internal sealed class CliHost : IDisposable
     {
         if (Directory.Exists(Root))
             Directory.Delete(Root, recursive: true);
+    }
+
+    private sealed class ReaderSnapshotProvider(IContentIndexReader reader) : IContentIndexSnapshotProvider
+    {
+        public Task<ContentIndexSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default) =>
+            reader.ReadAsync(cancellationToken);
     }
 }
 

--- a/tests/Borea.Cli.Tests/CliServicesTests.cs
+++ b/tests/Borea.Cli.Tests/CliServicesTests.cs
@@ -1,4 +1,5 @@
 using Borea.Composition;
+using Borea.Core.Index;
 
 namespace Borea.Cli.Tests;
 
@@ -22,6 +23,7 @@ public sealed class CliServicesTests : IDisposable
         Assert.Same(graph.InstalledVersion, services.InstalledVersion);
         Assert.Same(graph.IndexFetcher, services.IndexFetcher);
         Assert.Same(graph.IndexReader, services.IndexReader);
+        Assert.Same(graph.IndexSnapshots, services.IndexSnapshots);
         Assert.Same(graph.Paths, services.Paths);
         Assert.Same(graph.Mods, services.Mods);
         Assert.Same(graph.LoaderInstaller, services.LoaderInstaller);
@@ -39,13 +41,15 @@ public sealed class CliServicesTests : IDisposable
         var installed = new FakeInstalledGameVersionProvider();
         var indexFetcher = new FakeContentIndexFetcher();
         var indexReader = new FakeContentIndexReader();
+        var indexSnapshots = new StubContentIndexSnapshotProvider();
 
-        var services = CliServices.From(graph, ping, installed, indexFetcher, indexReader);
+        var services = CliServices.From(graph, ping, installed, indexFetcher, indexReader, indexSnapshots);
 
         Assert.Same(ping, services.LatestVersion);
         Assert.Same(installed, services.InstalledVersion);
         Assert.Same(indexFetcher, services.IndexFetcher);
         Assert.Same(indexReader, services.IndexReader);
+        Assert.Same(indexSnapshots, services.IndexSnapshots);
         Assert.Same(graph.Instances, services.Instances);
     }
 
@@ -65,6 +69,7 @@ public sealed class CliServicesTests : IDisposable
             InstalledVersion = new FakeInstalledGameVersionProvider(),
             IndexFetcher = new FakeContentIndexFetcher(),
             IndexReader = new FakeContentIndexReader(),
+            IndexSnapshots = graph.IndexSnapshots,
             Paths = graph.Paths,
             Mods = graph.Mods,
             LoaderInstaller = graph.LoaderInstaller,
@@ -90,6 +95,12 @@ public sealed class CliServicesTests : IDisposable
         public bool Disposed { get; private set; }
 
         public void Dispose() => Disposed = true;
+    }
+
+    private sealed class StubContentIndexSnapshotProvider : IContentIndexSnapshotProvider
+    {
+        public Task<ContentIndexSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
     }
 
     public void Dispose()

--- a/tests/Borea.Cli.Tests/ContentCommandFixtures.cs
+++ b/tests/Borea.Cli.Tests/ContentCommandFixtures.cs
@@ -1,0 +1,54 @@
+using Borea.Core.Dependencies;
+using Borea.Core.Mods;
+
+namespace Borea.Cli.Tests;
+
+internal static class ContentCommandFixtures
+{
+    public static ModMetadata Listing(
+        string id = "flight-tools",
+        string name = "Flight Tools",
+        ModStatus status = ModStatus.Active,
+        string? supersededBy = null) => new(
+            specVersion: 1,
+            modId: id,
+            source: "index",
+            name: name,
+            authors: new[] { "Test Author" },
+            abstractText: "Tools for orbital flight.",
+            license: "MIT",
+            links: new Dictionary<string, string>
+            {
+                ["forums"] = "https://forums.example/threads/flight-tools.1/",
+                ["repository"] = "https://example.com/flight-tools",
+            },
+            gameMin: "2026.8.22.5348",
+            tags: new[] { "utility" },
+            description: "A longer description of the flight tools.",
+            status: status,
+            supersededBy: supersededBy);
+
+    public static ModVersionMetadata Release(
+        string id = "flight-tools",
+        string version = "2.0.0",
+        int gameMinRevision = 5348,
+        int? gameMaxRevision = null,
+        bool yanked = false,
+        string? yankedReason = null,
+        IReadOnlyList<ModDependency>? dependencies = null) => new(
+            specVersion: 1,
+            modId: id,
+            version: ModVersion.Parse(version),
+            releaseStatus: ReleaseStatus.Stable,
+            releaseDate: new DateTimeOffset(2026, 9, 1, 12, 0, 0, TimeSpan.Zero),
+            gameMin: gameMinRevision == 5348 ? "2026.8.22.5348" : $"2026.1.1.{gameMinRevision}",
+            gameMinRevision: gameMinRevision,
+            download: new DownloadInfo("https://example.com/flight-tools.zip", new string('A', 64), 1024, "application/zip"),
+            installSizeBytes: 2048,
+            dependencies: dependencies ?? Array.Empty<ModDependency>(),
+            gameMax: gameMaxRevision is null ? null : $"2026.1.1.{gameMaxRevision}",
+            gameMaxRevision: gameMaxRevision,
+            yanked: yanked,
+            yankedReason: yankedReason,
+            source: "index");
+}

--- a/tests/Borea.Cli.Tests/FakeModRepository.cs
+++ b/tests/Borea.Cli.Tests/FakeModRepository.cs
@@ -12,6 +12,8 @@ internal sealed class FakeModRepository : IModRepository
 
     public Func<string, CancellationToken, Task<IReadOnlyList<ModVersion>>>? AvailableVersions { get; set; }
 
+    public List<(string ModId, ModVersion Version)> ReleaseRequests { get; } = new();
+
     public Task<IReadOnlyList<ModMetadata>> GetAvailableModsAsync(CancellationToken cancellationToken = default)
         => AvailableMods?.Invoke(cancellationToken) ?? Task.FromResult<IReadOnlyList<ModMetadata>>(Listings);
 
@@ -22,8 +24,11 @@ internal sealed class FakeModRepository : IModRepository
             .FirstOrDefault());
 
     public Task<ModVersionMetadata?> GetReleaseAsync(string modId, ModVersion version, CancellationToken cancellationToken = default)
-        => Task.FromResult(Releases.FirstOrDefault(release =>
+    {
+        ReleaseRequests.Add((modId, version));
+        return Task.FromResult(Releases.FirstOrDefault(release =>
             ModIds.Equals(release.ModId, modId) && release.Version == version));
+    }
 
     public Task<IReadOnlyList<ModVersion>> GetAvailableVersionsAsync(string modId, CancellationToken cancellationToken = default)
         => AvailableVersions?.Invoke(modId, cancellationToken) ?? Task.FromResult<IReadOnlyList<ModVersion>>(Releases

--- a/tests/Borea.Cli.Tests/SearchCommandTests.cs
+++ b/tests/Borea.Cli.Tests/SearchCommandTests.cs
@@ -1,0 +1,192 @@
+using Borea.Core.Game;
+using Borea.Core.Index;
+using Borea.Network.Index;
+using Borea.Storage.Index;
+
+namespace Borea.Cli.Tests;
+
+public sealed class SearchCommandTests : IDisposable
+{
+    private readonly CliHost _host = new();
+
+    [Fact]
+    public async Task Search_Hit_PrintsIdNameNewestReleaseAndCompatibility()
+    {
+        _host.Mods.Listings.Add(ContentCommandFixtures.Listing());
+        _host.Mods.Releases.Add(ContentCommandFixtures.Release());
+        _host.InstalledVersion = Installed("2026.9.7.5402");
+
+        var run = await _host.RunAsync("search", "Flight");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("flight-tools  Flight Tools  2.0.0  compatible", run.Output);
+        Assert.Equal(string.Empty, run.Error);
+    }
+
+    [Fact]
+    public async Task Search_DesignSnapshotFixture_UsesTheMappedIndexWithoutNetwork()
+    {
+        var indexPath = _host.Paths.GetIndexPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(indexPath)!);
+        File.Copy(
+            Path.Combine(AppContext.BaseDirectory, "Index", "Fixtures", "current-snapshot.json"),
+            indexPath);
+        var snapshot = await new ContentIndexReader(_host.Paths).ReadAsync();
+        _host.IndexReader.Snapshot = snapshot;
+        foreach (var listing in snapshot.Listings.Where(listing => listing.Authored is not null))
+        {
+            _host.Mods.Listings.Add(listing.Authored!);
+            _host.Mods.Releases.AddRange(listing.Releases);
+        }
+        _host.InstalledVersion = Installed("2026.9.7.5402");
+
+        var run = await _host.RunAsync("search", "Advanced Flight");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("AdvancedFlightComputer  Advanced Flight Computer  0.7.5  compatible", run.Output);
+        Assert.Null(_host.IndexFetcher.DestinationPath);
+    }
+
+    [Fact]
+    public async Task Search_WarmedSnapshot_RemainsUsableWhenTheReaderFails()
+    {
+        var listing = ContentCommandFixtures.Listing();
+        var release = ContentCommandFixtures.Release();
+        _host.IndexReader.Snapshot = Snapshot(
+            new[] { new ContentIndexListing(listing.ModId, listing, new[] { release }, null) },
+            new[]
+            {
+                new ContentIndexDiagnostic(
+                    ContentIndexDiagnosticKind.UnsupportedValue,
+                    ContentIndexDiagnosticScope.IndexStatus,
+                    "Index status state 'future-state' is not supported.",
+                    listing.ModId),
+            });
+        var snapshots = new ContentIndexSnapshotProvider(_host.IndexFetcher, _host.IndexReader, _host.Paths);
+        _host.IndexSnapshots = snapshots;
+        _host.ModRepository = new ContentIndexModRepository(snapshots);
+        Assert.Single(await _host.ModRepository.GetAvailableModsAsync());
+        _host.IndexReader.Read = _ => throw new IOException("The cache file is temporarily unreadable.");
+
+        var run = await _host.RunAsync("search", "flight");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("flight-tools  Flight Tools  2.0.0", run.Output);
+        Assert.Contains("unsupported-value index-status flight-tools", run.Output);
+        Assert.Equal(string.Empty, run.Error);
+    }
+
+    [Fact]
+    public async Task Search_NoHit_PrintsAnEmptyResult()
+    {
+        _host.Mods.Listings.Add(ContentCommandFixtures.Listing());
+
+        var run = await _host.RunAsync("search", "engines");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("No listings match 'engines'.", run.Output);
+    }
+
+    [Fact]
+    public async Task Search_ReleaseNeedsANewerGame_PrintsIncompatible()
+    {
+        _host.Mods.Listings.Add(ContentCommandFixtures.Listing());
+        _host.Mods.Releases.Add(ContentCommandFixtures.Release(gameMinRevision: 5402));
+        _host.InstalledVersion = Installed("2026.8.22.5348");
+
+        var run = await _host.RunAsync("search", "Flight");
+
+        Assert.Contains("2.0.0  incompatible", run.Output);
+    }
+
+    [Fact]
+    public async Task Search_NoInstalledBuild_PrintsUnknownCompatibility()
+    {
+        _host.Mods.Listings.Add(ContentCommandFixtures.Listing());
+        _host.Mods.Releases.Add(ContentCommandFixtures.Release());
+
+        var run = await _host.RunAsync("search", "Flight");
+
+        Assert.Contains("2.0.0  unknown", run.Output);
+    }
+
+    [Fact]
+    public async Task Search_UnknownSpecVersion_KeepsTheListingAndDiagnostic()
+    {
+        _host.IndexReader.Snapshot = Snapshot(new ContentIndexDiagnostic(
+            ContentIndexDiagnosticKind.UnsupportedVersion,
+            ContentIndexDiagnosticScope.Listing,
+            "Listing spec version 2 is newer than this client.",
+            "future-tools",
+            SpecVersion: 2));
+
+        var run = await _host.RunAsync("search", "future");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("future-tools  unknown listing  unknown  unknown", run.Output);
+        Assert.Contains("unsupported-version listing future-tools (spec version 2)", run.Output);
+    }
+
+    [Fact]
+    public async Task Search_Json_CarriesKnownAndUnknownResultsAndStatusDiagnostics()
+    {
+        _host.Mods.Listings.Add(ContentCommandFixtures.Listing());
+        _host.Mods.Releases.Add(ContentCommandFixtures.Release());
+        _host.InstalledVersion = Installed("2026.9.7.5402");
+        _host.IndexReader.Snapshot = Snapshot(
+            new ContentIndexDiagnostic(
+                ContentIndexDiagnosticKind.UnsupportedValue,
+                ContentIndexDiagnosticScope.IndexStatus,
+                "Index status state 'future-state' is not supported.",
+                "flight-tools"),
+            new ContentIndexDiagnostic(
+                ContentIndexDiagnosticKind.UnsupportedVersion,
+                ContentIndexDiagnosticScope.Listing,
+                "Listing spec version 2 is newer than this client.",
+                "flight-future",
+                SpecVersion: 2));
+
+        var run = await _host.RunAsync("search", "flight", "--json");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Equal("2026.9.7.5402", run.Json.GetProperty("installedGameVersion").GetString());
+        var results = run.Json.GetProperty("results");
+        Assert.Equal(2, results.GetArrayLength());
+        Assert.Equal("flight-future", results[0].GetProperty("id").GetString());
+        Assert.Equal("unknown", results[0].GetProperty("state").GetString());
+        Assert.Equal("flight-tools", results[1].GetProperty("id").GetString());
+        Assert.Equal("2.0.0", results[1].GetProperty("latestVersion").GetString());
+        Assert.Equal("compatible", results[1].GetProperty("compatibility").GetString());
+        var diagnostics = run.Json.GetProperty("diagnostics");
+        Assert.Equal(2, diagnostics.GetArrayLength());
+        Assert.Contains(diagnostics.EnumerateArray(), item => item.GetProperty("scope").GetString() == "index-status");
+    }
+
+    [Fact]
+    public async Task Search_EmptyText_IsAUsageErrorWithoutBuildingServices()
+    {
+        var run = await _host.RunAsync("search", " ");
+
+        Assert.Equal(2, run.ExitCode);
+        Assert.Equal(0, _host.Builds);
+    }
+
+    private static FakeInstalledGameVersionProvider Installed(string version) => new()
+    {
+        Installed = new InstalledGameVersion(GameVersion.Parse(version), version),
+    };
+
+    private static ContentIndexSnapshot Snapshot(params ContentIndexDiagnostic[] diagnostics) =>
+        Snapshot(Array.Empty<ContentIndexListing>(), diagnostics);
+
+    private static ContentIndexSnapshot Snapshot(
+        IReadOnlyList<ContentIndexListing> listings,
+        IReadOnlyList<ContentIndexDiagnostic> diagnostics) => new(
+        1,
+        listings,
+        Array.Empty<ContentIndexPack>(),
+        null,
+        diagnostics);
+
+    public void Dispose() => _host.Dispose();
+}

--- a/tests/Borea.Cli.Tests/ShowCommandTests.cs
+++ b/tests/Borea.Cli.Tests/ShowCommandTests.cs
@@ -1,0 +1,334 @@
+using Borea.Core.Dependencies;
+using Borea.Core.Game;
+using Borea.Core.Index;
+using Borea.Core.Mods;
+using Borea.Network.Index;
+using Borea.Storage.Index;
+
+namespace Borea.Cli.Tests;
+
+public sealed class ShowCommandTests : IDisposable
+{
+    private readonly CliHost _host = new();
+
+    [Fact]
+    public async Task Show_PrintsTheListingLinksStatusAndEveryReleaseNewestFirst()
+    {
+        var listing = ContentCommandFixtures.Listing(
+            status: ModStatus.Deprecated,
+            supersededBy: "new-flight-tools");
+        var newest = ContentCommandFixtures.Release(version: "2.0.0");
+        var yanked = ContentCommandFixtures.Release(
+            version: "1.0.0",
+            yanked: true,
+            yankedReason: "This release is broken.");
+        _host.Mods.Listings.Add(listing);
+        _host.Mods.Releases.AddRange(new[] { yanked, newest });
+        _host.IndexReader.Snapshot = Snapshot(new ContentIndexListing(
+            listing.ModId,
+            listing,
+            new[] { yanked, newest },
+            new IndexStatus(IndexStatusState.Disputed, "disputed", reason: "Ownership is under review.")));
+        _host.InstalledVersion = Installed("2026.9.7.5402");
+
+        var run = await _host.RunAsync("show", "flight-tools");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("Flight Tools (flight-tools)", run.Output);
+        Assert.Contains("Status: deprecated", run.Output);
+        Assert.Contains("Superseded by: new-flight-tools", run.Output);
+        Assert.Contains("repository: https://example.com/flight-tools", run.Output);
+        Assert.Contains("Index status: disputed", run.Output);
+        Assert.True(run.Output.IndexOf("2.0.0", StringComparison.Ordinal) < run.Output.IndexOf("1.0.0", StringComparison.Ordinal));
+        Assert.Contains("1.0.0  compatible  stable  yanked: This release is broken.", run.Output);
+    }
+
+    [Fact]
+    public async Task ShowVersion_PrintsOneReleaseAndItsDependencies()
+    {
+        var listing = ContentCommandFixtures.Listing();
+        var release = ContentCommandFixtures.Release(dependencies: new ModDependency[]
+        {
+            new("required-lib", ModDependencyKind.Required, ModVersion.Parse("1.0.0"), source: MetadataSource.Authored),
+            ModDependency.OfAlternatives(ModDependencyKind.Recommends, new[]
+            {
+                new ModDependencyAlternative("first-lib", ModVersion.Parse("2.0.0")),
+                new ModDependencyAlternative("second-lib"),
+            }, MetadataSource.Derived),
+        });
+        _host.Mods.Listings.Add(listing);
+        _host.Mods.Releases.Add(release);
+        _host.IndexReader.Snapshot = Snapshot(new ContentIndexListing(listing.ModId, listing, new[] { release }, null));
+
+        var run = await _host.RunAsync("show", "flight-tools", "--version", "2.0.0");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("required  required-lib >= 1.0.0 (authored)", run.Output);
+        Assert.Contains("recommends  any of [first-lib >= 2.0.0, second-lib] (derived)", run.Output);
+        Assert.Contains((listing.ModId, ModVersion.Parse("2.0.0")), _host.Mods.ReleaseRequests);
+    }
+
+    [Fact]
+    public async Task Show_UnknownReleaseSpecVersion_KeepsItInOrderInJson()
+    {
+        var listing = ContentCommandFixtures.Listing();
+        var known = ContentCommandFixtures.Release(version: "2.0.0");
+        _host.Mods.Listings.Add(listing);
+        _host.Mods.Releases.Add(known);
+        _host.IndexReader.Snapshot = Snapshot(
+            new[] { new ContentIndexListing(listing.ModId, listing, new[] { known }, null) },
+            new[]
+            {
+                new ContentIndexDiagnostic(
+                    ContentIndexDiagnosticKind.UnsupportedVersion,
+                    ContentIndexDiagnosticScope.Release,
+                    "Release spec version 2 is newer than this client.",
+                    listing.ModId,
+                    "3.0.0",
+                    2),
+            });
+
+        var run = await _host.RunAsync("show", listing.ModId, "--json");
+
+        Assert.Equal(0, run.ExitCode);
+        var releases = run.Json.GetProperty("releases");
+        Assert.Equal(2, releases.GetArrayLength());
+        Assert.Equal("3.0.0", releases[0].GetProperty("version").GetString());
+        Assert.Equal("unknown", releases[0].GetProperty("state").GetString());
+        Assert.Equal(2, releases[0].GetProperty("specVersion").GetInt32());
+        Assert.Equal("2.0.0", releases[1].GetProperty("version").GetString());
+        Assert.Equal("known", releases[1].GetProperty("state").GetString());
+    }
+
+    [Fact]
+    public async Task Show_UnknownSpecVersion_KeepsTheListingIdAndDiagnostic()
+    {
+        _host.IndexReader.Snapshot = Snapshot(
+            listings: Array.Empty<ContentIndexListing>(),
+            diagnostics: new[]
+            {
+                new ContentIndexDiagnostic(
+                    ContentIndexDiagnosticKind.UnsupportedVersion,
+                    ContentIndexDiagnosticScope.Listing,
+                    "Listing spec version 2 is newer than this client.",
+                    "future-tools",
+                    SpecVersion: 2),
+            });
+
+        var run = await _host.RunAsync("show", "future-tools");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("future-tools (unknown)", run.Output);
+        Assert.Contains("unsupported-version listing future-tools (spec version 2)", run.Output);
+    }
+
+    [Fact]
+    public async Task Show_UnknownIndexStatus_KeepsRawStatusAndDiagnostic()
+    {
+        var listing = ContentCommandFixtures.Listing();
+        var status = new IndexStatus(IndexStatusState.Unknown, "future-state", reason: "A future warning.");
+        _host.Mods.Listings.Add(listing);
+        _host.IndexReader.Snapshot = Snapshot(
+            new[] { new ContentIndexListing(listing.ModId, listing, Array.Empty<ModVersionMetadata>(), status) },
+            new[]
+            {
+                new ContentIndexDiagnostic(
+                    ContentIndexDiagnosticKind.UnsupportedValue,
+                    ContentIndexDiagnosticScope.IndexStatus,
+                    "Index status state 'future-state' is not supported.",
+                    listing.ModId),
+            });
+
+        var run = await _host.RunAsync("show", listing.ModId);
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("Index status: future-state", run.Output);
+        Assert.Contains("unsupported-value index-status flight-tools", run.Output);
+    }
+
+    [Fact]
+    public async Task Show_DelistedTombstone_PrintsTheIndexStatus()
+    {
+        var tombstone = new ContentIndexListing(
+            "removed-tools",
+            null,
+            Array.Empty<ModVersionMetadata>(),
+            new IndexStatus(IndexStatusState.Delisted, "delisted", reason: "Removed by a steward."));
+        _host.IndexReader.Snapshot = Snapshot(tombstone);
+
+        var run = await _host.RunAsync("show", "removed-tools");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("removed-tools (delisted)", run.Output);
+        Assert.Contains("Index status: delisted", run.Output);
+        Assert.Contains("Index reason: Removed by a steward.", run.Output);
+    }
+
+    [Fact]
+    public async Task ShowVersion_UnknownReleaseSpecVersion_PrintsUnknownAndTheDiagnostic()
+    {
+        var listing = ContentCommandFixtures.Listing();
+        _host.Mods.Listings.Add(listing);
+        _host.IndexReader.Snapshot = Snapshot(
+            new[] { new ContentIndexListing(listing.ModId, listing, Array.Empty<ModVersionMetadata>(), null) },
+            new[]
+            {
+                new ContentIndexDiagnostic(
+                    ContentIndexDiagnosticKind.UnsupportedVersion,
+                    ContentIndexDiagnosticScope.Release,
+                    "Release spec version 2 is newer than this client.",
+                    listing.ModId,
+                    "3.0.0",
+                    2),
+            });
+
+        var run = await _host.RunAsync("show", listing.ModId, "--version", "3.0.0+local.1");
+        var json = await _host.RunAsync("show", listing.ModId, "--version", "3.0.0+local.1", "--json");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("3.0.0  unknown (spec version 2)", run.Output);
+        Assert.Contains("unsupported-version release flight-tools 3.0.0", run.Output);
+        var unknown = Assert.Single(json.Json.GetProperty("releases").EnumerateArray());
+        Assert.Equal("unknown", unknown.GetProperty("state").GetString());
+        Assert.Equal("3.0.0", unknown.GetProperty("version").GetString());
+        Assert.Equal(2, unknown.GetProperty("specVersion").GetInt32());
+    }
+
+    [Fact]
+    public async Task Show_DesignSnapshotFixture_UsesMappedReleaseDataWithoutNetwork()
+    {
+        var indexPath = _host.Paths.GetIndexPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(indexPath)!);
+        File.Copy(
+            Path.Combine(AppContext.BaseDirectory, "Index", "Fixtures", "current-snapshot.json"),
+            indexPath);
+        var snapshot = await new ContentIndexReader(_host.Paths).ReadAsync();
+        _host.IndexReader.Snapshot = snapshot;
+        foreach (var entry in snapshot.Listings.Where(entry => entry.Authored is not null))
+        {
+            _host.Mods.Listings.Add(entry.Authored!);
+            _host.Mods.Releases.AddRange(entry.Releases);
+        }
+        _host.InstalledVersion = Installed("2026.9.7.5402");
+
+        var run = await _host.RunAsync(
+            "show",
+            "AdvancedFlightComputer",
+            "--version",
+            "0.7.5",
+            "--json");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Equal("Advanced Flight Computer", run.Json.GetProperty("listing").GetProperty("name").GetString());
+        var release = Assert.Single(run.Json.GetProperty("releases").EnumerateArray());
+        Assert.Equal("0.7.5", release.GetProperty("version").GetString());
+        Assert.Equal("compatible", release.GetProperty("compatibility").GetString());
+        Assert.Equal(System.Text.Json.JsonValueKind.Array, release.GetProperty("dependencies").ValueKind);
+        Assert.Null(_host.IndexFetcher.DestinationPath);
+    }
+
+    [Fact]
+    public async Task Show_WarmedSnapshot_RemainsUsableWhenTheReaderFails()
+    {
+        var listing = ContentCommandFixtures.Listing();
+        var release = ContentCommandFixtures.Release();
+        _host.IndexReader.Snapshot = Snapshot(
+            new[]
+            {
+                new ContentIndexListing(
+                    listing.ModId,
+                    listing,
+                    new[] { release },
+                    new IndexStatus(IndexStatusState.Disputed, "disputed", reason: "Ownership is under review.")),
+            },
+            new[]
+            {
+                new ContentIndexDiagnostic(
+                    ContentIndexDiagnosticKind.UnsupportedValue,
+                    ContentIndexDiagnosticScope.IndexStatus,
+                    "Index status state 'future-state' is not supported.",
+                    listing.ModId),
+            });
+        var snapshots = new ContentIndexSnapshotProvider(_host.IndexFetcher, _host.IndexReader, _host.Paths);
+        _host.IndexSnapshots = snapshots;
+        _host.ModRepository = new ContentIndexModRepository(snapshots);
+        Assert.Single(await _host.ModRepository.GetAvailableModsAsync());
+        _host.IndexReader.Read = _ => throw new IOException("The cache file is temporarily unreadable.");
+
+        var run = await _host.RunAsync("show", listing.ModId);
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("Flight Tools (flight-tools)", run.Output);
+        Assert.Contains("Index status: disputed", run.Output);
+        Assert.Contains("unsupported-value index-status flight-tools", run.Output);
+        Assert.Equal(string.Empty, run.Error);
+    }
+
+    [Fact]
+    public async Task ShowVersion_Json_CarriesCompatibilityYankAndDependencies()
+    {
+        var listing = ContentCommandFixtures.Listing();
+        var release = ContentCommandFixtures.Release(
+            gameMaxRevision: 5348,
+            yanked: true,
+            yankedReason: "Broken on newer games.",
+            dependencies: new[]
+            {
+                new ModDependency("required-lib", ModDependencyKind.Required, ModVersion.Parse("1.0.0")),
+            });
+        _host.Mods.Listings.Add(listing);
+        _host.Mods.Releases.Add(release);
+        _host.IndexReader.Snapshot = Snapshot(new ContentIndexListing(listing.ModId, listing, new[] { release }, null));
+        _host.InstalledVersion = Installed("2026.9.7.5402");
+
+        var run = await _host.RunAsync("show", listing.ModId, "--version", "2.0.0", "--json");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Equal("known", run.Json.GetProperty("state").GetString());
+        Assert.Equal("Flight Tools", run.Json.GetProperty("listing").GetProperty("name").GetString());
+        var shown = run.Json.GetProperty("releases")[0];
+        Assert.Equal("untested", shown.GetProperty("compatibility").GetString());
+        Assert.True(shown.GetProperty("yanked").GetBoolean());
+        Assert.Equal("Broken on newer games.", shown.GetProperty("yankedReason").GetString());
+        Assert.Equal("required", shown.GetProperty("dependencies")[0].GetProperty("kind").GetString());
+    }
+
+    [Fact]
+    public async Task Show_MissingListing_Fails()
+    {
+        var run = await _host.RunAsync("show", "missing-tools");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Contains("Listing 'missing-tools' was not found.", run.Error);
+    }
+
+    [Theory]
+    [InlineData("not-a-version")]
+    [InlineData("")]
+    public async Task ShowVersion_InvalidVersion_IsAUsageError(string version)
+    {
+        var run = await _host.RunAsync("show", "flight-tools", "--version", version);
+
+        Assert.Equal(2, run.ExitCode);
+        Assert.Equal(0, _host.Builds);
+    }
+
+    private static FakeInstalledGameVersionProvider Installed(string version) => new()
+    {
+        Installed = new InstalledGameVersion(GameVersion.Parse(version), version),
+    };
+
+    private static ContentIndexSnapshot Snapshot(params ContentIndexListing[] listings) =>
+        Snapshot(listings, Array.Empty<ContentIndexDiagnostic>());
+
+    private static ContentIndexSnapshot Snapshot(
+        IReadOnlyList<ContentIndexListing> listings,
+        IReadOnlyList<ContentIndexDiagnostic> diagnostics) => new(
+            1,
+            listings,
+            Array.Empty<ContentIndexPack>(),
+            null,
+            diagnostics);
+
+    public void Dispose() => _host.Dispose();
+}

--- a/tests/Borea.Network.Tests/Planning/RepositoryInstallPlannerTests.cs
+++ b/tests/Borea.Network.Tests/Planning/RepositoryInstallPlannerTests.cs
@@ -1,0 +1,471 @@
+using Borea.Core.Dependencies;
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+using Borea.Core.Planning;
+using Borea.Network.Planning;
+
+namespace Borea.Network.Tests.Planning;
+
+public sealed class RepositoryInstallPlannerTests
+{
+    [Fact]
+    public async Task PlanAsync_TransitiveChain_OrdersDependenciesFirst()
+    {
+        var c = Release("C");
+        var b = Release("B", dependencies: [Required("C")]);
+        var a = Release("A", dependencies: [Required("B")]);
+        var plan = await PlanAsync([a], [a, b, c]);
+        Assert.True(plan.IsReady);
+        Assert.Equal(["C", "B", "A"], plan.Operations.Select(value => value.Release.ModId));
+    }
+
+    [Fact]
+    public async Task PlanAsync_CombinedBounds_SelectsSharedCompatibleVersion()
+    {
+        var b2 = Release("B", "2.0.0");
+        var b3 = Release("B", "3.0.0");
+        var a = Release("A", dependencies: [Required("B", "2.0.0")]);
+        var c = Release("C", dependencies: [Required("B", max: "2.0.0")]);
+        var plan = await PlanAsync([a, c], [a, c, b2, b3]);
+        Assert.True(plan.IsReady);
+        Assert.Equal(ModVersion.Parse("2.0.0"), Assert.Single(plan.Selections, value => value.Release.ModId == "B").Release.Version);
+    }
+
+    [Fact]
+    public async Task PlanAsync_PlannedConflict_IsBlocking()
+    {
+        var a = Release("A", dependencies: [new ModDependency("B", ModDependencyKind.Conflict)]);
+        var b = Release("B");
+        var plan = await PlanAsync([a, b], [a, b]);
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.Conflicts, value => value.Code == "dependency-conflict");
+    }
+
+    [Fact]
+    public async Task PlanAsync_SatisfyingInstalledDependency_DoesNotPlanWrite()
+    {
+        var installed = Installed("B", "1.0.0");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [installed], false);
+        var a = Release("A", dependencies: [Required("B")]);
+        var repository = new FakeRepository([a]);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], repository));
+        Assert.True(plan.IsReady);
+        Assert.DoesNotContain(plan.Operations, value => value.Release.ModId == "B");
+        Assert.Equal(0, repository.ReleaseReads);
+    }
+
+    [Fact]
+    public async Task PlanAsync_UnboundedForeignDependency_IsSatisfiedWithoutRepositoryRead()
+    {
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [], [new ForeignMod("B")], false);
+        var a = Release("A", dependencies: [Required("B")]);
+        var repository = new FakeRepository([a]);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], repository));
+        Assert.True(plan.IsReady);
+        Assert.Equal(0, repository.VersionReads);
+    }
+
+    [Fact]
+    public async Task PlanAsync_Cycle_IsStableAndDoesNotWriteInstance()
+    {
+        var a = Release("A", dependencies: [Required("B")]);
+        var b = Release("B", dependencies: [Required("A")]);
+        var repository = new FakeRepository([a, b]);
+        var instance = new Instance("Test", InstanceSource.Custom.Value);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], repository));
+        Assert.True(plan.IsReady);
+        Assert.Empty(instance.Mods);
+        Assert.Equal(2, plan.Operations.Count);
+    }
+
+    [Fact]
+    public async Task PlanAsync_RetainedInstalledDependencyConstrainsUpdate()
+    {
+        var x = Installed("X", dependencies: [Required("B", max: "1.0.0")]);
+        var b1 = Release("B");
+        var b2 = Release("B", "2.0.0");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [x, Installed("B")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(b2, InstallReason.Manual)], new FakeRepository([b1, b2])));
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.Conflicts, value => value.Code == "retained-dependent");
+    }
+
+    [Fact]
+    public async Task PlanAsync_NonExactRequestCanSelectCompatibleVersion()
+    {
+        var b1 = Release("B");
+        var b2 = Release("B", "2.0.0");
+        var a = Release("A", dependencies: [Required("B", max: "1.0.0")]);
+        var request = new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), [new RequestedMod(a, InstallReason.Manual), new RequestedMod(b2, InstallReason.Manual, Exact: false)], new FakeRepository([a, b1, b2]));
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(request);
+        Assert.True(plan.IsReady);
+        Assert.Contains(plan.Selections, value => value.Release.ModId == "B" && value.Release.Version == ModVersion.Parse("1.0.0"));
+    }
+
+    [Fact]
+    public async Task PlanAsync_VersionDependentGraphBacktracksWithoutOscillation()
+    {
+        var c = Release("C", dependencies: [Required("B", max: "1.0.0")]);
+        var b1 = Release("B");
+        var b2 = Release("B", "2.0.0", [Required("C")]);
+        var a = Release("A", dependencies: [Required("B")]);
+        var plan = await PlanAsync([a], [a, b1, b2, c]);
+        Assert.True(plan.IsReady);
+        Assert.Equal(["B", "A"], plan.Operations.Select(value => value.Release.ModId));
+    }
+
+    [Fact]
+    public async Task PlanAsync_DirectForeignIdRequest_IsBlocking()
+    {
+        var b = Release("B");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [], [new ForeignMod("B")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(b, InstallReason.Manual)], new FakeRepository([b])));
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.Conflicts, value => value.Code == "foreign-owned");
+    }
+
+    [Fact]
+    public async Task PlanAsync_InstalledAlternativeNeedsNoChoice()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B"), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [dependency]);
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [Installed("C")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a])));
+        Assert.True(plan.IsReady);
+        Assert.Equal("C", Assert.Single(plan.Choices).Selected);
+    }
+
+    [Fact]
+    public async Task PlanAsync_SelectedAlternative_IsOrderedBeforeDependent()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B"), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [dependency]);
+        var b = Release("B");
+        var choices = new Dictionary<string, string> { ["A:dependency:0:alternative"] = "B" };
+        var request = new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a, b]), Alternatives: choices);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(request);
+        Assert.Equal(["B", "A"], plan.Operations.Select(value => value.Release.ModId));
+    }
+
+    [Fact]
+    public async Task PlanAsync_BoundedConflictWithForeignMod_IsUnknown()
+    {
+        var a = Release("A", dependencies: [new ModDependency("B", ModDependencyKind.Conflict, ModVersion.Parse("2.0.0"))]);
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [], [new ForeignMod("B")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a])));
+        Assert.False(plan.IsReady);
+        Assert.Empty(plan.Conflicts);
+        Assert.Contains(plan.UnresolvedChoices, value => value.Code == "foreign-conflict-unknown");
+    }
+
+    [Fact]
+    public async Task PlanAsync_RecommendationExposesStableCallerChoice()
+    {
+        var a = Release("A", dependencies: [new ModDependency("B", ModDependencyKind.Recommends)]);
+        var plan = await PlanAsync([a], [a, Release("B")]);
+        var choice = Assert.Single(plan.Choices);
+        Assert.Equal("A:dependency:0:recommendation", choice.Key);
+        Assert.Equal(["include", "exclude"], choice.Options);
+        Assert.Equal("exclude", choice.Selected);
+    }
+
+    [Fact]
+    public async Task PlanAsync_ReplacedInstalledVersionDoesNotCauseStaleConflict()
+    {
+        var a = Release("A", dependencies: [new ModDependency("B", ModDependencyKind.Conflict, maxVersion: ModVersion.Parse("1.0.0"))]);
+        var b2 = Release("B", "2.0.0");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [Installed("B")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual), new RequestedMod(b2, InstallReason.Manual)], new FakeRepository([a, b2])));
+        Assert.True(plan.IsReady);
+    }
+
+    [Fact]
+    public async Task PlanAsync_UnsatisfiedInstalledDependencyCanBeUpdated()
+    {
+        var a = Release("A", dependencies: [Required("B", "2.0.0")]);
+        var b2 = Release("B", "2.0.0");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [Installed("B")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a, b2])));
+        Assert.True(plan.IsReady);
+        Assert.Contains(plan.Operations, value => value.Release.ModId == "B" && value.Release.Version == ModVersion.Parse("2.0.0"));
+    }
+
+    [Fact]
+    public async Task PlanAsync_UnselectedAlternativeReturnsChoice()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B"), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [dependency]);
+        var plan = await PlanAsync([a], [a, Release("B"), Release("C")]);
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.UnresolvedChoices, value => value.Code == "alternative-choice");
+        Assert.Null(Assert.Single(plan.Choices).Selected);
+    }
+
+    [Fact]
+    public async Task PlanAsync_TruncatedSearchIsBlocking()
+    {
+        var available = new List<ModVersionMetadata>();
+        var requested = new List<RequestedMod>();
+        for (var id = 0; id < 6; id++)
+        {
+            for (var version = 0; version < 10; version++) available.Add(Release($"M{id}", $"1.0.{version}"));
+            requested.Add(new RequestedMod(available[^1], InstallReason.Manual, Exact: false));
+        }
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), requested, new FakeRepository(available)));
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.Conflicts, value => value.Code == "search-limit");
+    }
+
+    [Fact]
+    public async Task PlanAsync_RetainedInstalledAlternativeConstrainsReplacement()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B", maxVersion: ModVersion.Parse("1.0.0")), new ModDependencyAlternative("C")]);
+        var x = Installed("X", dependencies: [dependency]);
+        var b2 = Release("B", "2.0.0");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [x, Installed("B")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(b2, InstallReason.Manual)], new FakeRepository([b2])));
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.Conflicts, value => value.Code == "retained-alternative");
+    }
+
+    [Fact]
+    public async Task PlanAsync_NonExactYankedRootUsesUsableRelease()
+    {
+        var b1 = Release("B");
+        var b2 = Release("B", "2.0.0", yanked: true);
+        var request = new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), [new RequestedMod(b2, InstallReason.Manual, Exact: false)], new FakeRepository([b1, b2]));
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(request);
+        Assert.True(plan.IsReady);
+        Assert.Equal(ModVersion.Parse("1.0.0"), Assert.Single(plan.Selections).Release.Version);
+    }
+
+    [Fact]
+    public async Task PlanAsync_BoundedForeignAlternativeIsUnknown()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B", minVersion: ModVersion.Parse("2.0.0")), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [dependency]);
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [], [new ForeignMod("B")], false);
+        var alternatives = new Dictionary<string, string> { ["A:dependency:0:alternative"] = "B" };
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a]), Alternatives: alternatives));
+        Assert.False(plan.IsReady);
+        Assert.Empty(plan.Conflicts);
+        Assert.Contains(plan.UnresolvedChoices, value => value.Code == "foreign-alternative-unknown");
+    }
+
+    [Fact]
+    public async Task PlanAsync_InstalledDependencyIsSelectedAndItsDependencyIsPlanned()
+    {
+        var b = Installed("B", dependencies: [Required("C")]);
+        var a = Release("A", dependencies: [Required("B")]);
+        var c = Release("C");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [b], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a, c])));
+        Assert.True(plan.IsReady);
+        Assert.Contains(plan.Selections, value => value.Release.ModId == "B" && value.IsAlreadyInstalled);
+        Assert.Contains(plan.Operations, value => value.Release.ModId == "C");
+    }
+
+    [Fact]
+    public async Task PlanAsync_ReplacedInstalledAlternativeUsesProposedVersion()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B", maxVersion: ModVersion.Parse("1.0.0")), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [dependency]);
+        var b2 = Release("B", "2.0.0");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [Installed("B")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual), new RequestedMod(b2, InstallReason.Manual)], new FakeRepository([a, b2])));
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.UnresolvedChoices, value => value.Code == "alternative-choice");
+    }
+
+    [Fact]
+    public async Task PlanAsync_ExplicitRootSatisfiesAlternativeWithoutChoice()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B"), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [dependency]);
+        var b = Release("B");
+        var plan = await PlanAsync([a, b], [a, b, Release("C")]);
+        Assert.True(plan.IsReady);
+        Assert.Equal("B", Assert.Single(plan.Choices).Selected);
+    }
+
+    [Fact]
+    public async Task PlanAsync_RetainedBoundedForeignAlternativeIsUnknown()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B", minVersion: ModVersion.Parse("2.0.0")), new ModDependencyAlternative("C")]);
+        var x = Installed("X", dependencies: [dependency]);
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [x], [new ForeignMod("B")], false);
+        var a = Release("A");
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a])));
+        Assert.False(plan.IsReady);
+        Assert.Empty(plan.Conflicts);
+        Assert.Contains(plan.UnresolvedChoices, value => value.Code == "foreign-alternative-unknown");
+    }
+
+    [Fact]
+    public async Task PlanAsync_RecommendedAlternativeHasUniqueChoiceKeys()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Recommends, [new ModDependencyAlternative("B"), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [dependency]);
+        var recommended = new HashSet<string> { "A:dependency:0:recommendation" };
+        var request = new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a, Release("B"), Release("C")]), Recommended: recommended);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(request);
+        Assert.Equal(2, plan.Choices.Select(value => value.Key).Distinct().Count());
+        Assert.Contains(plan.Choices, value => value.Key == "A:dependency:0:recommendation");
+        Assert.Contains(plan.Choices, value => value.Key == "A:dependency:0:alternative");
+    }
+
+    [Fact]
+    public async Task PlanAsync_CircularAlternativesDoNotChooseEachOther()
+    {
+        var choice = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B"), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [choice]);
+        var c = Release("C", dependencies: [Required("B")]);
+        var plan = await PlanAsync([a], [a, Release("B"), c]);
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.UnresolvedChoices, value => value.Code == "alternative-choice");
+    }
+
+    [Fact]
+    public async Task PlanAsync_RetainedBoundedForeignDependencyIsUnknown()
+    {
+        var x = Installed("X", dependencies: [Required("B", "2.0.0")]);
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [x], [new ForeignMod("B")], false);
+        var a = Release("A");
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a])));
+        Assert.False(plan.IsReady);
+        Assert.Empty(plan.Conflicts);
+        Assert.Contains(plan.UnresolvedChoices, value => value.Code == "foreign-version-unknown");
+    }
+
+    [Fact]
+    public async Task PlanAsync_IncompatibleAvailableDependencyKeepsCompatibilityDecision()
+    {
+        var a = Release("A", dependencies: [Required("B")]);
+        var b = Release("B", gameMinRevision: 5000);
+        var request = new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a, b]), new Borea.Core.Game.GameVersion(2026, 7, 4, 2131));
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(request);
+        Assert.Contains(plan.Conflicts, value => value.Code == "incompatible" && value.ModId == "B");
+        Assert.DoesNotContain(plan.Conflicts, value => value.Code == "unsatisfied-dependency");
+    }
+
+    [Fact]
+    public async Task PlanAsync_YankedNonExactRootWithoutReplacementKeepsWarning()
+    {
+        var b = Release("B", "2.0.0", yanked: true);
+        var request = new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), [new RequestedMod(b, InstallReason.Manual, Exact: false)], new FakeRepository([]));
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(request);
+        Assert.Contains(plan.Selections, value => value.Release.Version == b.Version);
+        Assert.Contains(plan.Warnings, value => value.Code == "yanked");
+    }
+
+    [Fact]
+    public async Task PlanAsync_InstalledFallbackKeepsExplicitReason()
+    {
+        var a = Release("A", dependencies: [Required("B", max: "1.0.0")]);
+        var b2 = Release("B", "2.0.0");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [Installed("B")], false);
+        var requested = new[] { new RequestedMod(a, InstallReason.Manual), new RequestedMod(b2, InstallReason.ModPack, Exact: false) };
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, requested, new FakeRepository([a, b2])));
+        Assert.Equal(InstallReason.ModPack, Assert.Single(plan.Selections, value => value.Release.ModId == "B").Reason);
+    }
+
+    [Fact]
+    public async Task PlanAsync_UnsupportedPlatformIsExposed()
+    {
+        var a = Release("A", os: ["windows"]);
+        var request = new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a]), TargetPlatform: Borea.Core.Game.OsPlatform.Linux);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(request);
+        Assert.True(plan.IsReady);
+        Assert.Contains(plan.Warnings, value => value.Code == "platform");
+        Assert.False(Assert.Single(plan.Operations).PlatformSupport!.IsSupported);
+    }
+
+    [Fact]
+    public void PlanningState_OwnershipChange_DoesNotMatch()
+    {
+        var release = Release("A");
+        var owned = new InstalledMod("A", release.Version, InstallReason.Manual, DateTimeOffset.UnixEpoch, release, ownership: ModInstallOwnership.Borea, ownershipToken: "token");
+        var foreignOwned = new InstalledMod("A", release.Version, InstallReason.Manual, DateTimeOffset.UnixEpoch, release, ownership: ModInstallOwnership.Foreign);
+        var before = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [owned], false);
+        var after = Instance.FromExisting(before.InstanceId, "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [foreignOwned], false);
+        var state = InstallPlanningState.Capture(before);
+        Assert.False(state.Matches(after));
+    }
+
+    [Fact]
+    public void PlanningState_ForeignDependencyChange_DoesNotMatch()
+    {
+        var beforeMod = new ForeignMod("A", [new LocalModDependency("B", optional: false)]);
+        var afterMod = new ForeignMod("A", [new LocalModDependency("B", optional: true)]);
+        var before = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [], [beforeMod], false);
+        var after = Instance.FromExisting(before.InstanceId, "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [], [afterMod], false);
+        var state = InstallPlanningState.Capture(before);
+        Assert.False(state.Matches(after));
+    }
+
+    [Fact]
+    public void PlanningState_InstalledReleaseDecisionChange_DoesNotMatch()
+    {
+        var available = Release("A");
+        var yanked = Release("A", yanked: true);
+        var beforeMod = new InstalledMod("A", available.Version, InstallReason.Manual, DateTimeOffset.UnixEpoch, available);
+        var afterMod = new InstalledMod("A", yanked.Version, InstallReason.Manual, DateTimeOffset.UnixEpoch, yanked);
+        var before = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [beforeMod], false);
+        var after = Instance.FromExisting(before.InstanceId, "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [afterMod], false);
+        Assert.False(InstallPlanningState.Capture(before).Matches(after));
+    }
+
+    [Fact]
+    public void PlanningState_AlternativeOrderChange_DoesNotMatch()
+    {
+        var first = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B"), new ModDependencyAlternative("C")]);
+        var second = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("C"), new ModDependencyAlternative("B")]);
+        var before = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [Installed("A", dependencies: [first])], false);
+        var after = Instance.FromExisting(before.InstanceId, "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [Installed("A", dependencies: [second])], false);
+        Assert.False(InstallPlanningState.Capture(before).Matches(after));
+    }
+
+    [Fact]
+    public void PlanningState_NullAndEmptyYankReasons_DoNotMatch()
+    {
+        var nullReason = Release("A", yanked: true);
+        var emptyReason = new ModVersionMetadata(1, "A", nullReason.Version, ReleaseStatus.Stable, DateTimeOffset.UnixEpoch, "2026.7.4.2131", 2131, nullReason.Download, 1, [], yanked: true, yankedReason: string.Empty);
+        var before = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [new InstalledMod("A", nullReason.Version, InstallReason.Manual, DateTimeOffset.UnixEpoch, nullReason)], false);
+        var after = Instance.FromExisting(before.InstanceId, "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [new InstalledMod("A", emptyReason.Version, InstallReason.Manual, DateTimeOffset.UnixEpoch, emptyReason)], false);
+        Assert.False(InstallPlanningState.Capture(before).Matches(after));
+    }
+
+    [Fact]
+    public void PlanningState_ForeignCollectionBoundaries_DoNotCollide()
+    {
+        var firstMods = new[]
+        {
+            new ForeignMod("A", [new LocalModDependency("foreign", optional: false)]),
+            new ForeignMod("X", dependencyReadError: "required"),
+        };
+        var secondMods = new[]
+        {
+            new ForeignMod("A"),
+            new ForeignMod("required", [new LocalModDependency("X", optional: false)], "foreign"),
+        };
+        var first = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [], firstMods, false);
+        var second = Instance.FromExisting(first.InstanceId, "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [], secondMods, false);
+        Assert.NotEqual(InstallPlanningState.Capture(first), InstallPlanningState.Capture(second));
+    }
+
+    private static Task<InstallPlan> PlanAsync(IReadOnlyList<ModVersionMetadata> requested, IReadOnlyList<ModVersionMetadata> available) => new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), requested.Select(value => new RequestedMod(value, InstallReason.Manual)).ToList(), new FakeRepository(available)));
+    private static ModDependency Required(string id, string? min = null, string? max = null) => new(id, ModDependencyKind.Required, min is null ? null : ModVersion.Parse(min), max is null ? null : ModVersion.Parse(max));
+    private static InstalledMod Installed(string id, string version = "1.0.0", IReadOnlyList<ModDependency>? dependencies = null) => new(id, ModVersion.Parse(version), InstallReason.Manual, DateTimeOffset.UtcNow, Release(id, version, dependencies));
+    private static ModVersionMetadata Release(string id, string version = "1.0.0", IReadOnlyList<ModDependency>? dependencies = null, bool yanked = false, int gameMinRevision = 2131, IReadOnlyList<string>? os = null) => new(1, id, ModVersion.Parse(version), ReleaseStatus.Stable, DateTimeOffset.UnixEpoch, gameMinRevision == 2131 ? "2026.7.4.2131" : $"2026.7.4.{gameMinRevision}", gameMinRevision, new DownloadInfo("https://example.com/mod.zip", new string('A', 64), 1, "application/zip"), 1, dependencies ?? [], os: os, yanked: yanked);
+
+    private sealed class FakeRepository(IReadOnlyList<ModVersionMetadata> releases) : IModRepository
+    {
+        public int VersionReads { get; private set; }
+        public int ReleaseReads { get; private set; }
+        public Task<IReadOnlyList<ModVersion>> GetAvailableVersionsAsync(string modId, CancellationToken cancellationToken = default) { VersionReads++; return Task.FromResult<IReadOnlyList<ModVersion>>(releases.Where(value => ModIds.Equals(value.ModId, modId)).Select(value => value.Version).ToList()); }
+        public Task<ModVersionMetadata?> GetReleaseAsync(string modId, ModVersion version, CancellationToken cancellationToken = default) { ReleaseReads++; return Task.FromResult(releases.FirstOrDefault(value => ModIds.Equals(value.ModId, modId) && value.Version == version)); }
+        public Task<IReadOnlyList<ModMetadata>> GetAvailableModsAsync(CancellationToken cancellationToken = default) => Task.FromResult<IReadOnlyList<ModMetadata>>([]);
+        public Task<ModVersionMetadata?> GetLatestReleaseAsync(string modId, CancellationToken cancellationToken = default) => Task.FromResult<ModVersionMetadata?>(null);
+        public Task<IReadOnlyList<ModMetadata>> SearchAsync(string query, CancellationToken cancellationToken = default) => Task.FromResult<IReadOnlyList<ModMetadata>>([]);
+    }
+}

--- a/tests/Borea.Storage.Tests/Mods/FileModInstallerTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/FileModInstallerTests.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using Borea.Core.Dependencies;
 using Borea.Core.Instances;
 using Borea.Core.Mods;
+using Borea.Core.Planning;
 using Borea.Core.State;
 using Borea.Storage.Instances;
 using Borea.Storage.Mods;
@@ -59,9 +60,10 @@ public sealed class FileModInstallerTests : IAsyncLifetime
         InstallInfo? install = null,
         ContentType type = ContentType.Mod,
         string contentType = "application/zip",
-        string? sha256 = null) => new(
+        string? sha256 = null,
+        string modId = ModId) => new(
         specVersion: 1,
-        modId: ModId,
+        modId: modId,
         version: ModVersion.Parse("1.2.0"),
         releaseStatus: ReleaseStatus.Stable,
         releaseDate: new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero),
@@ -93,6 +95,38 @@ public sealed class FileModInstallerTests : IAsyncLifetime
         Assert.Empty(instance!.Mods);
         Assert.Empty(await _modState.GetEntriesAsync(_instanceId));
         Assert.All(_downloader.ArchivePaths, path => Assert.False(File.Exists(path)));
+    }
+
+    [Fact]
+    public async Task GuardedInstallAsync_ReturnsTheAdvancedPlanningState()
+    {
+        _downloader.Bytes = BuildZip((ModId + "/mod.toml", "name = \"test-mod\""));
+        var expected = InstallPlanningState.Capture((await _instances.GetByIdAsync(_instanceId))!);
+
+        var result = await _installer.InstallGuardedAsync(_instanceId, Release(), InstallReason.Manual, enable: true, expectedState: expected);
+
+        Assert.True(result.State.Matches((await _instances.GetByIdAsync(_instanceId))!));
+        Assert.Equal(ModId, result.Result.Mod.ModId);
+    }
+
+    [Fact]
+    public async Task GuardedInstallAsync_ManagedChangeDuringDownloadWritesNoTarget()
+    {
+        _downloader.Bytes = BuildZip((ModId + "/mod.toml", "name = \"test-mod\""));
+        var expected = InstallPlanningState.Capture((await _instances.GetByIdAsync(_instanceId))!);
+        var otherRelease = Release(modId: "other-mod");
+        _downloader.AfterDownload = () => _instances.UpdateAsync(
+            _instanceId,
+            instance =>
+            {
+                instance.AddMod(new InstalledMod("other-mod", otherRelease.Version, InstallReason.Manual, Now, otherRelease));
+                return true;
+            }).GetAwaiter().GetResult();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _installer.InstallGuardedAsync(_instanceId, Release(), InstallReason.Manual, enable: true, expectedState: expected));
+
+        Assert.False(Directory.Exists(ModFolder));
+        Assert.Equal("other-mod", Assert.Single((await _instances.GetByIdAsync(_instanceId))!.Mods).ModId);
     }
 
     #region Unpacking

--- a/tests/Borea.Storage.Tests/Mods/FileModReplacerTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/FileModReplacerTests.cs
@@ -1,6 +1,7 @@
 using Borea.Core.Dependencies;
 using Borea.Core.Instances;
 using Borea.Core.Mods;
+using Borea.Core.Planning;
 using Borea.Storage.Instances;
 using Borea.Storage.Mods;
 using Borea.Storage.State;
@@ -141,6 +142,43 @@ public sealed class FileModReplacerTests : IAsyncLifetime
         var saved = Assert.Single((await _instances.GetByIdAsync(_instanceId))!.Mods);
         Assert.Equal(ModVersion.Parse("1.0.0"), saved.Version);
         Assert.Equal(InstallReason.Manual, saved.Reason);
+    }
+
+    [Fact]
+    public async Task GuardedReplaceAsync_ReturnsTheAdvancedPlanningState()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        var expected = InstallPlanningState.Capture((await _instances.GetByIdAsync(_instanceId))!);
+        _downloader.Bytes = Archive("new");
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state);
+
+        var result = await replacer.ReplaceGuardedAsync(_instanceId, current, Release("1.1.0"), expected);
+
+        Assert.True(result.State.Matches((await _instances.GetByIdAsync(_instanceId))!));
+        Assert.Equal(ModVersion.Parse("1.1.0"), result.Result.Replacement.Version);
+    }
+
+    [Fact]
+    public async Task GuardedReplaceAsync_ForeignChangeDuringDownloadKeepsTheWorkingTarget()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        var expected = InstallPlanningState.Capture((await _instances.GetByIdAsync(_instanceId))!);
+        _downloader.Bytes = Archive("new");
+        _downloader.AfterDownload = () => _instances.UpdateAsync(
+            _instanceId,
+            instance =>
+            {
+                instance.ReplaceForeignMods([new ForeignMod("foreign-dependency")]);
+                return true;
+            }).GetAwaiter().GetResult();
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => replacer.ReplaceGuardedAsync(_instanceId, current, Release("1.1.0"), expected));
+
+        Assert.Equal("old", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+        var saved = await _instances.GetByIdAsync(_instanceId);
+        Assert.Equal(ModVersion.Parse("1.0.0"), Assert.Single(saved!.Mods).Version);
+        Assert.Equal("foreign-dependency", Assert.Single(saved.ForeignMods).ModId);
     }
 
     private string ModFolder => Path.Combine(_paths.GetInstanceModsFolder(_instanceId), ModId);

--- a/tests/Borea.Storage.Tests/Mods/FileModReplacerTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/FileModReplacerTests.cs
@@ -1,0 +1,249 @@
+using Borea.Core.Dependencies;
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+using Borea.Storage.Instances;
+using Borea.Storage.Mods;
+using Borea.Storage.State;
+using Borea.Storage.Tests.Paths;
+
+namespace Borea.Storage.Tests.Mods;
+
+public sealed class FileModReplacerTests : IAsyncLifetime
+{
+    private const string ModId = "test-mod";
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+    private readonly FakeModDownloader _downloader = new();
+    private TestGamePathProvider _paths = null!;
+    private FileInstanceRepository _instances = null!;
+    private FileModStateRepository _state = null!;
+    private Guid _instanceId;
+
+    public async Task InitializeAsync()
+    {
+        _paths = new TestGamePathProvider(_root);
+        _instances = new FileInstanceRepository(_paths);
+        _state = new FileModStateRepository(_paths);
+        _instanceId = (await _instances.CreateAsync("Test", InstanceSource.Custom.Value)).InstanceId;
+    }
+
+    public Task DisposeAsync()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+        return Task.CompletedTask;
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ReplaceAsync_ReplacesOwnedFilesAndPreservesState(bool enabled)
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled);
+        _downloader.Bytes = Archive("new");
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state);
+
+        var result = await replacer.ReplaceAsync(_instanceId, current, Release("1.1.0"));
+
+        Assert.Equal(ModVersion.Parse("1.1.0"), result.Replacement.Version);
+        Assert.Equal("new", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+        Assert.Equal(enabled, await _state.IsActiveAsync(_instanceId, ModId));
+        var saved = Assert.Single((await _instances.GetByIdAsync(_instanceId))!.Mods);
+        Assert.Equal(current.Reason, saved.Reason);
+        Assert.Equal(ModVersion.Parse("1.1.0"), saved.Version);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_InvalidArchiveLeavesTheCurrentInstallUntouched()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        _downloader.Bytes = TestArchives.Build((ModId + "/value.txt", "new"));
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => replacer.ReplaceAsync(_instanceId, current, Release("1.1.0")));
+
+        Assert.Equal("old", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+        Assert.Equal(ModVersion.Parse("1.0.0"), Assert.Single((await _instances.GetByIdAsync(_instanceId))!.Mods).Version);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_RejectsAStaleInstalledRecord()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        var stale = new InstalledMod(ModId, current.Version, current.Reason, current.InstalledAt, current.Metadata, current.Checksum, ModInstallOwnership.Borea, "different-token");
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => replacer.ReplaceAsync(_instanceId, stale, Release("1.1.0")));
+        Assert.Equal("old", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_RejectsForeignOwnership()
+    {
+        var metadata = Release("1.0.0");
+        var foreign = new InstalledMod(ModId, metadata.Version, InstallReason.Manual, DateTimeOffset.UtcNow, metadata, ownership: ModInstallOwnership.Foreign);
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => replacer.ReplaceAsync(_instanceId, foreign, Release("1.1.0")));
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_CancellationDuringPreparationLeavesTheCurrentInstallUntouched()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => replacer.ReplaceAsync(_instanceId, current, Release("1.1.0"), cancellationToken: cancellation.Token));
+        Assert.Equal("old", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_MetadataSaveFailureAfterSwapRestoresTheCurrentInstall()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        _downloader.Bytes = Archive("new");
+        var failingInstances = new FailBeforeSaveInstanceRepository(_instances);
+        var replacer = new FileModReplacer(_paths, _downloader, failingInstances, _state);
+
+        await Assert.ThrowsAsync<IOException>(() => replacer.ReplaceAsync(_instanceId, current, Release("1.1.0")));
+
+        Assert.Equal("old", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+        Assert.Equal(ModVersion.Parse("1.0.0"), Assert.Single((await _instances.GetByIdAsync(_instanceId))!.Mods).Version);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_BackupCleanupFailureKeepsTheReplacementAndReportsRecoveryData()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        _downloader.Bytes = Archive("new");
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state, timeProvider: null, deleteRecoveryDirectory: _ => false);
+
+        var result = await replacer.ReplaceAsync(_instanceId, current, Release("1.1.0"));
+
+        Assert.NotNull(result.RetainedRecoveryDirectory);
+        Assert.True(Directory.Exists(result.RetainedRecoveryDirectory));
+        Assert.Equal("new", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+        Assert.Equal(ModVersion.Parse("1.1.0"), Assert.Single((await _instances.GetByIdAsync(_instanceId))!.Mods).Version);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_CompetingUpdateWaitsForRecoveryFileAndRecordRestore()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        _downloader.Bytes = Archive("new");
+        var coordinatedInstances = new CompetingRecoveryInstanceRepository(_instances);
+        var replacer = new FileModReplacer(_paths, _downloader, coordinatedInstances, _state);
+
+        await Assert.ThrowsAsync<IOException>(() => replacer.ReplaceAsync(_instanceId, current, Release("1.1.0")));
+
+        Assert.Equal("old", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+        var saved = Assert.Single((await _instances.GetByIdAsync(_instanceId))!.Mods);
+        Assert.Equal(ModVersion.Parse("1.0.0"), saved.Version);
+        Assert.Equal(InstallReason.Manual, saved.Reason);
+    }
+
+    private string ModFolder => Path.Combine(_paths.GetInstanceModsFolder(_instanceId), ModId);
+
+    private async Task<InstalledMod> InstallAsync(ModVersionMetadata release, string value, bool enabled)
+    {
+        _downloader.Bytes = Archive(value);
+        var installer = new FileModInstaller(_paths, _downloader, _instances, _state);
+        return (await installer.InstallAsync(_instanceId, release, InstallReason.Dependency, enabled)).Mod;
+    }
+
+    private static byte[] Archive(string value) => TestArchives.Build((ModId + "/mod.toml", "name = \"test\""), (ModId + "/value.txt", value));
+
+    private static ModVersionMetadata Release(string version) => new(
+        1,
+        ModId,
+        ModVersion.Parse(version),
+        ReleaseStatus.Stable,
+        DateTimeOffset.UtcNow,
+        "2026.9.7.5402",
+        5402,
+        new DownloadInfo("https://example.com/mod.zip", null, null, "application/zip"),
+        null,
+        Array.Empty<ModDependency>(),
+        type: ContentType.Mod,
+        install: new InstallInfo(ModId, derived: true));
+
+    private sealed class FailBeforeSaveInstanceRepository(IInstanceRepository inner) : IInstanceRepository
+    {
+        private bool _fail = true;
+
+        public Task<IReadOnlyList<Instance>> GetAllAsync() => inner.GetAllAsync();
+        public Task<Instance?> GetByIdAsync(Guid instanceId) => inner.GetByIdAsync(instanceId);
+        public Task<Guid?> GetActiveInstanceIdAsync() => inner.GetActiveInstanceIdAsync();
+        public Task SetActiveInstanceAsync(Guid instanceId) => inner.SetActiveInstanceAsync(instanceId);
+        public Task<bool> IsNameAvailableAsync(string name, Guid? excludingInstanceId = null) => inner.IsNameAvailableAsync(name, excludingInstanceId);
+        public Task<Instance> CreateAsync(string name, InstanceSource source) => inner.CreateAsync(name, source);
+        public Task RenameAsync(Guid instanceId, string newName) => inner.RenameAsync(instanceId, newName);
+        public Task DeleteAsync(Guid instanceId) => inner.DeleteAsync(instanceId);
+        public Task SaveAsync(Instance instance) => inner.SaveAsync(instance);
+
+        public async Task<TResult> UpdateAsync<TResult>(Guid instanceId, Func<Instance, TResult> update, CancellationToken cancellationToken = default)
+        {
+            if (!_fail)
+                return await inner.UpdateAsync(instanceId, update, cancellationToken);
+
+            _fail = false;
+            var saved = await inner.GetByIdAsync(instanceId) ?? throw new InvalidOperationException();
+            var copy = Instance.FromExisting(saved.InstanceId, saved.Name, saved.Source, saved.CreatedAt, saved.Mods, saved.ForeignMods, saved.IsFavorite);
+            update(copy);
+            throw new IOException("Injected metadata save failure.");
+        }
+    }
+
+    private sealed class CompetingRecoveryInstanceRepository(IInstanceRepository inner) : IInstanceRepository
+    {
+        private bool _fail = true;
+
+        public Task<IReadOnlyList<Instance>> GetAllAsync() => inner.GetAllAsync();
+        public Task<Instance?> GetByIdAsync(Guid instanceId) => inner.GetByIdAsync(instanceId);
+        public Task<Guid?> GetActiveInstanceIdAsync() => inner.GetActiveInstanceIdAsync();
+        public Task SetActiveInstanceAsync(Guid instanceId) => inner.SetActiveInstanceAsync(instanceId);
+        public Task<bool> IsNameAvailableAsync(string name, Guid? excludingInstanceId = null) => inner.IsNameAvailableAsync(name, excludingInstanceId);
+        public Task<Instance> CreateAsync(string name, InstanceSource source) => inner.CreateAsync(name, source);
+        public Task RenameAsync(Guid instanceId, string newName) => inner.RenameAsync(instanceId, newName);
+        public Task DeleteAsync(Guid instanceId) => inner.DeleteAsync(instanceId);
+        public Task SaveAsync(Instance instance) => inner.SaveAsync(instance);
+
+        public async Task<TResult> UpdateAsync<TResult>(Guid instanceId, Func<Instance, TResult> update, CancellationToken cancellationToken = default)
+        {
+            if (_fail)
+            {
+                _fail = false;
+                var saved = await inner.GetByIdAsync(instanceId) ?? throw new InvalidOperationException();
+                var copy = Instance.FromExisting(saved.InstanceId, saved.Name, saved.Source, saved.CreatedAt, saved.Mods, saved.ForeignMods, saved.IsFavorite);
+                update(copy);
+                throw new IOException("Injected metadata save failure.");
+            }
+
+            Task? competitor = null;
+            var result = await inner.UpdateAsync(
+                instanceId,
+                current =>
+                {
+                    var recoveryResult = update(current);
+                    using var started = new ManualResetEventSlim();
+                    competitor = Task.Run(async () =>
+                    {
+                        started.Set();
+                        await inner.UpdateAsync(
+                            instanceId,
+                            competing =>
+                            {
+                                Assert.Single(competing.Mods).MarkAsManuallyInstalled();
+                                return true;
+                            });
+                    });
+                    started.Wait();
+                    return recoveryResult;
+                },
+                cancellationToken);
+            await competitor!;
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Review first: https://github.com/KSAModding/Borea/pull/116.
This PR is stacked on that pack repository PR; its diff contains only the CLI changes.

Closes #67.

You can now search the catalogue and inspect a mod or one specific release from the command line.
Search shows the mod ID, name, latest usable version and compatibility with the installed game.
Show includes links, release versions, yanked markers and index warnings; selecting a version also shows its dependencies.

Actual output excerpt for AdvancedFlightComputer from the current index:

```console
> borea show AdvancedFlightComputer --version 0.7.5
Release:
  0.7.5  unknown  stable
    Game: 2026.9.4.5400 to open
    Dependencies:
      optional  KittenExtensions (derived)
```

This run reports compatibility as unknown; the output is preserved as returned by the command.
Each command also accepts --json.

Entries from a newer metadata format remain visible as unknown.
Both commands use the retained snapshot, so a later cache-file read failure does not discard results or diagnostics.
