### PR TITLE
Test loader list command behavior

### DIFF
--- a/tests/Borea.Cli.Tests/FakeModRepository.cs
+++ b/tests/Borea.Cli.Tests/FakeModRepository.cs
@@ -10,6 +10,8 @@ internal sealed class FakeModRepository : IModRepository
 
     public Func<CancellationToken, Task<IReadOnlyList<ModMetadata>>>? AvailableMods { get; set; }
 
+    public Func<string, CancellationToken, Task<IReadOnlyList<ModVersion>>>? AvailableVersions { get; set; }
+
     public Task<IReadOnlyList<ModMetadata>> GetAvailableModsAsync(CancellationToken cancellationToken = default)
         => AvailableMods?.Invoke(cancellationToken) ?? Task.FromResult<IReadOnlyList<ModMetadata>>(Listings);
 
@@ -24,7 +26,7 @@ internal sealed class FakeModRepository : IModRepository
             ModIds.Equals(release.ModId, modId) && release.Version == version));
 
     public Task<IReadOnlyList<ModVersion>> GetAvailableVersionsAsync(string modId, CancellationToken cancellationToken = default)
-        => Task.FromResult<IReadOnlyList<ModVersion>>(Releases
+        => AvailableVersions?.Invoke(modId, cancellationToken) ?? Task.FromResult<IReadOnlyList<ModVersion>>(Releases
             .Where(release => ModIds.Equals(release.ModId, modId))
             .Select(release => release.Version)
             .Distinct()

--- a/tests/Borea.Cli.Tests/LoaderListCommandTests.cs
+++ b/tests/Borea.Cli.Tests/LoaderListCommandTests.cs
@@ -1,0 +1,103 @@
+using Borea.Core.Dependencies;
+using Borea.Core.Game;
+using Borea.Core.Mods;
+
+namespace Borea.Cli.Tests;
+
+public sealed class LoaderListCommandTests : IDisposable
+{
+    private readonly CliHost _host = new();
+
+    [Fact]
+    public async Task List_PrintsLoaderIdsAndExcludesOrdinaryMods()
+    {
+        _host.Mods.Listings.Add(LoaderFixtures.Listing("StarMap"));
+        _host.Mods.Listings.Add(ModListing("AdvancedFlightComputer"));
+        _host.Mods.Listings.Add(LoaderFixtures.Listing("OtherLoader"));
+
+        var run = await _host.RunAsync("loader", "list");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Equal($"StarMap{Environment.NewLine}OtherLoader{Environment.NewLine}", run.Output);
+        Assert.Empty(run.Error);
+    }
+
+    [Theory]
+    [InlineData("--versions")]
+    [InlineData("-v")]
+    public async Task List_VersionsFlagPrintsDescendingUniqueNonYankedVersions(string flag)
+    {
+        _host.Mods.Listings.Add(LoaderFixtures.Listing());
+        _host.Mods.Releases.Add(LoaderFixtures.Release(version: "0.4.5"));
+        _host.Mods.Releases.Add(LoaderFixtures.Release(version: "0.4.7"));
+        _host.Mods.Releases.Add(LoaderFixtures.Release(version: "0.4.6"));
+        _host.Mods.Releases.Add(LoaderFixtures.Release(version: "0.4.8", yanked: true));
+        _host.Mods.AvailableVersions = (_, _) => Task.FromResult<IReadOnlyList<ModVersion>>(
+            [
+                ModVersion.Parse("0.4.5"),
+                ModVersion.Parse("0.4.7"),
+                ModVersion.Parse("0.4.6"),
+                ModVersion.Parse("0.4.7"),
+                ModVersion.Parse("0.4.8"),
+            ]);
+
+        var run = await _host.RunAsync("loader", "list", flag);
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Equal(
+            $"StarMap{Environment.NewLine}  0.4.7{Environment.NewLine}  0.4.6{Environment.NewLine}  0.4.5{Environment.NewLine}",
+            run.Output);
+        Assert.Empty(run.Error);
+    }
+
+    [Fact]
+    public async Task List_VersionsWithNoReleases_PrintsOnlyTheLoaderId()
+    {
+        _host.Mods.Listings.Add(LoaderFixtures.Listing());
+        _host.Mods.AvailableVersions = (_, _) => Task.FromResult<IReadOnlyList<ModVersion>>(
+            [ModVersion.Parse("0.4.6")]);
+
+        var run = await _host.RunAsync("loader", "list", "--versions");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Equal($"StarMap{Environment.NewLine}", run.Output);
+        Assert.Empty(run.Error);
+    }
+
+    [Fact]
+    public async Task List_EmptyCatalogue_ReportsNoAvailableLoaders()
+    {
+        var run = await _host.RunAsync("loader", "list");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Equal($"No mod loaders available{Environment.NewLine}", run.Output);
+        Assert.Empty(run.Error);
+    }
+
+    [Fact]
+    public async Task List_RepositoryFailure_IsReportedAsAnOperationFailure()
+    {
+        _host.Mods.AvailableMods = _ => throw new IOException("Catalogue is unavailable.");
+
+        var run = await _host.RunAsync("loader", "list");
+
+        Assert.Equal(1, run.ExitCode);
+        Assert.Empty(run.Output);
+        Assert.Contains("error: Catalogue is unavailable.", run.Error);
+    }
+
+    public void Dispose() => _host.Dispose();
+
+    private static ModMetadata ModListing(string id) => new(
+        specVersion: 1,
+        modId: id,
+        source: "index",
+        name: id,
+        authors: new[] { "Mod author" },
+        abstractText: "A mod.",
+        license: "MIT",
+        links: new Dictionary<string, string> { ["forums"] = "https://example.invalid/forums" },
+        gameMin: "2026.9.7.5402",
+        type: ContentType.Mod,
+        install: new InstallDescriptor(target: InstallAnchor.Mods));
+}


### PR DESCRIPTION
Follow-up to #119.

Add focused command tests for `borea loader list`.

The tests cover loader-only output, both version flags, descending unique versions, yanked releases, empty and incomplete catalogues, and repository failures.
