### PR TITLE
Replace installed mods safely

### DIFF
--- a/src/Borea.Composition/BoreaServices.cs
+++ b/src/Borea.Composition/BoreaServices.cs
@@ -81,6 +81,8 @@ public sealed class BoreaServices : IDisposable
 
     public required IModUninstaller Uninstaller { get; init; }
 
+    public required IModReplacer Replacer { get; init; }
+
     public required IForeignModAdopter ForeignModAdopter { get; init; }
 
     /// <summary>
@@ -190,6 +192,8 @@ public sealed class BoreaServices : IDisposable
         var loaderConfiguration = new LoaderConfigurator();
         var instances = new FileInstanceRepository(paths);
 
+        var modState = new FileModStateRepository(paths);
+
         return new BoreaServices(http)
         {
             Settings = settings,
@@ -197,10 +201,11 @@ public sealed class BoreaServices : IDisposable
             SettingsRepository = settingsRepository,
             GameDirectoryChanger = new GameDirectoryChanger(settingsRepository, mods, loaderConfiguration),
             Instances = instances,
-            ModState = new FileModStateRepository(paths),
+            ModState = modState,
             ModFavorites = new FileModFavoritesRepository(paths),
             ModPackFavorites = new FileModPackFavoritesRepository(paths),
             Uninstaller = new FileModUninstaller(paths, instances),
+            Replacer = new FileModReplacer(paths, downloader, instances, modState),
             ForeignModAdopter = new FileForeignModAdopter(paths, instances, contentIndex),
             Mods = mods,
             ModPacks = modPacks,

--- a/src/Borea.Core/Instances/Instance.cs
+++ b/src/Borea.Core/Instances/Instance.cs
@@ -130,6 +130,17 @@ public sealed class Instance
         return true;
     }
 
+    public void ReplaceMod(InstalledMod replacement)
+    {
+        ArgumentNullException.ThrowIfNull(replacement);
+
+        var index = _mods.FindIndex(mod => ModIds.Equals(mod.ModId, replacement.ModId));
+        if (index < 0)
+            throw new InvalidOperationException($"Mod '{replacement.ModId}' is not installed in this instance.");
+
+        _mods[index] = replacement;
+    }
+
     public void ReplaceForeignMods(IReadOnlyList<ForeignMod> foreignMods)
     {
         ArgumentNullException.ThrowIfNull(foreignMods);

--- a/src/Borea.Core/Mods/IModReplacer.cs
+++ b/src/Borea.Core/Mods/IModReplacer.cs
@@ -1,0 +1,39 @@
+namespace Borea.Core.Mods;
+
+public interface IModReplacer
+{
+    Task<ModReplacementResult> ReplaceAsync(
+        Guid instanceId,
+        InstalledMod expectedCurrent,
+        ModVersionMetadata replacement,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record ModReplacementResult(
+    InstalledMod Previous,
+    InstalledMod Replacement,
+    DownloadResult Download,
+    string? RetainedRecoveryDirectory);
+
+public sealed class ModReplacementRecoveryException : Exception
+{
+    public Exception OperationError { get; }
+
+    public Exception RecoveryError { get; }
+
+    public string RecoveryDirectory { get; }
+
+    public ModReplacementRecoveryException(
+        Exception operationError,
+        Exception recoveryError,
+        string recoveryDirectory)
+        : base("The mod replacement failed, and Borea could not restore the previous installation.", operationError)
+    {
+        OperationError = operationError ?? throw new ArgumentNullException(nameof(operationError));
+        RecoveryError = recoveryError ?? throw new ArgumentNullException(nameof(recoveryError));
+        RecoveryDirectory = string.IsNullOrWhiteSpace(recoveryDirectory)
+            ? throw new ArgumentException("Recovery directory cannot be null or whitespace.", nameof(recoveryDirectory))
+            : recoveryDirectory;
+    }
+}

--- a/src/Borea.Storage/Borea.Storage.csproj
+++ b/src/Borea.Storage/Borea.Storage.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Borea.Core\Borea.Core.csproj" />
+    <InternalsVisibleTo Include="Borea.Storage.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Borea.Storage/Mods/FileModInstaller.cs
+++ b/src/Borea.Storage/Mods/FileModInstaller.cs
@@ -133,7 +133,7 @@ public sealed class FileModInstaller : IModInstaller
     /// the folder where the game does not look, since ModLibrary.AddMods scans
     /// the top level of the mods folder and nothing below it.
     /// </summary>
-    private static void RequireInstallable(ModVersionMetadata release)
+    internal static void RequireInstallable(ModVersionMetadata release)
     {
         if (release.Type != ContentType.Mod)
             throw new NotSupportedException($"'{release.ModId}' is a {release.Type}, and only a mod installs into the mods folder.");
@@ -158,7 +158,7 @@ public sealed class FileModInstaller : IModInstaller
     /// (ModLibrary.AddMods). The stated root decides where the content starts;
     /// a release that states none gets the root RFC 0035 rule 9 derives.
     /// </summary>
-    private static void Unpack(string archivePath, ModVersionMetadata release, string modFolder)
+    internal static void Unpack(string archivePath, ModVersionMetadata release, string modFolder)
     {
         var root = release.Install?.Root ?? ModArchive.DeriveRoot(archivePath);
         var files = ModArchive.Extract(archivePath, root, modFolder);

--- a/src/Borea.Storage/Mods/FileModReplacer.cs
+++ b/src/Borea.Storage/Mods/FileModReplacer.cs
@@ -1,0 +1,220 @@
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+using Borea.Core.Paths;
+using Borea.Core.State;
+
+namespace Borea.Storage.Mods;
+
+public sealed class FileModReplacer : IModReplacer
+{
+    private readonly IGamePathProvider _paths;
+    private readonly IModDownloader _downloader;
+    private readonly IInstanceRepository _instances;
+    private readonly IModStateRepository _modState;
+    private readonly TimeProvider _timeProvider;
+    private readonly Func<string, bool> _deleteRecoveryDirectory;
+
+    public FileModReplacer(
+        IGamePathProvider paths,
+        IModDownloader downloader,
+        IInstanceRepository instances,
+        IModStateRepository modState,
+        TimeProvider? timeProvider = null)
+        : this(paths, downloader, instances, modState, timeProvider, TryDeleteDirectory)
+    {
+    }
+
+    internal FileModReplacer(
+        IGamePathProvider paths,
+        IModDownloader downloader,
+        IInstanceRepository instances,
+        IModStateRepository modState,
+        TimeProvider? timeProvider,
+        Func<string, bool> deleteRecoveryDirectory)
+    {
+        _paths = paths ?? throw new ArgumentNullException(nameof(paths));
+        _downloader = downloader ?? throw new ArgumentNullException(nameof(downloader));
+        _instances = instances ?? throw new ArgumentNullException(nameof(instances));
+        _modState = modState ?? throw new ArgumentNullException(nameof(modState));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _deleteRecoveryDirectory = deleteRecoveryDirectory ?? throw new ArgumentNullException(nameof(deleteRecoveryDirectory));
+    }
+
+    public async Task<ModReplacementResult> ReplaceAsync(
+        Guid instanceId,
+        InstalledMod expectedCurrent,
+        ModVersionMetadata replacement,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(expectedCurrent);
+        ArgumentNullException.ThrowIfNull(replacement);
+        FileModInstaller.RequireInstallable(replacement);
+
+        if (!ModIds.Equals(expectedCurrent.ModId, replacement.ModId))
+            throw new ArgumentException("The replacement must have the same mod ID as the installed mod.", nameof(replacement));
+
+        RequireOwned(expectedCurrent);
+        var before = await _instances.GetByIdAsync(instanceId).ConfigureAwait(false)
+            ?? throw new InvalidOperationException($"No instance with ID '{instanceId}' exists.");
+        RequireExpected(before, expectedCurrent);
+
+        var entries = await _modState.GetEntriesAsync(instanceId, cancellationToken).ConfigureAwait(false);
+        var matchingEntries = entries.Where(entry => ModIds.Equals(entry.ModId, expectedCurrent.ModId)).ToArray();
+        if (matchingEntries.Length == 0)
+            throw new InvalidOperationException($"The manifest has no entry for installed mod '{expectedCurrent.ModId}'.");
+        var wasActive = matchingEntries.Any(entry => entry.Enabled);
+
+        var archivePath = Path.Combine(Path.GetTempPath(), $"borea-download-{Guid.NewGuid():N}.zip");
+        var instanceRoot = _paths.GetInstanceRoot(instanceId);
+        var stagingFolder = Path.Combine(instanceRoot, $".borea-staging-{Guid.NewGuid():N}");
+        var backupFolder = Path.Combine(instanceRoot, $".borea-recovery-{Guid.NewGuid():N}");
+        var modsFolder = _paths.GetInstanceModsFolder(instanceId);
+        DownloadResult download;
+        InstalledMod? installed = null;
+        string? installedFolder = null;
+        var backupCreated = false;
+        var replacementMoved = false;
+
+        try
+        {
+            download = await _downloader.DownloadAsync(replacement, archivePath, progress, cancellationToken).ConfigureAwait(false);
+            FileModInstaller.Unpack(archivePath, replacement, stagingFolder);
+            var ownershipToken = Guid.NewGuid().ToString("N");
+            await File.WriteAllTextAsync(Path.Combine(stagingFolder, ModFolders.OwnershipFileName), ownershipToken, cancellationToken).ConfigureAwait(false);
+
+            installed = new InstalledMod(
+                replacement.ModId,
+                replacement.Version,
+                expectedCurrent.Reason,
+                _timeProvider.GetUtcNow(),
+                replacement,
+                download.Sha256,
+                ModInstallOwnership.Borea,
+                ownershipToken);
+
+            await _instances.UpdateAsync(
+                instanceId,
+                current =>
+                {
+                    RequireExpected(current, expectedCurrent);
+                    installedFolder = ModFolders.FindOwned(modsFolder, expectedCurrent.ModId, expectedCurrent.OwnershipToken!)
+                        ?? throw new InvalidOperationException($"Borea cannot find its owned folder for '{expectedCurrent.ModId}'.");
+                    Directory.Move(installedFolder, backupFolder);
+                    backupCreated = true;
+                    Directory.Move(stagingFolder, installedFolder);
+                    replacementMoved = true;
+                    current.ReplaceMod(installed);
+                    return true;
+                },
+                cancellationToken).ConfigureAwait(false);
+
+            await _modState.AddEntryAsync(instanceId, replacement.ModId, wasActive, cancellationToken).ConfigureAwait(false);
+            var active = await _modState.IsActiveAsync(instanceId, replacement.ModId, cancellationToken).ConfigureAwait(false);
+            if (active != wasActive)
+                throw new InvalidOperationException($"The manifest state changed while '{replacement.ModId}' was replaced.");
+
+            var retainedRecoveryDirectory = _deleteRecoveryDirectory(backupFolder) ? null : backupFolder;
+            backupCreated = retainedRecoveryDirectory is not null;
+            return new ModReplacementResult(expectedCurrent, installed, download, retainedRecoveryDirectory);
+        }
+        catch (Exception operationError)
+        {
+            if (backupCreated)
+            {
+                try
+                {
+                    await RestoreAsync(instanceId, expectedCurrent, installed!, installedFolder!, backupFolder, replacementMoved).ConfigureAwait(false);
+                    backupCreated = false;
+                    replacementMoved = false;
+                }
+                catch (Exception recoveryError)
+                {
+                    var recoveryDirectory = Directory.Exists(backupFolder) ? backupFolder : installedFolder!;
+                    throw new ModReplacementRecoveryException(operationError, recoveryError, recoveryDirectory);
+                }
+            }
+
+            throw;
+        }
+        finally
+        {
+            TryDeleteFile(archivePath);
+            TryDeleteDirectory(stagingFolder);
+        }
+    }
+
+    private async Task RestoreAsync(Guid instanceId, InstalledMod previous, InstalledMod replacement, string installedFolder, string backupFolder, bool replacementMoved)
+    {
+        await _instances.UpdateAsync(
+            instanceId,
+            current =>
+            {
+                var currentMod = current.Mods.FirstOrDefault(mod => ModIds.Equals(mod.ModId, previous.ModId))
+                    ?? throw new InvalidOperationException($"The installed record for '{previous.ModId}' is missing.");
+                if (!Matches(currentMod, previous) && !Matches(currentMod, replacement))
+                    throw new InvalidOperationException($"Mod '{previous.ModId}' changed while Borea tried to restore it.");
+
+                if (replacementMoved && Directory.Exists(installedFolder))
+                {
+                    var ownedReplacement = ModFolders.FindOwned(Path.GetDirectoryName(installedFolder)!, replacement.ModId, replacement.OwnershipToken!);
+                    if (!string.Equals(ownedReplacement, installedFolder, StringComparison.Ordinal))
+                        throw new InvalidOperationException($"The installed folder for '{previous.ModId}' changed while Borea tried to restore it.");
+                    Directory.Delete(installedFolder, recursive: true);
+                }
+                if (!Directory.Exists(backupFolder))
+                    throw new InvalidOperationException($"The recovery folder for '{previous.ModId}' is missing.");
+                Directory.Move(backupFolder, installedFolder);
+
+                if (!Matches(currentMod, previous))
+                    current.ReplaceMod(previous);
+                return true;
+            }).ConfigureAwait(false);
+    }
+
+    private static void RequireExpected(Instance instance, InstalledMod expected)
+    {
+        var current = instance.Mods.FirstOrDefault(mod => ModIds.Equals(mod.ModId, expected.ModId))
+            ?? throw new InvalidOperationException($"Mod '{expected.ModId}' is no longer installed.");
+        RequireOwned(current);
+        if (!Matches(current, expected))
+            throw new InvalidOperationException($"Mod '{expected.ModId}' changed after the replacement was requested.");
+    }
+
+    private static bool Matches(InstalledMod current, InstalledMod expected) =>
+        current.Version == expected.Version &&
+        current.Reason == expected.Reason &&
+        current.InstalledAt == expected.InstalledAt &&
+        string.Equals(current.Checksum, expected.Checksum, StringComparison.OrdinalIgnoreCase) &&
+        current.Ownership == expected.Ownership &&
+        string.Equals(current.OwnershipToken, expected.OwnershipToken, StringComparison.Ordinal);
+
+    private static void RequireOwned(InstalledMod installed)
+    {
+        if (!installed.CanDeleteFiles)
+            throw new InvalidOperationException($"Borea cannot replace '{installed.ModId}' because it does not own the installed folder.");
+    }
+
+    private static bool TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+            return true;
+        }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+}

--- a/tests/Borea.Storage.Tests/Mods/FileModReplacerTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/FileModReplacerTests.cs
@@ -1,0 +1,249 @@
+using Borea.Core.Dependencies;
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+using Borea.Storage.Instances;
+using Borea.Storage.Mods;
+using Borea.Storage.State;
+using Borea.Storage.Tests.Paths;
+
+namespace Borea.Storage.Tests.Mods;
+
+public sealed class FileModReplacerTests : IAsyncLifetime
+{
+    private const string ModId = "test-mod";
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "BoreaTest_" + Guid.NewGuid());
+    private readonly FakeModDownloader _downloader = new();
+    private TestGamePathProvider _paths = null!;
+    private FileInstanceRepository _instances = null!;
+    private FileModStateRepository _state = null!;
+    private Guid _instanceId;
+
+    public async Task InitializeAsync()
+    {
+        _paths = new TestGamePathProvider(_root);
+        _instances = new FileInstanceRepository(_paths);
+        _state = new FileModStateRepository(_paths);
+        _instanceId = (await _instances.CreateAsync("Test", InstanceSource.Custom.Value)).InstanceId;
+    }
+
+    public Task DisposeAsync()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+        return Task.CompletedTask;
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ReplaceAsync_ReplacesOwnedFilesAndPreservesState(bool enabled)
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled);
+        _downloader.Bytes = Archive("new");
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state);
+
+        var result = await replacer.ReplaceAsync(_instanceId, current, Release("1.1.0"));
+
+        Assert.Equal(ModVersion.Parse("1.1.0"), result.Replacement.Version);
+        Assert.Equal("new", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+        Assert.Equal(enabled, await _state.IsActiveAsync(_instanceId, ModId));
+        var saved = Assert.Single((await _instances.GetByIdAsync(_instanceId))!.Mods);
+        Assert.Equal(current.Reason, saved.Reason);
+        Assert.Equal(ModVersion.Parse("1.1.0"), saved.Version);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_InvalidArchiveLeavesTheCurrentInstallUntouched()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        _downloader.Bytes = TestArchives.Build((ModId + "/value.txt", "new"));
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => replacer.ReplaceAsync(_instanceId, current, Release("1.1.0")));
+
+        Assert.Equal("old", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+        Assert.Equal(ModVersion.Parse("1.0.0"), Assert.Single((await _instances.GetByIdAsync(_instanceId))!.Mods).Version);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_RejectsAStaleInstalledRecord()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        var stale = new InstalledMod(ModId, current.Version, current.Reason, current.InstalledAt, current.Metadata, current.Checksum, ModInstallOwnership.Borea, "different-token");
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => replacer.ReplaceAsync(_instanceId, stale, Release("1.1.0")));
+        Assert.Equal("old", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_RejectsForeignOwnership()
+    {
+        var metadata = Release("1.0.0");
+        var foreign = new InstalledMod(ModId, metadata.Version, InstallReason.Manual, DateTimeOffset.UtcNow, metadata, ownership: ModInstallOwnership.Foreign);
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => replacer.ReplaceAsync(_instanceId, foreign, Release("1.1.0")));
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_CancellationDuringPreparationLeavesTheCurrentInstallUntouched()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => replacer.ReplaceAsync(_instanceId, current, Release("1.1.0"), cancellationToken: cancellation.Token));
+        Assert.Equal("old", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_MetadataSaveFailureAfterSwapRestoresTheCurrentInstall()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        _downloader.Bytes = Archive("new");
+        var failingInstances = new FailBeforeSaveInstanceRepository(_instances);
+        var replacer = new FileModReplacer(_paths, _downloader, failingInstances, _state);
+
+        await Assert.ThrowsAsync<IOException>(() => replacer.ReplaceAsync(_instanceId, current, Release("1.1.0")));
+
+        Assert.Equal("old", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+        Assert.Equal(ModVersion.Parse("1.0.0"), Assert.Single((await _instances.GetByIdAsync(_instanceId))!.Mods).Version);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_BackupCleanupFailureKeepsTheReplacementAndReportsRecoveryData()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        _downloader.Bytes = Archive("new");
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state, timeProvider: null, deleteRecoveryDirectory: _ => false);
+
+        var result = await replacer.ReplaceAsync(_instanceId, current, Release("1.1.0"));
+
+        Assert.NotNull(result.RetainedRecoveryDirectory);
+        Assert.True(Directory.Exists(result.RetainedRecoveryDirectory));
+        Assert.Equal("new", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+        Assert.Equal(ModVersion.Parse("1.1.0"), Assert.Single((await _instances.GetByIdAsync(_instanceId))!.Mods).Version);
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_CompetingUpdateWaitsForRecoveryFileAndRecordRestore()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        _downloader.Bytes = Archive("new");
+        var coordinatedInstances = new CompetingRecoveryInstanceRepository(_instances);
+        var replacer = new FileModReplacer(_paths, _downloader, coordinatedInstances, _state);
+
+        await Assert.ThrowsAsync<IOException>(() => replacer.ReplaceAsync(_instanceId, current, Release("1.1.0")));
+
+        Assert.Equal("old", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+        var saved = Assert.Single((await _instances.GetByIdAsync(_instanceId))!.Mods);
+        Assert.Equal(ModVersion.Parse("1.0.0"), saved.Version);
+        Assert.Equal(InstallReason.Manual, saved.Reason);
+    }
+
+    private string ModFolder => Path.Combine(_paths.GetInstanceModsFolder(_instanceId), ModId);
+
+    private async Task<InstalledMod> InstallAsync(ModVersionMetadata release, string value, bool enabled)
+    {
+        _downloader.Bytes = Archive(value);
+        var installer = new FileModInstaller(_paths, _downloader, _instances, _state);
+        return (await installer.InstallAsync(_instanceId, release, InstallReason.Dependency, enabled)).Mod;
+    }
+
+    private static byte[] Archive(string value) => TestArchives.Build((ModId + "/mod.toml", "name = \"test\""), (ModId + "/value.txt", value));
+
+    private static ModVersionMetadata Release(string version) => new(
+        1,
+        ModId,
+        ModVersion.Parse(version),
+        ReleaseStatus.Stable,
+        DateTimeOffset.UtcNow,
+        "2026.9.7.5402",
+        5402,
+        new DownloadInfo("https://example.com/mod.zip", null, null, "application/zip"),
+        null,
+        Array.Empty<ModDependency>(),
+        type: ContentType.Mod,
+        install: new InstallInfo(ModId, derived: true));
+
+    private sealed class FailBeforeSaveInstanceRepository(IInstanceRepository inner) : IInstanceRepository
+    {
+        private bool _fail = true;
+
+        public Task<IReadOnlyList<Instance>> GetAllAsync() => inner.GetAllAsync();
+        public Task<Instance?> GetByIdAsync(Guid instanceId) => inner.GetByIdAsync(instanceId);
+        public Task<Guid?> GetActiveInstanceIdAsync() => inner.GetActiveInstanceIdAsync();
+        public Task SetActiveInstanceAsync(Guid instanceId) => inner.SetActiveInstanceAsync(instanceId);
+        public Task<bool> IsNameAvailableAsync(string name, Guid? excludingInstanceId = null) => inner.IsNameAvailableAsync(name, excludingInstanceId);
+        public Task<Instance> CreateAsync(string name, InstanceSource source) => inner.CreateAsync(name, source);
+        public Task RenameAsync(Guid instanceId, string newName) => inner.RenameAsync(instanceId, newName);
+        public Task DeleteAsync(Guid instanceId) => inner.DeleteAsync(instanceId);
+        public Task SaveAsync(Instance instance) => inner.SaveAsync(instance);
+
+        public async Task<TResult> UpdateAsync<TResult>(Guid instanceId, Func<Instance, TResult> update, CancellationToken cancellationToken = default)
+        {
+            if (!_fail)
+                return await inner.UpdateAsync(instanceId, update, cancellationToken);
+
+            _fail = false;
+            var saved = await inner.GetByIdAsync(instanceId) ?? throw new InvalidOperationException();
+            var copy = Instance.FromExisting(saved.InstanceId, saved.Name, saved.Source, saved.CreatedAt, saved.Mods, saved.ForeignMods, saved.IsFavorite);
+            update(copy);
+            throw new IOException("Injected metadata save failure.");
+        }
+    }
+
+    private sealed class CompetingRecoveryInstanceRepository(IInstanceRepository inner) : IInstanceRepository
+    {
+        private bool _fail = true;
+
+        public Task<IReadOnlyList<Instance>> GetAllAsync() => inner.GetAllAsync();
+        public Task<Instance?> GetByIdAsync(Guid instanceId) => inner.GetByIdAsync(instanceId);
+        public Task<Guid?> GetActiveInstanceIdAsync() => inner.GetActiveInstanceIdAsync();
+        public Task SetActiveInstanceAsync(Guid instanceId) => inner.SetActiveInstanceAsync(instanceId);
+        public Task<bool> IsNameAvailableAsync(string name, Guid? excludingInstanceId = null) => inner.IsNameAvailableAsync(name, excludingInstanceId);
+        public Task<Instance> CreateAsync(string name, InstanceSource source) => inner.CreateAsync(name, source);
+        public Task RenameAsync(Guid instanceId, string newName) => inner.RenameAsync(instanceId, newName);
+        public Task DeleteAsync(Guid instanceId) => inner.DeleteAsync(instanceId);
+        public Task SaveAsync(Instance instance) => inner.SaveAsync(instance);
+
+        public async Task<TResult> UpdateAsync<TResult>(Guid instanceId, Func<Instance, TResult> update, CancellationToken cancellationToken = default)
+        {
+            if (_fail)
+            {
+                _fail = false;
+                var saved = await inner.GetByIdAsync(instanceId) ?? throw new InvalidOperationException();
+                var copy = Instance.FromExisting(saved.InstanceId, saved.Name, saved.Source, saved.CreatedAt, saved.Mods, saved.ForeignMods, saved.IsFavorite);
+                update(copy);
+                throw new IOException("Injected metadata save failure.");
+            }
+
+            Task? competitor = null;
+            var result = await inner.UpdateAsync(
+                instanceId,
+                current =>
+                {
+                    var recoveryResult = update(current);
+                    using var started = new ManualResetEventSlim();
+                    competitor = Task.Run(async () =>
+                    {
+                        started.Set();
+                        await inner.UpdateAsync(
+                            instanceId,
+                            competing =>
+                            {
+                                Assert.Single(competing.Mods).MarkAsManuallyInstalled();
+                                return true;
+                            });
+                    });
+                    started.Wait();
+                    return recoveryResult;
+                },
+                cancellationToken);
+            await competitor!;
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Adds one shared replacement service for an explicitly selected mod release.

The service prepares the new archive before it changes the instance, keeps the old owned folder for recovery, preserves the install reason and enable state, and rejects stale or foreign installations.

For example, an invalid 1.1 archive leaves the working 1.0 files and record unchanged.

Closes #121
