### PR TITLE
Add curated tag filtering backend

### DIFF
--- a/src/Borea.Cli/Commands/IndexCommand.cs
+++ b/src/Borea.Cli/Commands/IndexCommand.cs
@@ -146,6 +146,7 @@ internal static class IndexCommand
         ContentIndexDiagnosticScope.PackVersion => "pack-version",
         ContentIndexDiagnosticScope.IndexStatus => "index-status",
         ContentIndexDiagnosticScope.GameVersions => "game-versions",
+        ContentIndexDiagnosticScope.Tags => "tags",
         _ => throw new ArgumentOutOfRangeException(nameof(scope), scope, null),
     };
 }

--- a/src/Borea.Core/Index/ContentIndexDiagnostic.cs
+++ b/src/Borea.Core/Index/ContentIndexDiagnostic.cs
@@ -15,6 +15,7 @@ public enum ContentIndexDiagnosticScope
     PackVersion = 3,
     IndexStatus = 4,
     GameVersions = 5,
+    Tags = 6,
 }
 
 /// <summary>One part of the snapshot that Borea could not read safely.</summary>

--- a/src/Borea.Core/Index/ContentIndexSnapshot.cs
+++ b/src/Borea.Core/Index/ContentIndexSnapshot.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using Borea.Core.ModPacks;
 using Borea.Core.Mods;
+using Borea.Core.Tags;
 
 namespace Borea.Core.Index;
 
@@ -17,12 +18,15 @@ public sealed class ContentIndexSnapshot
 
     public IReadOnlyList<ContentIndexDiagnostic> Diagnostics { get; }
 
+    public CuratedTagVocabulary Tags { get; }
+
     public ContentIndexSnapshot(
         int snapshotVersion,
         IReadOnlyList<ContentIndexListing> listings,
         IReadOnlyList<ContentIndexPack> packs,
         ContentIndexGameVersions? gameVersions,
-        IReadOnlyList<ContentIndexDiagnostic> diagnostics)
+        IReadOnlyList<ContentIndexDiagnostic> diagnostics,
+        CuratedTagVocabulary? tags = null)
     {
         if (snapshotVersion < 1)
             throw new ArgumentOutOfRangeException(nameof(snapshotVersion), "Snapshot version must be a positive integer.");
@@ -32,6 +36,7 @@ public sealed class ContentIndexSnapshot
         Packs = Copy(packs, nameof(packs));
         GameVersions = gameVersions;
         Diagnostics = Copy(diagnostics, nameof(diagnostics));
+        Tags = tags ?? CuratedTagVocabulary.Empty;
     }
 
     private static IReadOnlyList<T> Copy<T>(IReadOnlyList<T> values, string parameterName)

--- a/src/Borea.Core/Tags/ContentTagFilter.cs
+++ b/src/Borea.Core/Tags/ContentTagFilter.cs
@@ -1,0 +1,56 @@
+using Borea.Core.Mods;
+using Borea.Core.ModPacks;
+
+namespace Borea.Core.Tags;
+
+public static class ContentTagFilter
+{
+    public static IReadOnlyList<ModMetadata> Filter(IEnumerable<ModMetadata> listings, CuratedTagVocabulary vocabulary, ContentType contentType, IEnumerable<string>? selectedTags = null, bool includeOther = false)
+    {
+        ArgumentNullException.ThrowIfNull(listings);
+        ArgumentNullException.ThrowIfNull(vocabulary);
+        var selected = selectedTags?.ToHashSet(StringComparer.OrdinalIgnoreCase) ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var curated = vocabulary.GetTags(contentType).Select(item => item.Tag).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return listings.Where(listing => listing.Type == contentType).Where(listing => Matches(listing, selected, curated, includeOther)).ToArray();
+    }
+
+    public static IReadOnlyList<ModPackMetadata> Filter(IEnumerable<ModPackMetadata> packs, CuratedTagVocabulary vocabulary, IEnumerable<string>? selectedTags = null, bool includeOther = false)
+    {
+        ArgumentNullException.ThrowIfNull(packs);
+        ArgumentNullException.ThrowIfNull(vocabulary);
+        var selected = selectedTags?.ToHashSet(StringComparer.OrdinalIgnoreCase) ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var curated = vocabulary.GetTags(ContentType.ModPack).Select(item => item.Tag).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return packs.Where(pack => Matches(pack.Tags, selected, curated, includeOther)).ToArray();
+    }
+
+    public static bool MatchesSearch(ModMetadata listing, string query)
+    {
+        ArgumentNullException.ThrowIfNull(listing);
+        ArgumentNullException.ThrowIfNull(query);
+        return Contains(listing.ModId, query) || Contains(listing.Name, query) || Contains(listing.Abstract, query) || Contains(listing.Description, query) || listing.Tags.Any(tag => Contains(tag, query));
+    }
+
+    public static bool MatchesSearch(ModPackMetadata pack, string query)
+    {
+        ArgumentNullException.ThrowIfNull(pack);
+        ArgumentNullException.ThrowIfNull(query);
+        return Contains(pack.ModPackId, query)
+            || Contains(pack.Name, query)
+            || Contains(pack.Abstract, query)
+            || Contains(pack.Description, query)
+            || pack.Authors.Any(author => Contains(author, query))
+            || pack.Tags.Any(tag => Contains(tag, query));
+    }
+
+    private static bool Matches(ModMetadata listing, IReadOnlySet<string> selected, IReadOnlySet<string> curated, bool includeOther)
+    {
+        if (selected.Count == 0 && !includeOther)
+            return true;
+        return Matches(listing.Tags, selected, curated, includeOther);
+    }
+
+    private static bool Matches(IReadOnlyList<string> tags, IReadOnlySet<string> selected, IReadOnlySet<string> curated, bool includeOther) =>
+        tags.Any(selected.Contains) || (includeOther && !tags.Any(curated.Contains));
+
+    private static bool Contains(string? value, string query) => value?.Contains(query, StringComparison.OrdinalIgnoreCase) == true;
+}

--- a/src/Borea.Core/Tags/CuratedTag.cs
+++ b/src/Borea.Core/Tags/CuratedTag.cs
@@ -1,0 +1,20 @@
+namespace Borea.Core.Tags;
+
+public sealed record CuratedTag
+{
+    public string Tag { get; }
+    public string Name { get; }
+    public string Meaning { get; }
+    public string? ForumPrefix { get; }
+
+    public CuratedTag(string tag, string name, string meaning, string? forumPrefix = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tag);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(meaning);
+        Tag = tag;
+        Name = name;
+        Meaning = meaning;
+        ForumPrefix = forumPrefix;
+    }
+}

--- a/src/Borea.Core/Tags/CuratedTagVocabulary.cs
+++ b/src/Borea.Core/Tags/CuratedTagVocabulary.cs
@@ -1,0 +1,28 @@
+using System.Collections.ObjectModel;
+using Borea.Core.Mods;
+
+namespace Borea.Core.Tags;
+
+public sealed class CuratedTagVocabulary
+{
+    public static CuratedTagVocabulary Empty { get; } = new(1, Array.Empty<CuratedTag>());
+    public int SpecVersion { get; }
+    public IReadOnlyList<CuratedTag> ModTags { get; }
+
+    public CuratedTagVocabulary(int specVersion, IReadOnlyList<CuratedTag> modTags)
+    {
+        if (specVersion != 1)
+            throw new ArgumentOutOfRangeException(nameof(specVersion), "Only curated tag vocabulary version 1 is supported.");
+        ArgumentNullException.ThrowIfNull(modTags);
+        if (modTags.Select(item => item.Tag).Distinct(StringComparer.OrdinalIgnoreCase).Count() != modTags.Count)
+            throw new ArgumentException("Each curated tag must be unique.", nameof(modTags));
+        SpecVersion = specVersion;
+        ModTags = new ReadOnlyCollection<CuratedTag>(modTags.ToArray());
+    }
+
+    public IReadOnlyList<CuratedTag> GetTags(ContentType contentType) => contentType switch
+    {
+        ContentType.Mod or ContentType.ModLoader or ContentType.ModPack => ModTags,
+        _ => Array.Empty<CuratedTag>(),
+    };
+}

--- a/src/Borea.Network/Index/ContentIndexModPackRepository.cs
+++ b/src/Borea.Network/Index/ContentIndexModPackRepository.cs
@@ -1,6 +1,7 @@
 using Borea.Core.Index;
 using Borea.Core.ModPacks;
 using Borea.Core.Mods;
+using Borea.Core.Tags;
 
 namespace Borea.Network.Index;
 
@@ -85,7 +86,7 @@ public sealed class ContentIndexModPackRepository : IModPackRepository
     public async Task<IReadOnlyList<ModPackResult>> SearchAsync(string query, CancellationToken cancellationToken = default)
     {
         var packs = await GetAvailableModPacksAsync(cancellationToken).ConfigureAwait(false);
-        return packs.Where(result => Matches(result.Metadata!, query)).ToArray();
+        return packs.Where(result => ContentTagFilter.MatchesSearch(result.Metadata!, query)).ToArray();
     }
 
     private static ContentIndexPack? AvailablePack(ContentIndexSnapshot snapshot, string id) =>
@@ -157,15 +158,4 @@ public sealed class ContentIndexModPackRepository : IModPackRepository
         ModVersion.TryParse(left, out var leftVersion)
         && ModVersion.TryParse(right, out var rightVersion)
         && leftVersion.Equals(rightVersion);
-
-    private static bool Matches(ModPackMetadata pack, string query) =>
-        Contains(pack.ModPackId, query)
-        || Contains(pack.Name, query)
-        || Contains(pack.Abstract, query)
-        || Contains(pack.Description, query)
-        || pack.Authors.Any(author => Contains(author, query))
-        || pack.Tags.Any(tag => Contains(tag, query));
-
-    private static bool Contains(string? value, string query) =>
-        value?.Contains(query, StringComparison.OrdinalIgnoreCase) == true;
 }

--- a/src/Borea.Network/Index/ContentIndexModRepository.cs
+++ b/src/Borea.Network/Index/ContentIndexModRepository.cs
@@ -1,6 +1,7 @@
 using Borea.Core.Index;
 using Borea.Core.Mods;
 using Borea.Core.Paths;
+using Borea.Core.Tags;
 
 namespace Borea.Network.Index;
 
@@ -75,7 +76,7 @@ public sealed class ContentIndexModRepository : IContentIndexRepository, IModIdC
         var snapshot = await GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
         return AvailableListings(snapshot)
             .Select(listing => listing.Authored!)
-            .Where(mod => Matches(mod, query))
+            .Where(mod => ContentTagFilter.MatchesSearch(mod, query))
             .ToArray();
     }
 
@@ -135,13 +136,4 @@ public sealed class ContentIndexModRepository : IContentIndexRepository, IModIdC
             listing.Authored is { Type: ContentType.Mod or ContentType.ModLoader }
             && listing.IndexStatus?.State != IndexStatusState.Delisted);
 
-    private static bool Matches(ModMetadata mod, string query) =>
-        Contains(mod.ModId, query)
-        || Contains(mod.Name, query)
-        || Contains(mod.Abstract, query)
-        || Contains(mod.Description, query)
-        || mod.Tags.Any(tag => Contains(tag, query));
-
-    private static bool Contains(string? value, string query) =>
-        value?.Contains(query, StringComparison.OrdinalIgnoreCase) == true;
 }

--- a/src/Borea.Storage/Index/ContentIndexReader.cs
+++ b/src/Borea.Storage/Index/ContentIndexReader.cs
@@ -1,5 +1,6 @@
 using Borea.Core.Index;
 using Borea.Core.Paths;
+using Borea.Core.Tags;
 
 namespace Borea.Storage.Index;
 
@@ -95,7 +96,17 @@ public sealed class ContentIndexReader : IContentIndexReader, IContentIndexCandi
                 result.GameVersions.Source,
                 result.GameVersions.Versions.ToArray());
 
-        return new ContentIndexSnapshot(result.SnapshotVersion, listings, packs, gameVersions, diagnostics);
+        AddMalformed(diagnostics, result.TagsError, ContentIndexDiagnosticScope.Tags);
+        if (result.UnknownTags is not null)
+        {
+            diagnostics.Add(new ContentIndexDiagnostic(
+                ContentIndexDiagnosticKind.UnsupportedVersion,
+                ContentIndexDiagnosticScope.Tags,
+                result.UnknownTags.Reason,
+                SpecVersion: result.UnknownTags.SpecVersion));
+        }
+
+        return new ContentIndexSnapshot(result.SnapshotVersion, listings, packs, gameVersions, diagnostics, result.Tags);
     }
 
     private static void AddUnsupportedStatus(

--- a/src/Borea.Storage/Index/Dtos/CuratedTagsDto.cs
+++ b/src/Borea.Storage/Index/Dtos/CuratedTagsDto.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Borea.Storage.Index.Dtos;
+
+public sealed class CuratedTagsDto
+{
+    [JsonPropertyName("spec_version")]
+    public required int SpecVersion { get; set; }
+
+    [JsonPropertyName("mod")]
+    public List<CuratedTagDto> Mod { get; set; } = new();
+}
+
+public sealed class CuratedTagDto
+{
+    [JsonPropertyName("tag")]
+    public required string Tag { get; set; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    [JsonPropertyName("meaning")]
+    public required string Meaning { get; set; }
+
+    [JsonPropertyName("forum_prefix")]
+    public string? ForumPrefix { get; set; }
+}

--- a/src/Borea.Storage/Index/Dtos/SnapshotDto.cs
+++ b/src/Borea.Storage/Index/Dtos/SnapshotDto.cs
@@ -11,6 +11,9 @@ public sealed class SnapshotDto
     [JsonPropertyName("sources")]
     public SourcesDto? Sources { get; set; }
 
+    [JsonPropertyName("tags")]
+    public JsonElement? Tags { get; set; }
+
     /// <summary>
     /// Stores <see cref="JsonElement"/> instead of <see cref="ListingEntryDto"/>
     /// because storing <see cref="ListingEntryDto"/> here would cause any unparseable

--- a/src/Borea.Storage/Index/IndexValidationResult.cs
+++ b/src/Borea.Storage/Index/IndexValidationResult.cs
@@ -1,4 +1,5 @@
 using Borea.Storage.Index.Dtos;
+using Borea.Core.Tags;
 
 namespace Borea.Storage.Index;
 
@@ -24,6 +25,12 @@ public sealed class IndexValidationResult
     /// <summary>Null when the index does not carry a sources table.</summary>
     public SourcesDto? Sources { get; }
 
+    public CuratedTagVocabulary Tags { get; }
+
+    public RejectedIndexEntry? TagsError { get; }
+
+    public UnknownIndexVersionEntry? UnknownTags { get; }
+
     public IndexValidationResult(
         int snapshotVersion,
         IReadOnlyList<ParsedListing> validListings,
@@ -34,7 +41,10 @@ public sealed class IndexValidationResult
         IReadOnlyList<RejectedIndexEntry> malformedPacks,
         GameVersionsDto? gameVersions,
         SourcesDto? sources,
-        RejectedIndexEntry? gameVersionsError = null)
+        RejectedIndexEntry? gameVersionsError = null,
+        CuratedTagVocabulary? tags = null,
+        RejectedIndexEntry? tagsError = null,
+        UnknownIndexVersionEntry? unknownTags = null)
     {
         SnapshotVersion = snapshotVersion;
         ValidListings = validListings ?? throw new ArgumentNullException(nameof(validListings));
@@ -46,5 +56,8 @@ public sealed class IndexValidationResult
         GameVersions = gameVersions;
         Sources = sources;
         GameVersionsError = gameVersionsError;
+        Tags = tags ?? CuratedTagVocabulary.Empty;
+        TagsError = tagsError;
+        UnknownTags = unknownTags;
     }
 }

--- a/src/Borea.Storage/Index/SnapshotParser.cs
+++ b/src/Borea.Storage/Index/SnapshotParser.cs
@@ -1,6 +1,7 @@
 using Borea.Core.Index;
 using Borea.Core.Game;
 using Borea.Core.Mods;
+using Borea.Core.Tags;
 using Borea.Storage.Index.Dtos;
 using System.Text.Json;
 
@@ -95,11 +96,42 @@ public static class SnapshotParser
 
         cancellationToken.ThrowIfCancellationRequested();
         var (gameVersions, gameVersionsError) = ParseGameVersions(snapshot.GameVersions, cancellationToken);
+        var (tags, tagsError, unknownTags) = ParseTags(snapshot.Tags, cancellationToken);
 
         return new IndexValidationResult(
             snapshot.SnapshotVersion, validListings, unknownListings,
             malformedListings, validPacks, unknownPacks, malformedPacks,
-            gameVersions, snapshot.Sources, gameVersionsError);
+            gameVersions, snapshot.Sources, gameVersionsError, tags, tagsError, unknownTags);
+    }
+
+    private static (CuratedTagVocabulary Value, RejectedIndexEntry? Error, UnknownIndexVersionEntry? Unknown) ParseTags(
+        JsonElement? element,
+        CancellationToken cancellationToken)
+    {
+        if (element is null || element.Value.ValueKind == JsonValueKind.Null)
+            return (CuratedTagVocabulary.Empty, null, null);
+
+        var specVersion = IndexJsonHelpers.TryExtractInt(element.Value, "spec_version");
+        if (specVersion is not null && specVersion != 1)
+        {
+            return (
+                CuratedTagVocabulary.Empty,
+                null,
+                new UnknownIndexVersionEntry(null, null, specVersion.Value, $"The curated tag vocabulary uses unsupported spec_version {specVersion}."));
+        }
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var dto = element.Value.Deserialize<CuratedTagsDto>(IndexJsonOptions.Value)
+                ?? throw new JsonException("The tags value deserialized to null.");
+            var tags = dto.Mod.Select(item => new CuratedTag(item.Tag, item.Name, item.Meaning, item.ForumPrefix)).ToArray();
+            return (new CuratedTagVocabulary(dto.SpecVersion, tags), null, null);
+        }
+        catch (Exception ex) when (ex is JsonException or ArgumentException or NullReferenceException)
+        {
+            return (CuratedTagVocabulary.Empty, new RejectedIndexEntry(null, $"The curated tag vocabulary is unreadable. {ex.Message}"), null);
+        }
     }
 
     private static (GameVersionsDto? Value, RejectedIndexEntry? Error) ParseGameVersions(

--- a/tests/Borea.Cli.Tests/IndexCommandTests.cs
+++ b/tests/Borea.Cli.Tests/IndexCommandTests.cs
@@ -112,6 +112,21 @@ public sealed class IndexCommandTests : IDisposable
     }
 
     [Fact]
+    public async Task Validate_TagDiagnostic_ReportsScopeWithoutCrashing()
+    {
+        _host.IndexReader.Snapshot = Snapshot(new ContentIndexDiagnostic(
+            ContentIndexDiagnosticKind.UnsupportedVersion,
+            ContentIndexDiagnosticScope.Tags,
+            "The curated tag vocabulary uses an unsupported version.",
+            SpecVersion: 2));
+
+        var run = await _host.RunAsync("index", "validate");
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("unsupported-version tags (spec version 2)", run.Output);
+    }
+
+    [Fact]
     public async Task Validate_Cancellation_ReachesReaderAndReportsFailure()
     {
         _host.IndexReader.Read = async cancellationToken =>

--- a/tests/Borea.Core.Tests/Tags/ContentTagFilterTests.cs
+++ b/tests/Borea.Core.Tests/Tags/ContentTagFilterTests.cs
@@ -1,0 +1,74 @@
+using Borea.Core.Mods;
+using Borea.Core.ModPacks;
+using Borea.Core.Tags;
+
+namespace Borea.Core.Tests.Tags;
+
+public sealed class ContentTagFilterTests
+{
+    private static readonly CuratedTagVocabulary Vocabulary = new(1,
+    [
+        new CuratedTag("parts", "Parts", "New parts."),
+        new CuratedTag("tools", "Tools", "Tools for players and modders."),
+    ]);
+
+    [Fact]
+    public void Filter_OneSelectedTag_ReturnsMatchingListings()
+    {
+        var result = ContentTagFilter.Filter(Listings(), Vocabulary, ContentType.Mod, ["parts"]);
+        Assert.Equal("parts-mod", Assert.Single(result).ModId);
+    }
+
+    [Fact]
+    public void Filter_TwoSelectedTags_ReturnsListingsThatMatchEitherTag()
+    {
+        var result = ContentTagFilter.Filter(Listings(), Vocabulary, ContentType.Mod, ["parts", "tools"]);
+        Assert.Equal(["parts-mod", "tools-mod"], result.Select(item => item.ModId));
+    }
+
+    [Fact]
+    public void Filter_Other_ReturnsListingsWithoutACuratedTag()
+    {
+        var result = ContentTagFilter.Filter(Listings(), Vocabulary, ContentType.Mod, includeOther: true);
+        Assert.Equal(["free-form-mod", "untagged-mod"], result.Select(item => item.ModId));
+    }
+
+    [Fact]
+    public void MatchesSearch_MatchesCuratedAndFreeFormTags()
+    {
+        Assert.True(ContentTagFilter.MatchesSearch(Create("test", "parts", "custom-tag"), "parts"));
+        Assert.True(ContentTagFilter.MatchesSearch(Create("test", "parts", "custom-tag"), "custom"));
+    }
+
+    [Fact]
+    public void Filter_ModPacksSupportsCuratedTagsAndOther()
+    {
+        var curated = CreatePack("curated", "parts");
+        var other = CreatePack("other", "custom-tag");
+
+        Assert.Equal("curated", Assert.Single(ContentTagFilter.Filter([curated, other], Vocabulary, ["parts"])).ModPackId);
+        Assert.Equal("other", Assert.Single(ContentTagFilter.Filter([curated, other], Vocabulary, includeOther: true)).ModPackId);
+        Assert.True(ContentTagFilter.MatchesSearch(other, "custom"));
+    }
+
+    private static ModMetadata[] Listings() =>
+    [
+        Create("parts-mod", "parts"),
+        Create("tools-mod", "tools"),
+        Create("free-form-mod", "automation"),
+        Create("untagged-mod"),
+        Create("loader", "tools", type: ContentType.ModLoader),
+    ];
+
+    private static ModMetadata Create(string id, string? firstTag = null, string? secondTag = null, ContentType type = ContentType.Mod) => new(
+        1, id, "test", id, ["Author"], "Test content.", "MIT",
+        new Dictionary<string, string> { ["forums"] = "https://forums.example/thread/1" },
+        "2026.9", type,
+        new[] { firstTag, secondTag }.Where(tag => tag is not null).Select(tag => tag!).ToArray());
+
+    private static ModPackMetadata CreatePack(string id, string tag) => new(
+        1, id, "test", id, ["Author"], "Test pack.", "CC0-1.0",
+        new Dictionary<string, string> { ["forums"] = "https://forums.example/thread/1" },
+        "2026.9", ModVersion.Parse("1.0.0"), DateTimeOffset.UnixEpoch,
+        [new ModPackEntry("test-mod", ModVersion.Parse("1.0.0"))], [tag]);
+}

--- a/tests/Borea.Storage.Tests/Index/ContentIndexReaderTests.cs
+++ b/tests/Borea.Storage.Tests/Index/ContentIndexReaderTests.cs
@@ -115,6 +115,64 @@ public sealed class ContentIndexReaderTests : IDisposable
         Assert.Empty(result.Packs);
         Assert.Equal("master-server", result.GameVersions!.Source);
         Assert.Empty(result.Diagnostics);
+        Assert.Empty(result.Tags.ModTags);
+    }
+
+    [Fact]
+    public async Task ReadAsync_CuratedTags_ReturnsMappedVocabulary()
+    {
+        var tags = """
+            "tags": {
+                "spec_version": 1,
+                "mod": [
+                    { "tag": "parts", "name": "Parts", "meaning": "New parts.", "forum_prefix": "Parts" },
+                    { "tag": "library", "name": "Library", "meaning": "Shared code." }
+                ]
+            },
+            """;
+        await WriteIndexAsync(Snapshot(Listing("test-mod", ValidAuthoredJson), prefix: tags));
+
+        var result = await _reader.ReadAsync();
+
+        Assert.Equal(1, result.Tags.SpecVersion);
+        Assert.Equal(["parts", "library"], result.Tags.ModTags.Select(item => item.Tag));
+        Assert.Equal("Parts", result.Tags.ModTags[0].ForumPrefix);
+        Assert.Null(result.Tags.ModTags[1].ForumPrefix);
+    }
+
+    [Fact]
+    public async Task ReadAsync_UnsupportedCuratedTagsVersion_KeepsListingAndAddsDiagnostic()
+    {
+        var tags = """
+            "tags": { "spec_version": 2, "mod": [] },
+            """;
+        await WriteIndexAsync(Snapshot(Listing("test-mod", ValidAuthoredJson), prefix: tags));
+
+        var result = await _reader.ReadAsync();
+
+        Assert.Single(result.Listings);
+        Assert.Empty(result.Tags.ModTags);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(ContentIndexDiagnosticKind.UnsupportedVersion, diagnostic.Kind);
+        Assert.Equal(ContentIndexDiagnosticScope.Tags, diagnostic.Scope);
+        Assert.Equal(2, diagnostic.SpecVersion);
+    }
+
+    [Fact]
+    public async Task ReadAsync_MalformedCuratedTags_KeepsListingAndAddsDiagnostic()
+    {
+        var tags = """
+            "tags": [],
+            """;
+        await WriteIndexAsync(Snapshot(Listing("test-mod", ValidAuthoredJson), prefix: tags));
+
+        var result = await _reader.ReadAsync();
+
+        Assert.Single(result.Listings);
+        Assert.Empty(result.Tags.ModTags);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal(ContentIndexDiagnosticKind.Malformed, diagnostic.Kind);
+        Assert.Equal(ContentIndexDiagnosticScope.Tags, diagnostic.Scope);
     }
 
     [Fact]
@@ -309,10 +367,12 @@ public sealed class ContentIndexReaderTests : IDisposable
 
     private static string Snapshot(
         string listings,
-        string gameVersions = """{ "spec_version": 1, "source": "master-server", "versions": ["2026.9.7.5402"] }""") =>
+        string gameVersions = """{ "spec_version": 1, "source": "master-server", "versions": ["2026.9.7.5402"] }""",
+        string prefix = "") =>
         $$"""
         {
             "snapshot_version": 1,
+            {{prefix}}
             "listings": [{{listings}}],
             "packs": [],
             "game_versions": {{gameVersions}}


### PR DESCRIPTION
Implements the backend part of #88 against the curated tag contract.

Snapshots can now expose the optional curated vocabulary to Core, while snapshots without it keep an empty vocabulary.

Shared helpers filter mods, mod loaders and mod packs by one or several curated tags, include content without a curated tag under Other, and keep free-form tags searchable.

The Borea.App filter chips and detail-page presentation remain separate UI work, so this pull request does not close #88.

Part of #88.
Depends on KSAModding/content-index-releases#40.

Based on #116; review and merge #116 first.
