### PR TITLE
Plan complete mod installations

### DIFF
--- a/src/Borea.Composition/BoreaServices.cs
+++ b/src/Borea.Composition/BoreaServices.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Headers;
+using Borea.Core.Dependencies;
 using Borea.Core.Game;
 using Borea.Core.Index;
 using Borea.Core.Instances;
@@ -7,11 +8,13 @@ using Borea.Core.ModLoaders;
 using Borea.Core.ModPacks;
 using Borea.Core.Mods;
 using Borea.Core.Paths;
+using Borea.Core.Planning;
 using Borea.Core.Settings;
 using Borea.Core.State;
 using Borea.Network.Downloads;
 using Borea.Network.Index;
 using Borea.Network.MasterServer;
+using Borea.Network.Planning;
 using Borea.Network.Sources;
 using Borea.Network.SpaceDock;
 using Borea.Storage.Game;
@@ -88,6 +91,8 @@ public sealed class BoreaServices : IDisposable
     public required IModPackRepository ModPacks { get; init; }
 
     public required IModDownloader Downloader { get; init; }
+
+    public required IInstallPlanner InstallPlanner { get; init; }
 
     public required ILoaderInstaller LoaderInstaller { get; init; }
 
@@ -200,6 +205,7 @@ public sealed class BoreaServices : IDisposable
             Mods = mods,
             ModPacks = modPacks,
             Downloader = downloader,
+            InstallPlanner = new RepositoryInstallPlanner(new ModDependencyResolver()),
             LoaderInstaller = new FileLoaderInstaller(paths, downloader, settingsRepository, loaderConfiguration),
             LoaderAdopter = new FileLoaderAdopter(settingsRepository, loaderConfiguration),
             LoaderUninstaller = new FileLoaderUninstaller(settingsRepository),

--- a/src/Borea.Core/Planning/IInstallPlanner.cs
+++ b/src/Borea.Core/Planning/IInstallPlanner.cs
@@ -1,0 +1,10 @@
+using Borea.Core.Mods;
+
+namespace Borea.Core.Planning;
+
+public interface IInstallPlanner
+{
+    Task<InstallPlan> PlanAsync(InstallPlanningRequest request, CancellationToken cancellationToken = default);
+}
+
+public sealed record RequestedMod(ModVersionMetadata Release, InstallReason Reason, bool Exact = true);

--- a/src/Borea.Core/Planning/InstallPlan.cs
+++ b/src/Borea.Core/Planning/InstallPlan.cs
@@ -1,0 +1,34 @@
+using Borea.Core.Game;
+using Borea.Core.Mods;
+
+namespace Borea.Core.Planning;
+
+public sealed record PlannedInstall(ModVersionMetadata Release, InstallReason Reason, GameCompatibility Compatibility, OsSupport? PlatformSupport);
+public sealed record PlannedSelection(ModVersionMetadata Release, InstallReason Reason, bool IsAlreadyInstalled);
+public sealed record PlanningMessage(string ModId, string Code, string Message);
+public sealed record PlanningChoice(string Key, string OwnerModId, string Kind, IReadOnlyList<string> Options, string? Selected);
+
+public sealed class InstallPlan
+{
+    public Guid InstanceId { get; }
+    public InstallPlanningState InstanceState { get; }
+    public IReadOnlyList<PlannedSelection> Selections { get; }
+    public IReadOnlyList<PlannedInstall> Operations { get; }
+    public IReadOnlyList<PlanningMessage> Warnings { get; }
+    public IReadOnlyList<PlanningMessage> UnresolvedChoices { get; }
+    public IReadOnlyList<PlanningMessage> Conflicts { get; }
+    public IReadOnlyList<PlanningChoice> Choices { get; }
+    public bool IsReady => UnresolvedChoices.Count == 0 && Conflicts.Count == 0;
+
+    public InstallPlan(Guid instanceId, InstallPlanningState instanceState, IReadOnlyList<PlannedSelection> selections, IReadOnlyList<PlannedInstall> operations, IReadOnlyList<PlanningMessage> warnings, IReadOnlyList<PlanningMessage> unresolvedChoices, IReadOnlyList<PlanningMessage> conflicts, IReadOnlyList<PlanningChoice> choices)
+    {
+        InstanceId = instanceId;
+        InstanceState = instanceState;
+        Selections = selections;
+        Operations = operations;
+        Warnings = warnings;
+        UnresolvedChoices = unresolvedChoices;
+        Conflicts = conflicts;
+        Choices = choices;
+    }
+}

--- a/src/Borea.Core/Planning/InstallPlanningRequest.cs
+++ b/src/Borea.Core/Planning/InstallPlanningRequest.cs
@@ -1,0 +1,14 @@
+using Borea.Core.Game;
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+
+namespace Borea.Core.Planning;
+
+public sealed record InstallPlanningRequest(
+    Instance Instance,
+    IReadOnlyList<RequestedMod> Requested,
+    IModRepository Repository,
+    GameVersion? GameVersion = null,
+    OsPlatform? TargetPlatform = null,
+    IReadOnlySet<string>? Recommended = null,
+    IReadOnlyDictionary<string, string>? Alternatives = null);

--- a/src/Borea.Core/Planning/InstallPlanningState.cs
+++ b/src/Borea.Core/Planning/InstallPlanningState.cs
@@ -1,0 +1,98 @@
+using System.Security.Cryptography;
+using System.Text;
+using Borea.Core.Dependencies;
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+
+namespace Borea.Core.Planning;
+
+public sealed record InstallPlanningState(string Value)
+{
+    public static InstallPlanningState Capture(Instance instance)
+    {
+        ArgumentNullException.ThrowIfNull(instance);
+        var value = new StringBuilder();
+        Add(value, instance.InstanceId.ToString("D"));
+        Add(value, Source(instance.Source));
+        Add(value, instance.Mods.Count.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        foreach (var mod in instance.Mods.OrderBy(item => item.ModId, ModIds.Comparer))
+        {
+            Add(value, "managed");
+            Add(value, mod.ModId);
+            Add(value, mod.Version.ToString());
+            Add(value, mod.Reason.ToString());
+            Add(value, mod.Ownership.ToString());
+            Add(value, mod.OwnershipToken);
+            Add(value, mod.Checksum);
+            Add(value, mod.Metadata.ModId);
+            Add(value, mod.Metadata.Version.ToString());
+            Add(value, mod.Metadata.GameMinRevision.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            Add(value, mod.Metadata.GameMaxRevision?.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            Add(value, mod.Metadata.Os?.Count.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            foreach (var platform in mod.Metadata.Os ?? []) Add(value, platform);
+            Add(value, mod.Metadata.Yanked ? "yanked" : "available");
+            Add(value, mod.Metadata.YankedReason);
+            AddDependencies(value, mod.Metadata.Dependencies);
+        }
+        Add(value, instance.ForeignMods.Count.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        foreach (var mod in instance.ForeignMods.OrderBy(item => item.ModId, ModIds.Comparer))
+        {
+            Add(value, "foreign");
+            Add(value, mod.ModId);
+            Add(value, mod.DependencyReadError);
+            Add(value, mod.Dependencies.Count.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            foreach (var dependency in mod.Dependencies.OrderBy(item => item.ModId, StringComparer.Ordinal).ThenBy(item => item.Optional))
+            {
+                Add(value, dependency.ModId);
+                Add(value, dependency.Optional ? "optional" : "required");
+            }
+        }
+        return new InstallPlanningState(Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value.ToString()))));
+    }
+
+    public bool Matches(Instance instance) => this == Capture(instance);
+
+    private static void AddDependencies(StringBuilder value, IReadOnlyList<ModDependency> dependencies)
+    {
+        Add(value, dependencies.Count.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        foreach (var dependency in dependencies)
+        {
+            Add(value, dependency.Kind.ToString());
+            Add(value, dependency.Source?.ToString());
+            if (dependency.IsAnyOf)
+            {
+                Add(value, "any-of");
+                Add(value, dependency.AnyOf.Count.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                foreach (var alternative in dependency.AnyOf)
+                {
+                    Add(value, alternative.ModId);
+                    Add(value, alternative.MinVersion?.ToString());
+                    Add(value, alternative.MaxVersion?.ToString());
+                }
+            }
+            else
+            {
+                Add(value, dependency.ModId);
+                Add(value, dependency.MinVersion?.ToString());
+                Add(value, dependency.MaxVersion?.ToString());
+            }
+        }
+    }
+
+    private static string Source(InstanceSource source) => source switch
+    {
+        InstanceSource.Custom => "custom",
+        InstanceSource.FromModPack pack => $"pack:{pack.ModPackId}:{pack.Version}",
+        _ => throw new ArgumentOutOfRangeException(nameof(source)),
+    };
+
+    private static void Add(StringBuilder value, string? field)
+    {
+        if (field is null)
+        {
+            value.Append("-1:");
+            return;
+        }
+        value.Append(field.Length).Append(':').Append(field);
+    }
+}

--- a/src/Borea.Network/Planning/RepositoryInstallPlanner.cs
+++ b/src/Borea.Network/Planning/RepositoryInstallPlanner.cs
@@ -1,0 +1,307 @@
+using Borea.Core.Dependencies;
+using Borea.Core.Game;
+using Borea.Core.Mods;
+using Borea.Core.Planning;
+
+namespace Borea.Network.Planning;
+
+public sealed class RepositoryInstallPlanner : IInstallPlanner
+{
+    private const int SearchLimit = 100_000;
+    private readonly ModDependencyResolver _resolver;
+
+    public RepositoryInstallPlanner(ModDependencyResolver resolver) => _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+
+    public async Task<InstallPlan> PlanAsync(InstallPlanningRequest request, CancellationToken cancellationToken = default)
+    {
+        Validate(request);
+        var roots = BuildRoots(request, out var initialConflicts);
+        var domains = await BuildDomainsAsync(request, roots, cancellationToken).ConfigureAwait(false);
+        var ids = domains.Keys.OrderBy(value => value, ModIds.Comparer).ToList();
+        SearchResult? best = null;
+        var states = 0;
+        var truncated = false;
+        var assigned = new Dictionary<string, RequestedMod?>(ModIds.Comparer);
+
+        void Search(int index)
+        {
+            if (++states > SearchLimit) { truncated = true; return; }
+            if (index == ids.Count)
+            {
+                var result = Evaluate(request, roots, assigned, initialConflicts);
+                if (best is null || result.Score.CompareTo(best.Score) < 0) best = result;
+                return;
+            }
+            var id = ids[index];
+            foreach (var candidate in domains[id])
+            {
+                assigned[id] = candidate;
+                Search(index + 1);
+            }
+            assigned.Remove(id);
+        }
+
+        Search(0);
+        if (truncated)
+        {
+            var conflict = Message("planning", "search-limit", $"Planning exceeded the deterministic limit of {SearchLimit} candidate states.");
+            return new InstallPlan(request.Instance.InstanceId, InstallPlanningState.Capture(request.Instance), [], [], [], [], [conflict], []);
+        }
+        if (best is null)
+        {
+            var conflict = Message("planning", "search-limit", $"Planning exceeded the deterministic limit of {SearchLimit} candidate states.");
+            return new InstallPlan(request.Instance.InstanceId, InstallPlanningState.Capture(request.Instance), [], [], [], [], [conflict], []);
+        }
+        return ToPlan(request, best);
+    }
+
+    private static Dictionary<string, RequestedMod> BuildRoots(InstallPlanningRequest request, out List<PlanningMessage> conflicts)
+    {
+        var roots = new Dictionary<string, RequestedMod>(ModIds.Comparer);
+        conflicts = [];
+        foreach (var item in request.Requested.OrderBy(value => value.Release.ModId, ModIds.Comparer))
+        {
+            if (request.Instance.ForeignMods.Any(value => ModIds.Equals(value.ModId, item.Release.ModId)))
+                conflicts.Add(Message(item.Release.ModId, "foreign-owned", "A managed install cannot replace foreign content."));
+            if (roots.TryGetValue(item.Release.ModId, out var previous) && previous.Exact && item.Exact && previous.Release.Version != item.Release.Version)
+                conflicts.Add(Message(item.Release.ModId, "exact-pin-conflict", $"Exact versions {previous.Release.Version} and {item.Release.Version} were both requested."));
+            else if (!roots.TryGetValue(item.Release.ModId, out previous) || item.Exact || !previous.Exact)
+                roots[item.Release.ModId] = item;
+        }
+        return roots;
+    }
+
+    private static async Task<Dictionary<string, IReadOnlyList<RequestedMod?>>> BuildDomainsAsync(InstallPlanningRequest request, Dictionary<string, RequestedMod> roots, CancellationToken cancellationToken)
+    {
+        var releases = new Dictionary<string, List<ModVersionMetadata>>(ModIds.Comparer);
+        var pending = new Queue<string>(roots.Keys.OrderBy(value => value, ModIds.Comparer));
+        var seen = new HashSet<string>(ModIds.Comparer);
+        while (pending.Count > 0)
+        {
+            var id = pending.Dequeue();
+            if (!seen.Add(id)) continue;
+            var values = new List<ModVersionMetadata>();
+            if (roots.TryGetValue(id, out var root) && root.Exact)
+                values.Add(root.Release);
+            else if (!request.Instance.ForeignMods.Any(value => ModIds.Equals(value.ModId, id)))
+            {
+                if (request.Instance.Mods.FirstOrDefault(value => ModIds.Equals(value.ModId, id)) is { } installed && !roots.ContainsKey(id)) values.Add(installed.Metadata);
+                foreach (var version in (await request.Repository.GetAvailableVersionsAsync(id, cancellationToken).ConfigureAwait(false)).OrderByDescending(value => value))
+                {
+                    var release = await request.Repository.GetReleaseAsync(id, version, cancellationToken).ConfigureAwait(false);
+                    if (release is { Yanked: false }) values.Add(release);
+                }
+            }
+            if (roots.TryGetValue(id, out root) && values.All(value => value.Version != root.Release.Version)) values.Add(root.Release);
+            releases[id] = values.DistinctBy(value => value.Version).OrderByDescending(value => value.Version).ToList();
+            foreach (var dependencyId in releases[id].SelectMany(DependencyIds).Distinct(ModIds.Comparer).OrderBy(value => value, ModIds.Comparer)) pending.Enqueue(dependencyId);
+        }
+
+        return releases.ToDictionary(
+            pair => pair.Key,
+            pair => (IReadOnlyList<RequestedMod?>)pair.Value.Select(value => new RequestedMod(value, roots.TryGetValue(pair.Key, out var root) ? root.Reason : InstallReason.Dependency, roots.TryGetValue(pair.Key, out root) && root.Exact)).Cast<RequestedMod?>().Concat(roots.TryGetValue(pair.Key, out var requested) && requested.Exact ? [] : [null]).ToList(),
+            ModIds.Comparer);
+    }
+
+    private static IEnumerable<string> DependencyIds(ModVersionMetadata release) => release.Dependencies.SelectMany(value => value.IsAnyOf ? value.AnyOf.Select(item => item.ModId) : value.ModId is null ? [] : [value.ModId]);
+
+    private SearchResult Evaluate(InstallPlanningRequest request, Dictionary<string, RequestedMod> roots, Dictionary<string, RequestedMod?> assigned, IReadOnlyList<PlanningMessage> initialConflicts)
+    {
+        var selected = assigned.Where(value => value.Value is not null).ToDictionary(value => value.Key, value => value.Value!, ModIds.Comparer);
+        ExpandInstalledClosure(request, roots, selected);
+        var warnings = new List<PlanningMessage>();
+        var unresolved = new List<PlanningMessage>();
+        var conflicts = new List<PlanningMessage>(initialConflicts);
+        var choices = new List<PlanningChoice>();
+        var proposed = BuildProposedInstance(request, selected);
+
+        foreach (var root in roots.Values)
+        {
+            if (!selected.TryGetValue(root.Release.ModId, out var chosen)) conflicts.Add(Message(root.Release.ModId, "missing-request", "No release was selected for the request."));
+            else if (root.Exact && chosen.Release.Version != root.Release.Version) conflicts.Add(Message(root.Release.ModId, "exact-pin", $"Exact version {root.Release.Version} was not selected."));
+        }
+
+        foreach (var item in selected.Values.OrderBy(value => value.Release.ModId, ModIds.Comparer))
+        {
+            EvaluateRelease(request, item.Release, selected, warnings, unresolved, conflicts, choices);
+            foreach (var evaluation in _resolver.Evaluate(proposed, item.Release).Where(value => value.Outcome == DependencyOutcome.Conflict)) conflicts.Add(Message(item.Release.ModId, "proposed-conflict", evaluation.Dependency.ToString()));
+        }
+        EvaluateRetainedInstalled(request, selected, unresolved, conflicts);
+        return new SearchResult(selected, Sort(warnings), Sort(unresolved), Sort(conflicts), choices.OrderBy(value => value.Key, StringComparer.Ordinal).ToList());
+    }
+
+    private static void EvaluateRelease(InstallPlanningRequest request, ModVersionMetadata release, Dictionary<string, RequestedMod> selected, List<PlanningMessage> warnings, List<PlanningMessage> unresolved, List<PlanningMessage> conflicts, List<PlanningChoice> choices)
+    {
+        if (release.Yanked) warnings.Add(Message(release.ModId, "yanked", release.YankedReason ?? "The selected release is yanked."));
+        var compatibility = Compatibility.Evaluate(release, request.GameVersion);
+        if (compatibility == GameCompatibility.Incompatible) conflicts.Add(Message(release.ModId, "incompatible", "The release is incompatible with the target game."));
+        else if (compatibility != GameCompatibility.Compatible) warnings.Add(Message(release.ModId, "compatibility", $"Game compatibility is {compatibility}."));
+        if (request.TargetPlatform is { } target)
+        {
+            var support = Compatibility.EvaluateOs(release.Os, target);
+            if (!support.IsSupported) warnings.Add(Message(release.ModId, "platform", $"The release does not list {target} as a supported platform."));
+            foreach (var value in support.Unrecognized) warnings.Add(Message(release.ModId, "platform-unknown", $"The release contains the unknown platform '{value}'."));
+        }
+
+        for (var index = 0; index < release.Dependencies.Count; index++)
+        {
+            var dependency = release.Dependencies[index];
+            var key = ChoiceKey(release.ModId, index, "recommendation");
+            if (dependency.Kind == ModDependencyKind.Unknown) { unresolved.Add(Message(release.ModId, "unknown-dependency", dependency.ToString())); continue; }
+            if (dependency.Kind == ModDependencyKind.Recommends)
+            {
+                var chosen = request.Recommended?.Contains(key) ?? false;
+                choices.Add(new PlanningChoice(key, release.ModId, "recommendation", ["include", "exclude"], chosen ? "include" : "exclude"));
+                if (!chosen) continue;
+            }
+            if (dependency.Kind is ModDependencyKind.Optional or ModDependencyKind.Suggests) continue;
+            if (dependency.IsAnyOf) EvaluateAlternative(request, release.ModId, ChoiceKey(release.ModId, index, "alternative"), dependency, selected, unresolved, conflicts, choices);
+            else EvaluateSingle(request, release.ModId, dependency, selected, unresolved, conflicts);
+        }
+    }
+
+    private static void EvaluateSingle(InstallPlanningRequest request, string owner, ModDependency dependency, Dictionary<string, RequestedMod> selected, List<PlanningMessage> unresolved, List<PlanningMessage> conflicts)
+    {
+        var version = FindManagedVersion(request, selected, dependency.ModId!);
+        var foreign = request.Instance.ForeignMods.Any(value => ModIds.Equals(value.ModId, dependency.ModId));
+        if (dependency.Kind == ModDependencyKind.Conflict)
+        {
+            if (version is { } found && dependency.BoundsContain(found)) conflicts.Add(Message(owner, "dependency-conflict", dependency.ToString()));
+            else if (foreign && (dependency.MinVersion is not null || dependency.MaxVersion is not null)) unresolved.Add(Message(owner, "foreign-conflict-unknown", dependency.ToString()));
+            else if (foreign) conflicts.Add(Message(owner, "foreign-conflict", dependency.ToString()));
+            return;
+        }
+        if (version is { } installed && dependency.BoundsContain(installed)) return;
+        if (foreign && dependency.MinVersion is null && dependency.MaxVersion is null) return;
+        if (foreign) unresolved.Add(Message(owner, "foreign-version-unknown", dependency.ToString()));
+        else conflicts.Add(Message(owner, "unsatisfied-dependency", dependency.ToString()));
+    }
+
+    private static void EvaluateAlternative(InstallPlanningRequest request, string owner, string key, ModDependency dependency, Dictionary<string, RequestedMod> selected, List<PlanningMessage> unresolved, List<PlanningMessage> conflicts, List<PlanningChoice> choices)
+    {
+        var satisfied = dependency.AnyOf!.FirstOrDefault(value => ExistingAlternativeSatisfied(request, selected, value) && ForcedAlternative(request, selected, value.ModId));
+        string? requested = null;
+        request.Alternatives?.TryGetValue(key, out requested);
+        choices.Add(new PlanningChoice(key, owner, "alternative", dependency.AnyOf!.Select(value => value.ModId).ToList(), requested ?? satisfied?.ModId));
+        if (satisfied is not null && requested is null) return;
+        if (requested is null) { unresolved.Add(Message(owner, "alternative-choice", $"Select one alternative for {dependency}.")); return; }
+        var chosen = dependency.AnyOf!.FirstOrDefault(value => ModIds.Equals(value.ModId, requested));
+        if (chosen is null) { conflicts.Add(Message(owner, "invalid-alternative", $"'{requested}' is not an available alternative.")); return; }
+        if (AlternativeSatisfied(request, selected, chosen)) return;
+        if (request.Instance.ForeignMods.Any(value => ModIds.Equals(value.ModId, chosen.ModId))) unresolved.Add(Message(owner, "foreign-alternative-unknown", chosen.ModId));
+        else conflicts.Add(Message(owner, "unsatisfied-alternative", chosen.ModId));
+    }
+
+    private static void EvaluateRetainedInstalled(InstallPlanningRequest request, Dictionary<string, RequestedMod> selected, List<PlanningMessage> unresolved, List<PlanningMessage> conflicts)
+    {
+        foreach (var installed in request.Instance.Mods.Where(value => !selected.ContainsKey(value.ModId)))
+            foreach (var dependency in installed.Metadata.Dependencies)
+            {
+                if (dependency.Kind == ModDependencyKind.Required && dependency.IsAnyOf && !dependency.AnyOf.Any(value => AlternativeSatisfied(request, selected, value)))
+                {
+                    if (dependency.AnyOf.Any(value => request.Instance.ForeignMods.Any(foreign => ModIds.Equals(foreign.ModId, value.ModId)) && (value.MinVersion is not null || value.MaxVersion is not null))) unresolved.Add(Message(installed.ModId, "foreign-alternative-unknown", dependency.ToString()));
+                    else conflicts.Add(Message(installed.ModId, "retained-alternative", dependency.ToString()));
+                }
+                else if (!dependency.IsAnyOf && selected.TryGetValue(dependency.ModId!, out var planned))
+                {
+                    if (dependency.Kind == ModDependencyKind.Required && !dependency.BoundsContain(planned.Release.Version)) conflicts.Add(Message(installed.ModId, "retained-dependent", dependency.ToString()));
+                    if (dependency.Kind == ModDependencyKind.Conflict && dependency.BoundsContain(planned.Release.Version)) conflicts.Add(Message(installed.ModId, "retained-conflict", dependency.ToString()));
+                }
+                else if (!dependency.IsAnyOf && dependency.Kind == ModDependencyKind.Required)
+                {
+                    var local = request.Instance.Mods.FirstOrDefault(value => ModIds.Equals(value.ModId, dependency.ModId));
+                    if (local is not null && dependency.BoundsContain(local.Version)) continue;
+                    var foreign = request.Instance.ForeignMods.Any(value => ModIds.Equals(value.ModId, dependency.ModId));
+                    if (foreign && (dependency.MinVersion is not null || dependency.MaxVersion is not null)) unresolved.Add(Message(installed.ModId, "foreign-version-unknown", dependency.ToString()));
+                    else if (!foreign) conflicts.Add(Message(installed.ModId, "retained-unsatisfied", dependency.ToString()));
+                }
+            }
+    }
+
+    private static ModVersion? FindManagedVersion(InstallPlanningRequest request, Dictionary<string, RequestedMod> selected, string id) => selected.TryGetValue(id, out var item) ? item.Release.Version : request.Instance.Mods.FirstOrDefault(value => ModIds.Equals(value.ModId, id))?.Version;
+    private static bool AlternativeSatisfied(InstallPlanningRequest request, Dictionary<string, RequestedMod> selected, ModDependencyAlternative alternative) => FindManagedVersion(request, selected, alternative.ModId) is { } version ? alternative.BoundsContain(version) : request.Instance.ForeignMods.Any(value => ModIds.Equals(value.ModId, alternative.ModId)) && alternative.MinVersion is null && alternative.MaxVersion is null;
+    private static bool ExistingAlternativeSatisfied(InstallPlanningRequest request, Dictionary<string, RequestedMod> selected, ModDependencyAlternative alternative) => FindManagedVersion(request, selected, alternative.ModId) is { } version ? alternative.BoundsContain(version) : request.Instance.ForeignMods.Any(value => ModIds.Equals(value.ModId, alternative.ModId)) && alternative.MinVersion is null && alternative.MaxVersion is null;
+
+    private static bool ForcedAlternative(InstallPlanningRequest request, Dictionary<string, RequestedMod> selected, string alternativeId)
+    {
+        if (request.Instance.Mods.FirstOrDefault(value => ModIds.Equals(value.ModId, alternativeId)) is { } installed && (!selected.TryGetValue(alternativeId, out var planned) || planned.Release.Version == installed.Version)) return true;
+        var forced = new HashSet<string>(request.Requested.Select(value => value.Release.ModId), ModIds.Comparer);
+        var pending = new Queue<string>(forced);
+        while (pending.Count > 0)
+        {
+            var id = pending.Dequeue();
+            if (!selected.TryGetValue(id, out var item)) continue;
+            foreach (var dependency in item.Release.Dependencies.Where(value => !value.IsAnyOf && value.Kind == ModDependencyKind.Required))
+                if (forced.Add(dependency.ModId!)) pending.Enqueue(dependency.ModId!);
+        }
+        return forced.Contains(alternativeId);
+    }
+
+    private static void ExpandInstalledClosure(InstallPlanningRequest request, Dictionary<string, RequestedMod> roots, Dictionary<string, RequestedMod> selected)
+    {
+        var pending = new Queue<RequestedMod>(selected.Values);
+        while (pending.Count > 0)
+        {
+            var item = pending.Dequeue();
+            foreach (var dependency in item.Release.Dependencies.Where(value => value.Kind == ModDependencyKind.Required && !value.IsAnyOf))
+            {
+                if (selected.ContainsKey(dependency.ModId!)) continue;
+                var installed = request.Instance.Mods.FirstOrDefault(value => ModIds.Equals(value.ModId, dependency.ModId));
+                if (installed is null || !dependency.BoundsContain(installed.Version)) continue;
+                var reason = roots.TryGetValue(installed.ModId, out var root) ? root.Reason : InstallReason.Dependency;
+                var added = new RequestedMod(installed.Metadata, reason, Exact: false);
+                selected[installed.ModId] = added;
+                pending.Enqueue(added);
+            }
+        }
+    }
+
+    private static Borea.Core.Instances.Instance BuildProposedInstance(InstallPlanningRequest request, Dictionary<string, RequestedMod> selected)
+    {
+        var retained = request.Instance.Mods.Where(value => !selected.ContainsKey(value.ModId));
+        var planned = selected.Values.Select(value => new InstalledMod(value.Release.ModId, value.Release.Version, value.Reason, DateTimeOffset.UnixEpoch, value.Release));
+        var foreign = request.Instance.ForeignMods.Where(value => !selected.ContainsKey(value.ModId)).ToList();
+        return Borea.Core.Instances.Instance.FromExisting(request.Instance.InstanceId, request.Instance.Name, request.Instance.Source, request.Instance.CreatedAt, retained.Concat(planned).ToList(), foreign, request.Instance.IsFavorite);
+    }
+
+    private static InstallPlan ToPlan(InstallPlanningRequest request, SearchResult result)
+    {
+        var ordered = OrderOperations(request, result.Selected);
+        var selections = result.Selected.Values.OrderBy(value => value.Release.ModId, ModIds.Comparer).Select(value => new PlannedSelection(value.Release, value.Reason, IsInstalled(request, value.Release))).ToList();
+        var operations = ordered.Where(value => !IsInstalled(request, value.Release)).Select(value => new PlannedInstall(value.Release, value.Reason, Compatibility.Evaluate(value.Release, request.GameVersion), request.TargetPlatform is { } target ? Compatibility.EvaluateOs(value.Release.Os, target) : null)).ToList();
+        return new InstallPlan(request.Instance.InstanceId, InstallPlanningState.Capture(request.Instance), selections, operations, result.Warnings, result.Unresolved, result.Conflicts, result.Choices);
+    }
+
+    private static IReadOnlyList<RequestedMod> OrderOperations(InstallPlanningRequest request, Dictionary<string, RequestedMod> selected)
+    {
+        var result = new List<RequestedMod>(); var visited = new HashSet<string>(ModIds.Comparer);
+        void Visit(RequestedMod item)
+        {
+            if (!visited.Add(item.Release.ModId)) return;
+            for (var index = 0; index < item.Release.Dependencies.Count; index++)
+            {
+                var dependency = item.Release.Dependencies[index]; string? id = dependency.ModId;
+                if (dependency.IsAnyOf) { var key = ChoiceKey(item.Release.ModId, index, "alternative"); id = request.Alternatives is not null && request.Alternatives.TryGetValue(key, out var chosen) ? chosen : dependency.AnyOf.FirstOrDefault(value => AlternativeSatisfied(request, selected, value))?.ModId; }
+                if (id is not null && selected.TryGetValue(id, out var child)) Visit(child);
+            }
+            result.Add(item);
+        }
+        foreach (var item in selected.Values.OrderBy(value => value.Release.ModId, ModIds.Comparer)) Visit(item);
+        return result;
+    }
+
+    private static void Validate(InstallPlanningRequest request) { ArgumentNullException.ThrowIfNull(request); ArgumentNullException.ThrowIfNull(request.Instance); ArgumentNullException.ThrowIfNull(request.Requested); ArgumentNullException.ThrowIfNull(request.Repository); }
+    private static bool IsInstalled(InstallPlanningRequest request, ModVersionMetadata release) => request.Instance.Mods.Any(value => ModIds.Equals(value.ModId, release.ModId) && value.Version == release.Version);
+    private static string ChoiceKey(string owner, int index, string kind) => $"{owner}:dependency:{index}:{kind}";
+    private static PlanningMessage Message(string id, string code, string message) => new(id, code, message);
+    private static IReadOnlyList<PlanningMessage> Sort(List<PlanningMessage> values) => values.Distinct().OrderBy(value => value.ModId, ModIds.Comparer).ThenBy(value => value.Code, StringComparer.Ordinal).ThenBy(value => value.Message, StringComparer.Ordinal).ToList();
+
+    private sealed record SearchResult(Dictionary<string, RequestedMod> Selected, IReadOnlyList<PlanningMessage> Warnings, IReadOnlyList<PlanningMessage> Unresolved, IReadOnlyList<PlanningMessage> Conflicts, IReadOnlyList<PlanningChoice> Choices)
+    {
+        public SearchScore Score => new(Conflicts.Count, Conflicts.Count(value => value.Code is "unsatisfied-dependency" or "missing-request" or "retained-unsatisfied"), Unresolved.Count, Warnings.Count, Selected.Count);
+    }
+    private readonly record struct SearchScore(int Conflicts, int Missing, int Unresolved, int Warnings, int Selected) : IComparable<SearchScore>
+    {
+        public int CompareTo(SearchScore other) { var value = Conflicts.CompareTo(other.Conflicts); if (value != 0) return value; value = Missing.CompareTo(other.Missing); if (value != 0) return value; value = Unresolved.CompareTo(other.Unresolved); if (value != 0) return value; value = Warnings.CompareTo(other.Warnings); if (value != 0) return value; return Selected.CompareTo(other.Selected); }
+    }
+}

--- a/tests/Borea.Network.Tests/Planning/RepositoryInstallPlannerTests.cs
+++ b/tests/Borea.Network.Tests/Planning/RepositoryInstallPlannerTests.cs
@@ -1,0 +1,471 @@
+using Borea.Core.Dependencies;
+using Borea.Core.Instances;
+using Borea.Core.Mods;
+using Borea.Core.Planning;
+using Borea.Network.Planning;
+
+namespace Borea.Network.Tests.Planning;
+
+public sealed class RepositoryInstallPlannerTests
+{
+    [Fact]
+    public async Task PlanAsync_TransitiveChain_OrdersDependenciesFirst()
+    {
+        var c = Release("C");
+        var b = Release("B", dependencies: [Required("C")]);
+        var a = Release("A", dependencies: [Required("B")]);
+        var plan = await PlanAsync([a], [a, b, c]);
+        Assert.True(plan.IsReady);
+        Assert.Equal(["C", "B", "A"], plan.Operations.Select(value => value.Release.ModId));
+    }
+
+    [Fact]
+    public async Task PlanAsync_CombinedBounds_SelectsSharedCompatibleVersion()
+    {
+        var b2 = Release("B", "2.0.0");
+        var b3 = Release("B", "3.0.0");
+        var a = Release("A", dependencies: [Required("B", "2.0.0")]);
+        var c = Release("C", dependencies: [Required("B", max: "2.0.0")]);
+        var plan = await PlanAsync([a, c], [a, c, b2, b3]);
+        Assert.True(plan.IsReady);
+        Assert.Equal(ModVersion.Parse("2.0.0"), Assert.Single(plan.Selections, value => value.Release.ModId == "B").Release.Version);
+    }
+
+    [Fact]
+    public async Task PlanAsync_PlannedConflict_IsBlocking()
+    {
+        var a = Release("A", dependencies: [new ModDependency("B", ModDependencyKind.Conflict)]);
+        var b = Release("B");
+        var plan = await PlanAsync([a, b], [a, b]);
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.Conflicts, value => value.Code == "dependency-conflict");
+    }
+
+    [Fact]
+    public async Task PlanAsync_SatisfyingInstalledDependency_DoesNotPlanWrite()
+    {
+        var installed = Installed("B", "1.0.0");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [installed], false);
+        var a = Release("A", dependencies: [Required("B")]);
+        var repository = new FakeRepository([a]);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], repository));
+        Assert.True(plan.IsReady);
+        Assert.DoesNotContain(plan.Operations, value => value.Release.ModId == "B");
+        Assert.Equal(0, repository.ReleaseReads);
+    }
+
+    [Fact]
+    public async Task PlanAsync_UnboundedForeignDependency_IsSatisfiedWithoutRepositoryRead()
+    {
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [], [new ForeignMod("B")], false);
+        var a = Release("A", dependencies: [Required("B")]);
+        var repository = new FakeRepository([a]);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], repository));
+        Assert.True(plan.IsReady);
+        Assert.Equal(0, repository.VersionReads);
+    }
+
+    [Fact]
+    public async Task PlanAsync_Cycle_IsStableAndDoesNotWriteInstance()
+    {
+        var a = Release("A", dependencies: [Required("B")]);
+        var b = Release("B", dependencies: [Required("A")]);
+        var repository = new FakeRepository([a, b]);
+        var instance = new Instance("Test", InstanceSource.Custom.Value);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], repository));
+        Assert.True(plan.IsReady);
+        Assert.Empty(instance.Mods);
+        Assert.Equal(2, plan.Operations.Count);
+    }
+
+    [Fact]
+    public async Task PlanAsync_RetainedInstalledDependencyConstrainsUpdate()
+    {
+        var x = Installed("X", dependencies: [Required("B", max: "1.0.0")]);
+        var b1 = Release("B");
+        var b2 = Release("B", "2.0.0");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [x, Installed("B")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(b2, InstallReason.Manual)], new FakeRepository([b1, b2])));
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.Conflicts, value => value.Code == "retained-dependent");
+    }
+
+    [Fact]
+    public async Task PlanAsync_NonExactRequestCanSelectCompatibleVersion()
+    {
+        var b1 = Release("B");
+        var b2 = Release("B", "2.0.0");
+        var a = Release("A", dependencies: [Required("B", max: "1.0.0")]);
+        var request = new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), [new RequestedMod(a, InstallReason.Manual), new RequestedMod(b2, InstallReason.Manual, Exact: false)], new FakeRepository([a, b1, b2]));
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(request);
+        Assert.True(plan.IsReady);
+        Assert.Contains(plan.Selections, value => value.Release.ModId == "B" && value.Release.Version == ModVersion.Parse("1.0.0"));
+    }
+
+    [Fact]
+    public async Task PlanAsync_VersionDependentGraphBacktracksWithoutOscillation()
+    {
+        var c = Release("C", dependencies: [Required("B", max: "1.0.0")]);
+        var b1 = Release("B");
+        var b2 = Release("B", "2.0.0", [Required("C")]);
+        var a = Release("A", dependencies: [Required("B")]);
+        var plan = await PlanAsync([a], [a, b1, b2, c]);
+        Assert.True(plan.IsReady);
+        Assert.Equal(["B", "A"], plan.Operations.Select(value => value.Release.ModId));
+    }
+
+    [Fact]
+    public async Task PlanAsync_DirectForeignIdRequest_IsBlocking()
+    {
+        var b = Release("B");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [], [new ForeignMod("B")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(b, InstallReason.Manual)], new FakeRepository([b])));
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.Conflicts, value => value.Code == "foreign-owned");
+    }
+
+    [Fact]
+    public async Task PlanAsync_InstalledAlternativeNeedsNoChoice()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B"), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [dependency]);
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [Installed("C")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a])));
+        Assert.True(plan.IsReady);
+        Assert.Equal("C", Assert.Single(plan.Choices).Selected);
+    }
+
+    [Fact]
+    public async Task PlanAsync_SelectedAlternative_IsOrderedBeforeDependent()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B"), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [dependency]);
+        var b = Release("B");
+        var choices = new Dictionary<string, string> { ["A:dependency:0:alternative"] = "B" };
+        var request = new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a, b]), Alternatives: choices);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(request);
+        Assert.Equal(["B", "A"], plan.Operations.Select(value => value.Release.ModId));
+    }
+
+    [Fact]
+    public async Task PlanAsync_BoundedConflictWithForeignMod_IsUnknown()
+    {
+        var a = Release("A", dependencies: [new ModDependency("B", ModDependencyKind.Conflict, ModVersion.Parse("2.0.0"))]);
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [], [new ForeignMod("B")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a])));
+        Assert.False(plan.IsReady);
+        Assert.Empty(plan.Conflicts);
+        Assert.Contains(plan.UnresolvedChoices, value => value.Code == "foreign-conflict-unknown");
+    }
+
+    [Fact]
+    public async Task PlanAsync_RecommendationExposesStableCallerChoice()
+    {
+        var a = Release("A", dependencies: [new ModDependency("B", ModDependencyKind.Recommends)]);
+        var plan = await PlanAsync([a], [a, Release("B")]);
+        var choice = Assert.Single(plan.Choices);
+        Assert.Equal("A:dependency:0:recommendation", choice.Key);
+        Assert.Equal(["include", "exclude"], choice.Options);
+        Assert.Equal("exclude", choice.Selected);
+    }
+
+    [Fact]
+    public async Task PlanAsync_ReplacedInstalledVersionDoesNotCauseStaleConflict()
+    {
+        var a = Release("A", dependencies: [new ModDependency("B", ModDependencyKind.Conflict, maxVersion: ModVersion.Parse("1.0.0"))]);
+        var b2 = Release("B", "2.0.0");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [Installed("B")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual), new RequestedMod(b2, InstallReason.Manual)], new FakeRepository([a, b2])));
+        Assert.True(plan.IsReady);
+    }
+
+    [Fact]
+    public async Task PlanAsync_UnsatisfiedInstalledDependencyCanBeUpdated()
+    {
+        var a = Release("A", dependencies: [Required("B", "2.0.0")]);
+        var b2 = Release("B", "2.0.0");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [Installed("B")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a, b2])));
+        Assert.True(plan.IsReady);
+        Assert.Contains(plan.Operations, value => value.Release.ModId == "B" && value.Release.Version == ModVersion.Parse("2.0.0"));
+    }
+
+    [Fact]
+    public async Task PlanAsync_UnselectedAlternativeReturnsChoice()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B"), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [dependency]);
+        var plan = await PlanAsync([a], [a, Release("B"), Release("C")]);
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.UnresolvedChoices, value => value.Code == "alternative-choice");
+        Assert.Null(Assert.Single(plan.Choices).Selected);
+    }
+
+    [Fact]
+    public async Task PlanAsync_TruncatedSearchIsBlocking()
+    {
+        var available = new List<ModVersionMetadata>();
+        var requested = new List<RequestedMod>();
+        for (var id = 0; id < 6; id++)
+        {
+            for (var version = 0; version < 10; version++) available.Add(Release($"M{id}", $"1.0.{version}"));
+            requested.Add(new RequestedMod(available[^1], InstallReason.Manual, Exact: false));
+        }
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), requested, new FakeRepository(available)));
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.Conflicts, value => value.Code == "search-limit");
+    }
+
+    [Fact]
+    public async Task PlanAsync_RetainedInstalledAlternativeConstrainsReplacement()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B", maxVersion: ModVersion.Parse("1.0.0")), new ModDependencyAlternative("C")]);
+        var x = Installed("X", dependencies: [dependency]);
+        var b2 = Release("B", "2.0.0");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [x, Installed("B")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(b2, InstallReason.Manual)], new FakeRepository([b2])));
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.Conflicts, value => value.Code == "retained-alternative");
+    }
+
+    [Fact]
+    public async Task PlanAsync_NonExactYankedRootUsesUsableRelease()
+    {
+        var b1 = Release("B");
+        var b2 = Release("B", "2.0.0", yanked: true);
+        var request = new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), [new RequestedMod(b2, InstallReason.Manual, Exact: false)], new FakeRepository([b1, b2]));
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(request);
+        Assert.True(plan.IsReady);
+        Assert.Equal(ModVersion.Parse("1.0.0"), Assert.Single(plan.Selections).Release.Version);
+    }
+
+    [Fact]
+    public async Task PlanAsync_BoundedForeignAlternativeIsUnknown()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B", minVersion: ModVersion.Parse("2.0.0")), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [dependency]);
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [], [new ForeignMod("B")], false);
+        var alternatives = new Dictionary<string, string> { ["A:dependency:0:alternative"] = "B" };
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a]), Alternatives: alternatives));
+        Assert.False(plan.IsReady);
+        Assert.Empty(plan.Conflicts);
+        Assert.Contains(plan.UnresolvedChoices, value => value.Code == "foreign-alternative-unknown");
+    }
+
+    [Fact]
+    public async Task PlanAsync_InstalledDependencyIsSelectedAndItsDependencyIsPlanned()
+    {
+        var b = Installed("B", dependencies: [Required("C")]);
+        var a = Release("A", dependencies: [Required("B")]);
+        var c = Release("C");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [b], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a, c])));
+        Assert.True(plan.IsReady);
+        Assert.Contains(plan.Selections, value => value.Release.ModId == "B" && value.IsAlreadyInstalled);
+        Assert.Contains(plan.Operations, value => value.Release.ModId == "C");
+    }
+
+    [Fact]
+    public async Task PlanAsync_ReplacedInstalledAlternativeUsesProposedVersion()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B", maxVersion: ModVersion.Parse("1.0.0")), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [dependency]);
+        var b2 = Release("B", "2.0.0");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [Installed("B")], false);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual), new RequestedMod(b2, InstallReason.Manual)], new FakeRepository([a, b2])));
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.UnresolvedChoices, value => value.Code == "alternative-choice");
+    }
+
+    [Fact]
+    public async Task PlanAsync_ExplicitRootSatisfiesAlternativeWithoutChoice()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B"), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [dependency]);
+        var b = Release("B");
+        var plan = await PlanAsync([a, b], [a, b, Release("C")]);
+        Assert.True(plan.IsReady);
+        Assert.Equal("B", Assert.Single(plan.Choices).Selected);
+    }
+
+    [Fact]
+    public async Task PlanAsync_RetainedBoundedForeignAlternativeIsUnknown()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B", minVersion: ModVersion.Parse("2.0.0")), new ModDependencyAlternative("C")]);
+        var x = Installed("X", dependencies: [dependency]);
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [x], [new ForeignMod("B")], false);
+        var a = Release("A");
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a])));
+        Assert.False(plan.IsReady);
+        Assert.Empty(plan.Conflicts);
+        Assert.Contains(plan.UnresolvedChoices, value => value.Code == "foreign-alternative-unknown");
+    }
+
+    [Fact]
+    public async Task PlanAsync_RecommendedAlternativeHasUniqueChoiceKeys()
+    {
+        var dependency = ModDependency.OfAlternatives(ModDependencyKind.Recommends, [new ModDependencyAlternative("B"), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [dependency]);
+        var recommended = new HashSet<string> { "A:dependency:0:recommendation" };
+        var request = new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a, Release("B"), Release("C")]), Recommended: recommended);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(request);
+        Assert.Equal(2, plan.Choices.Select(value => value.Key).Distinct().Count());
+        Assert.Contains(plan.Choices, value => value.Key == "A:dependency:0:recommendation");
+        Assert.Contains(plan.Choices, value => value.Key == "A:dependency:0:alternative");
+    }
+
+    [Fact]
+    public async Task PlanAsync_CircularAlternativesDoNotChooseEachOther()
+    {
+        var choice = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B"), new ModDependencyAlternative("C")]);
+        var a = Release("A", dependencies: [choice]);
+        var c = Release("C", dependencies: [Required("B")]);
+        var plan = await PlanAsync([a], [a, Release("B"), c]);
+        Assert.False(plan.IsReady);
+        Assert.Contains(plan.UnresolvedChoices, value => value.Code == "alternative-choice");
+    }
+
+    [Fact]
+    public async Task PlanAsync_RetainedBoundedForeignDependencyIsUnknown()
+    {
+        var x = Installed("X", dependencies: [Required("B", "2.0.0")]);
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [x], [new ForeignMod("B")], false);
+        var a = Release("A");
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a])));
+        Assert.False(plan.IsReady);
+        Assert.Empty(plan.Conflicts);
+        Assert.Contains(plan.UnresolvedChoices, value => value.Code == "foreign-version-unknown");
+    }
+
+    [Fact]
+    public async Task PlanAsync_IncompatibleAvailableDependencyKeepsCompatibilityDecision()
+    {
+        var a = Release("A", dependencies: [Required("B")]);
+        var b = Release("B", gameMinRevision: 5000);
+        var request = new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a, b]), new Borea.Core.Game.GameVersion(2026, 7, 4, 2131));
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(request);
+        Assert.Contains(plan.Conflicts, value => value.Code == "incompatible" && value.ModId == "B");
+        Assert.DoesNotContain(plan.Conflicts, value => value.Code == "unsatisfied-dependency");
+    }
+
+    [Fact]
+    public async Task PlanAsync_YankedNonExactRootWithoutReplacementKeepsWarning()
+    {
+        var b = Release("B", "2.0.0", yanked: true);
+        var request = new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), [new RequestedMod(b, InstallReason.Manual, Exact: false)], new FakeRepository([]));
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(request);
+        Assert.Contains(plan.Selections, value => value.Release.Version == b.Version);
+        Assert.Contains(plan.Warnings, value => value.Code == "yanked");
+    }
+
+    [Fact]
+    public async Task PlanAsync_InstalledFallbackKeepsExplicitReason()
+    {
+        var a = Release("A", dependencies: [Required("B", max: "1.0.0")]);
+        var b2 = Release("B", "2.0.0");
+        var instance = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UtcNow, [Installed("B")], false);
+        var requested = new[] { new RequestedMod(a, InstallReason.Manual), new RequestedMod(b2, InstallReason.ModPack, Exact: false) };
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(instance, requested, new FakeRepository([a, b2])));
+        Assert.Equal(InstallReason.ModPack, Assert.Single(plan.Selections, value => value.Release.ModId == "B").Reason);
+    }
+
+    [Fact]
+    public async Task PlanAsync_UnsupportedPlatformIsExposed()
+    {
+        var a = Release("A", os: ["windows"]);
+        var request = new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), [new RequestedMod(a, InstallReason.Manual)], new FakeRepository([a]), TargetPlatform: Borea.Core.Game.OsPlatform.Linux);
+        var plan = await new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(request);
+        Assert.True(plan.IsReady);
+        Assert.Contains(plan.Warnings, value => value.Code == "platform");
+        Assert.False(Assert.Single(plan.Operations).PlatformSupport!.IsSupported);
+    }
+
+    [Fact]
+    public void PlanningState_OwnershipChange_DoesNotMatch()
+    {
+        var release = Release("A");
+        var owned = new InstalledMod("A", release.Version, InstallReason.Manual, DateTimeOffset.UnixEpoch, release, ownership: ModInstallOwnership.Borea, ownershipToken: "token");
+        var foreignOwned = new InstalledMod("A", release.Version, InstallReason.Manual, DateTimeOffset.UnixEpoch, release, ownership: ModInstallOwnership.Foreign);
+        var before = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [owned], false);
+        var after = Instance.FromExisting(before.InstanceId, "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [foreignOwned], false);
+        var state = InstallPlanningState.Capture(before);
+        Assert.False(state.Matches(after));
+    }
+
+    [Fact]
+    public void PlanningState_ForeignDependencyChange_DoesNotMatch()
+    {
+        var beforeMod = new ForeignMod("A", [new LocalModDependency("B", optional: false)]);
+        var afterMod = new ForeignMod("A", [new LocalModDependency("B", optional: true)]);
+        var before = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [], [beforeMod], false);
+        var after = Instance.FromExisting(before.InstanceId, "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [], [afterMod], false);
+        var state = InstallPlanningState.Capture(before);
+        Assert.False(state.Matches(after));
+    }
+
+    [Fact]
+    public void PlanningState_InstalledReleaseDecisionChange_DoesNotMatch()
+    {
+        var available = Release("A");
+        var yanked = Release("A", yanked: true);
+        var beforeMod = new InstalledMod("A", available.Version, InstallReason.Manual, DateTimeOffset.UnixEpoch, available);
+        var afterMod = new InstalledMod("A", yanked.Version, InstallReason.Manual, DateTimeOffset.UnixEpoch, yanked);
+        var before = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [beforeMod], false);
+        var after = Instance.FromExisting(before.InstanceId, "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [afterMod], false);
+        Assert.False(InstallPlanningState.Capture(before).Matches(after));
+    }
+
+    [Fact]
+    public void PlanningState_AlternativeOrderChange_DoesNotMatch()
+    {
+        var first = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("B"), new ModDependencyAlternative("C")]);
+        var second = ModDependency.OfAlternatives(ModDependencyKind.Required, [new ModDependencyAlternative("C"), new ModDependencyAlternative("B")]);
+        var before = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [Installed("A", dependencies: [first])], false);
+        var after = Instance.FromExisting(before.InstanceId, "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [Installed("A", dependencies: [second])], false);
+        Assert.False(InstallPlanningState.Capture(before).Matches(after));
+    }
+
+    [Fact]
+    public void PlanningState_NullAndEmptyYankReasons_DoNotMatch()
+    {
+        var nullReason = Release("A", yanked: true);
+        var emptyReason = new ModVersionMetadata(1, "A", nullReason.Version, ReleaseStatus.Stable, DateTimeOffset.UnixEpoch, "2026.7.4.2131", 2131, nullReason.Download, 1, [], yanked: true, yankedReason: string.Empty);
+        var before = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [new InstalledMod("A", nullReason.Version, InstallReason.Manual, DateTimeOffset.UnixEpoch, nullReason)], false);
+        var after = Instance.FromExisting(before.InstanceId, "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [new InstalledMod("A", emptyReason.Version, InstallReason.Manual, DateTimeOffset.UnixEpoch, emptyReason)], false);
+        Assert.False(InstallPlanningState.Capture(before).Matches(after));
+    }
+
+    [Fact]
+    public void PlanningState_ForeignCollectionBoundaries_DoNotCollide()
+    {
+        var firstMods = new[]
+        {
+            new ForeignMod("A", [new LocalModDependency("foreign", optional: false)]),
+            new ForeignMod("X", dependencyReadError: "required"),
+        };
+        var secondMods = new[]
+        {
+            new ForeignMod("A"),
+            new ForeignMod("required", [new LocalModDependency("X", optional: false)], "foreign"),
+        };
+        var first = Instance.FromExisting(Guid.NewGuid(), "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [], firstMods, false);
+        var second = Instance.FromExisting(first.InstanceId, "Test", InstanceSource.Custom.Value, DateTimeOffset.UnixEpoch, [], secondMods, false);
+        Assert.NotEqual(InstallPlanningState.Capture(first), InstallPlanningState.Capture(second));
+    }
+
+    private static Task<InstallPlan> PlanAsync(IReadOnlyList<ModVersionMetadata> requested, IReadOnlyList<ModVersionMetadata> available) => new RepositoryInstallPlanner(new ModDependencyResolver()).PlanAsync(new InstallPlanningRequest(new Instance("Test", InstanceSource.Custom.Value), requested.Select(value => new RequestedMod(value, InstallReason.Manual)).ToList(), new FakeRepository(available)));
+    private static ModDependency Required(string id, string? min = null, string? max = null) => new(id, ModDependencyKind.Required, min is null ? null : ModVersion.Parse(min), max is null ? null : ModVersion.Parse(max));
+    private static InstalledMod Installed(string id, string version = "1.0.0", IReadOnlyList<ModDependency>? dependencies = null) => new(id, ModVersion.Parse(version), InstallReason.Manual, DateTimeOffset.UtcNow, Release(id, version, dependencies));
+    private static ModVersionMetadata Release(string id, string version = "1.0.0", IReadOnlyList<ModDependency>? dependencies = null, bool yanked = false, int gameMinRevision = 2131, IReadOnlyList<string>? os = null) => new(1, id, ModVersion.Parse(version), ReleaseStatus.Stable, DateTimeOffset.UnixEpoch, gameMinRevision == 2131 ? "2026.7.4.2131" : $"2026.7.4.{gameMinRevision}", gameMinRevision, new DownloadInfo("https://example.com/mod.zip", new string('A', 64), 1, "application/zip"), 1, dependencies ?? [], os: os, yanked: yanked);
+
+    private sealed class FakeRepository(IReadOnlyList<ModVersionMetadata> releases) : IModRepository
+    {
+        public int VersionReads { get; private set; }
+        public int ReleaseReads { get; private set; }
+        public Task<IReadOnlyList<ModVersion>> GetAvailableVersionsAsync(string modId, CancellationToken cancellationToken = default) { VersionReads++; return Task.FromResult<IReadOnlyList<ModVersion>>(releases.Where(value => ModIds.Equals(value.ModId, modId)).Select(value => value.Version).ToList()); }
+        public Task<ModVersionMetadata?> GetReleaseAsync(string modId, ModVersion version, CancellationToken cancellationToken = default) { ReleaseReads++; return Task.FromResult(releases.FirstOrDefault(value => ModIds.Equals(value.ModId, modId) && value.Version == version)); }
+        public Task<IReadOnlyList<ModMetadata>> GetAvailableModsAsync(CancellationToken cancellationToken = default) => Task.FromResult<IReadOnlyList<ModMetadata>>([]);
+        public Task<ModVersionMetadata?> GetLatestReleaseAsync(string modId, CancellationToken cancellationToken = default) => Task.FromResult<ModVersionMetadata?>(null);
+        public Task<IReadOnlyList<ModMetadata>> SearchAsync(string query, CancellationToken cancellationToken = default) => Task.FromResult<IReadOnlyList<ModMetadata>>([]);
+    }
+}


### PR DESCRIPTION
Closes #120.

Add one shared planner for CLI, pack and App consumers. It selects the complete set of releases and dependencies before installation starts, and returns warnings, choices and conflicts for the caller to show.

For example, when two requested mods need the same dependency, the planner selects one version that satisfies both. If none exists, it reports the conflict before any files change.

Plans also capture instance state so execution can reject a plan when ownership or dependency data has changed.
