### PR TITLE
Guard planned mod writes against stale state

### DIFF
--- a/src/Borea.Core/Mods/IModInstaller.cs
+++ b/src/Borea.Core/Mods/IModInstaller.cs
@@ -1,4 +1,5 @@
 using Borea.Core.State;
+using Borea.Core.Planning;
 
 namespace Borea.Core.Mods;
 
@@ -42,6 +43,15 @@ public interface IModInstaller
         bool enable,
         IProgress<DownloadProgress>? progress = null,
         CancellationToken cancellationToken = default);
+
+    Task<GuardedInstallResult> InstallGuardedAsync(
+        Guid instanceId,
+        ModVersionMetadata release,
+        InstallReason reason,
+        bool enable,
+        InstallPlanningState expectedState,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -51,3 +61,5 @@ public interface IModInstaller
 /// <param name="Download">Where the archive came from and what it hashed to.</param>
 /// <param name="ManifestEntry">Whether the manifest entry was written or was already there.</param>
 public sealed record InstallResult(InstalledMod Mod, DownloadResult Download, ModEntryAddResult ManifestEntry);
+
+public sealed record GuardedInstallResult(InstallResult Result, InstallPlanningState State);

--- a/src/Borea.Core/Mods/IModReplacer.cs
+++ b/src/Borea.Core/Mods/IModReplacer.cs
@@ -1,3 +1,5 @@
+using Borea.Core.Planning;
+
 namespace Borea.Core.Mods;
 
 public interface IModReplacer
@@ -8,6 +10,14 @@ public interface IModReplacer
         ModVersionMetadata replacement,
         IProgress<DownloadProgress>? progress = null,
         CancellationToken cancellationToken = default);
+
+    Task<GuardedModReplacementResult> ReplaceGuardedAsync(
+        Guid instanceId,
+        InstalledMod expectedCurrent,
+        ModVersionMetadata replacement,
+        InstallPlanningState expectedState,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default);
 }
 
 public sealed record ModReplacementResult(
@@ -15,6 +25,8 @@ public sealed record ModReplacementResult(
     InstalledMod Replacement,
     DownloadResult Download,
     string? RetainedRecoveryDirectory);
+
+public sealed record GuardedModReplacementResult(ModReplacementResult Result, InstallPlanningState State);
 
 public sealed class ModReplacementRecoveryException : Exception
 {

--- a/src/Borea.Storage/Mods/FileModInstaller.cs
+++ b/src/Borea.Storage/Mods/FileModInstaller.cs
@@ -1,6 +1,7 @@
 using Borea.Core.Instances;
 using Borea.Core.Mods;
 using Borea.Core.Paths;
+using Borea.Core.Planning;
 using Borea.Core.State;
 
 namespace Borea.Storage.Mods;
@@ -39,6 +40,29 @@ public sealed class FileModInstaller : IModInstaller
         bool enable,
         IProgress<DownloadProgress>? progress = null,
         CancellationToken cancellationToken = default)
+        => (await InstallCoreAsync(instanceId, release, reason, enable, expectedState: null, progress, cancellationToken).ConfigureAwait(false)).Result;
+
+    public async Task<GuardedInstallResult> InstallGuardedAsync(
+        Guid instanceId,
+        ModVersionMetadata release,
+        InstallReason reason,
+        bool enable,
+        InstallPlanningState expectedState,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(expectedState);
+        return await InstallCoreAsync(instanceId, release, reason, enable, expectedState, progress, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<GuardedInstallResult> InstallCoreAsync(
+        Guid instanceId,
+        ModVersionMetadata release,
+        InstallReason reason,
+        bool enable,
+        InstallPlanningState? expectedState,
+        IProgress<DownloadProgress>? progress,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(release);
         RequireInstallable(release);
@@ -64,6 +88,7 @@ public sealed class FileModInstaller : IModInstaller
         var stagingFolder = Path.Combine(_pathProvider.GetInstanceRoot(instanceId), $".borea-staging-{Guid.NewGuid():N}");
         var recorded = false;
         string? ownershipToken = null;
+        InstallPlanningState? resultingState = null;
 
         try
         {
@@ -90,12 +115,16 @@ public sealed class FileModInstaller : IModInstaller
                 instanceId,
                 current =>
                 {
+                    if (expectedState is not null && !expectedState.Matches(current))
+                        throw new InvalidOperationException("The instance changed after the installation was planned.");
+
                     if (ModFolders.Find(modsFolder, release.ModId) is not null)
                         throw new InvalidOperationException($"The instance received a foreign folder for '{release.ModId}' while the archive downloaded.");
 
                     Directory.CreateDirectory(modsFolder);
                     Directory.Move(stagingFolder, modFolder);
                     current.AddMod(installed);
+                    resultingState = InstallPlanningState.Capture(current);
                     return true;
                 },
                 cancellationToken).ConfigureAwait(false);
@@ -103,7 +132,8 @@ public sealed class FileModInstaller : IModInstaller
 
             var entry = await _modState.AddEntryAsync(instanceId, release.ModId, enable, cancellationToken).ConfigureAwait(false);
 
-            return new InstallResult(installed, download, entry);
+            var result = new InstallResult(installed, download, entry);
+            return new GuardedInstallResult(result, resultingState!);
         }
         catch
         {

--- a/src/Borea.Storage/Mods/FileModReplacer.cs
+++ b/src/Borea.Storage/Mods/FileModReplacer.cs
@@ -1,6 +1,7 @@
 using Borea.Core.Instances;
 using Borea.Core.Mods;
 using Borea.Core.Paths;
+using Borea.Core.Planning;
 using Borea.Core.State;
 
 namespace Borea.Storage.Mods;
@@ -46,6 +47,27 @@ public sealed class FileModReplacer : IModReplacer
         ModVersionMetadata replacement,
         IProgress<DownloadProgress>? progress = null,
         CancellationToken cancellationToken = default)
+        => (await ReplaceCoreAsync(instanceId, expectedCurrent, replacement, expectedState: null, progress, cancellationToken).ConfigureAwait(false)).Result;
+
+    public async Task<GuardedModReplacementResult> ReplaceGuardedAsync(
+        Guid instanceId,
+        InstalledMod expectedCurrent,
+        ModVersionMetadata replacement,
+        InstallPlanningState expectedState,
+        IProgress<DownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(expectedState);
+        return await ReplaceCoreAsync(instanceId, expectedCurrent, replacement, expectedState, progress, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<GuardedModReplacementResult> ReplaceCoreAsync(
+        Guid instanceId,
+        InstalledMod expectedCurrent,
+        ModVersionMetadata replacement,
+        InstallPlanningState? expectedState,
+        IProgress<DownloadProgress>? progress,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(expectedCurrent);
         ArgumentNullException.ThrowIfNull(replacement);
@@ -75,6 +97,7 @@ public sealed class FileModReplacer : IModReplacer
         string? installedFolder = null;
         var backupCreated = false;
         var replacementMoved = false;
+        InstallPlanningState? resultingState = null;
 
         try
         {
@@ -97,6 +120,9 @@ public sealed class FileModReplacer : IModReplacer
                 instanceId,
                 current =>
                 {
+                    if (expectedState is not null && !expectedState.Matches(current))
+                        throw new InvalidOperationException("The instance changed after the replacement was planned.");
+
                     RequireExpected(current, expectedCurrent);
                     installedFolder = ModFolders.FindOwned(modsFolder, expectedCurrent.ModId, expectedCurrent.OwnershipToken!)
                         ?? throw new InvalidOperationException($"Borea cannot find its owned folder for '{expectedCurrent.ModId}'.");
@@ -105,6 +131,7 @@ public sealed class FileModReplacer : IModReplacer
                     Directory.Move(stagingFolder, installedFolder);
                     replacementMoved = true;
                     current.ReplaceMod(installed);
+                    resultingState = InstallPlanningState.Capture(current);
                     return true;
                 },
                 cancellationToken).ConfigureAwait(false);
@@ -116,7 +143,8 @@ public sealed class FileModReplacer : IModReplacer
 
             var retainedRecoveryDirectory = _deleteRecoveryDirectory(backupFolder) ? null : backupFolder;
             backupCreated = retainedRecoveryDirectory is not null;
-            return new ModReplacementResult(expectedCurrent, installed, download, retainedRecoveryDirectory);
+            var result = new ModReplacementResult(expectedCurrent, installed, download, retainedRecoveryDirectory);
+            return new GuardedModReplacementResult(result, resultingState!);
         }
         catch (Exception operationError)
         {

--- a/tests/Borea.Storage.Tests/Mods/FileModInstallerTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/FileModInstallerTests.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using Borea.Core.Dependencies;
 using Borea.Core.Instances;
 using Borea.Core.Mods;
+using Borea.Core.Planning;
 using Borea.Core.State;
 using Borea.Storage.Instances;
 using Borea.Storage.Mods;
@@ -59,9 +60,10 @@ public sealed class FileModInstallerTests : IAsyncLifetime
         InstallInfo? install = null,
         ContentType type = ContentType.Mod,
         string contentType = "application/zip",
-        string? sha256 = null) => new(
+        string? sha256 = null,
+        string modId = ModId) => new(
         specVersion: 1,
-        modId: ModId,
+        modId: modId,
         version: ModVersion.Parse("1.2.0"),
         releaseStatus: ReleaseStatus.Stable,
         releaseDate: new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero),
@@ -93,6 +95,38 @@ public sealed class FileModInstallerTests : IAsyncLifetime
         Assert.Empty(instance!.Mods);
         Assert.Empty(await _modState.GetEntriesAsync(_instanceId));
         Assert.All(_downloader.ArchivePaths, path => Assert.False(File.Exists(path)));
+    }
+
+    [Fact]
+    public async Task GuardedInstallAsync_ReturnsTheAdvancedPlanningState()
+    {
+        _downloader.Bytes = BuildZip((ModId + "/mod.toml", "name = \"test-mod\""));
+        var expected = InstallPlanningState.Capture((await _instances.GetByIdAsync(_instanceId))!);
+
+        var result = await _installer.InstallGuardedAsync(_instanceId, Release(), InstallReason.Manual, enable: true, expectedState: expected);
+
+        Assert.True(result.State.Matches((await _instances.GetByIdAsync(_instanceId))!));
+        Assert.Equal(ModId, result.Result.Mod.ModId);
+    }
+
+    [Fact]
+    public async Task GuardedInstallAsync_ManagedChangeDuringDownloadWritesNoTarget()
+    {
+        _downloader.Bytes = BuildZip((ModId + "/mod.toml", "name = \"test-mod\""));
+        var expected = InstallPlanningState.Capture((await _instances.GetByIdAsync(_instanceId))!);
+        var otherRelease = Release(modId: "other-mod");
+        _downloader.AfterDownload = () => _instances.UpdateAsync(
+            _instanceId,
+            instance =>
+            {
+                instance.AddMod(new InstalledMod("other-mod", otherRelease.Version, InstallReason.Manual, Now, otherRelease));
+                return true;
+            }).GetAwaiter().GetResult();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _installer.InstallGuardedAsync(_instanceId, Release(), InstallReason.Manual, enable: true, expectedState: expected));
+
+        Assert.False(Directory.Exists(ModFolder));
+        Assert.Equal("other-mod", Assert.Single((await _instances.GetByIdAsync(_instanceId))!.Mods).ModId);
     }
 
     #region Unpacking

--- a/tests/Borea.Storage.Tests/Mods/FileModReplacerTests.cs
+++ b/tests/Borea.Storage.Tests/Mods/FileModReplacerTests.cs
@@ -1,6 +1,7 @@
 using Borea.Core.Dependencies;
 using Borea.Core.Instances;
 using Borea.Core.Mods;
+using Borea.Core.Planning;
 using Borea.Storage.Instances;
 using Borea.Storage.Mods;
 using Borea.Storage.State;
@@ -141,6 +142,43 @@ public sealed class FileModReplacerTests : IAsyncLifetime
         var saved = Assert.Single((await _instances.GetByIdAsync(_instanceId))!.Mods);
         Assert.Equal(ModVersion.Parse("1.0.0"), saved.Version);
         Assert.Equal(InstallReason.Manual, saved.Reason);
+    }
+
+    [Fact]
+    public async Task GuardedReplaceAsync_ReturnsTheAdvancedPlanningState()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        var expected = InstallPlanningState.Capture((await _instances.GetByIdAsync(_instanceId))!);
+        _downloader.Bytes = Archive("new");
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state);
+
+        var result = await replacer.ReplaceGuardedAsync(_instanceId, current, Release("1.1.0"), expected);
+
+        Assert.True(result.State.Matches((await _instances.GetByIdAsync(_instanceId))!));
+        Assert.Equal(ModVersion.Parse("1.1.0"), result.Result.Replacement.Version);
+    }
+
+    [Fact]
+    public async Task GuardedReplaceAsync_ForeignChangeDuringDownloadKeepsTheWorkingTarget()
+    {
+        var current = await InstallAsync(Release("1.0.0"), "old", enabled: true);
+        var expected = InstallPlanningState.Capture((await _instances.GetByIdAsync(_instanceId))!);
+        _downloader.Bytes = Archive("new");
+        _downloader.AfterDownload = () => _instances.UpdateAsync(
+            _instanceId,
+            instance =>
+            {
+                instance.ReplaceForeignMods([new ForeignMod("foreign-dependency")]);
+                return true;
+            }).GetAwaiter().GetResult();
+        var replacer = new FileModReplacer(_paths, _downloader, _instances, _state);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => replacer.ReplaceGuardedAsync(_instanceId, current, Release("1.1.0"), expected));
+
+        Assert.Equal("old", File.ReadAllText(Path.Combine(ModFolder, "value.txt")));
+        var saved = await _instances.GetByIdAsync(_instanceId);
+        Assert.Equal(ModVersion.Parse("1.0.0"), Assert.Single(saved!.Mods).Version);
+        Assert.Equal("foreign-dependency", Assert.Single(saved.ForeignMods).ModId);
     }
 
     private string ModFolder => Path.Combine(_paths.GetInstanceModsFolder(_instanceId), ModId);


### PR DESCRIPTION
Adds explicit guarded install and replacement operations for consumers that execute an installation plan.

Each operation checks the complete expected instance state under the instance write lock before it changes the target folder or record, then returns the exact next state for the following planned operation.

For example, if an unrelated foreign dependency appears while a replacement archive downloads, the replacement stops and keeps the working installed version.

Supports #7 and #68.
